### PR TITLE
Issue #64: Add javadoc creation and deployment to travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,13 @@
 language: java
 sudo: false
-script: mvn install -Dmaven.javadoc.skip=true -B -V
+script:
+  - mvn install -B -V
+  - mvn javadoc:javadoc
+
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $DEPLOYMENT_TOKEN
+  keep-history: true
+  on:
+    branch: master

--- a/pom.xml
+++ b/pom.xml
@@ -47,20 +47,11 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>${maven-javadoc-version}</version>
 				<configuration>
-					<reportOutputDirectory>docs</reportOutputDirectory>
-					<destDir>docs</destDir>
+					<reportOutputDirectory>target/javadoc</reportOutputDirectory>
+					<destDir>target/javadoc</destDir>
 					<notimestamp>true</notimestamp>
 					<locale>en_US</locale>
 				</configuration>
-				<executions>
-					<execution>
-						<id>attach-javadocs</id>
-						<phase>install</phase>
-						<goals>
-							<goal>javadoc</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Issue #64: Add javadoc creation to travis and add default github pages deployment configuration.