### PR TITLE
#48: Use notimestamp=true in maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
 				<configuration>
 					<reportOutputDirectory>docs</reportOutputDirectory>
 					<destDir>docs</destDir>
+					<notimestamp>true</notimestamp>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Implements issue #48. Removing timestamps makes it easier to see what parts of the documentation have changed when regenerating.