### PR TITLE
#46: Use en_US locale in maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
 				<configuration>
 					<reportOutputDirectory>docs</reportOutputDirectory>
 					<destDir>docs</destDir>
+					<locale>en_US</locale>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Implements #46. The locale affects the language inside html tag in the beginning of the html files.