### PR TITLE
Issue #30: Add interface for pitched notation elements

### DIFF
--- a/src/main/java/org/wmn4j/notation/elements/Note.java
+++ b/src/main/java/org/wmn4j/notation/elements/Note.java
@@ -21,7 +21,7 @@ import java.util.Set;
  *
  * @author otsobjorklund
  */
-public final class Note implements Durational {
+public final class Note implements Durational, Pitched {
 
 	private final Pitch pitch;
 	private final Duration duration;
@@ -137,6 +137,7 @@ public final class Note implements Durational {
 	 *
 	 * @return the Pitch of this Note.
 	 */
+	@Override
 	public Pitch getPitch() {
 		return this.pitch;
 	}

--- a/src/main/java/org/wmn4j/notation/elements/Pitched.java
+++ b/src/main/java/org/wmn4j/notation/elements/Pitched.java
@@ -1,0 +1,17 @@
+/*
+ * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
+ */
+package org.wmn4j.notation.elements;
+
+/**
+ * Interface for notation elements that have pitch.
+ */
+public interface Pitched {
+
+	/**
+	 * Returns the pitch of the notation element.
+	 *
+	 * @return the pitch of the notation element
+	 */
+	Pitch getPitch();
+}


### PR DESCRIPTION
Add an interface for pitched notation elements and have Note implement the interface (it is currently the only pitched notation element supported by wmn4j).