### PR TITLE
Issue #77: Improve and clean up documentation in notation package

### DIFF
--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
@@ -576,19 +576,19 @@ class MusicXmlReaderDom implements MusicXmlReader {
 				.map(clefLineNode -> Integer.parseInt(clefLineNode.getTextContent()))
 				.orElse(3);
 
-		Clef.Type type = Clef.Type.G;
+		Clef.Symbol type = Clef.Symbol.G;
 		switch (clefName) {
 		case MusicXmlTags.CLEF_G:
-			type = Clef.Type.G;
+			type = Clef.Symbol.G;
 			break;
 		case MusicXmlTags.CLEF_F:
-			type = Clef.Type.F;
+			type = Clef.Symbol.F;
 			break;
 		case MusicXmlTags.CLEF_C:
-			type = Clef.Type.C;
+			type = Clef.Symbol.C;
 			break;
 		case MusicXmlTags.CLEF_PERC:
-			type = Clef.Type.PERCUSSION;
+			type = Clef.Symbol.PERCUSSION;
 			break;
 		}
 

--- a/src/main/java/org/wmn4j/notation/builders/ChordBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/ChordBuilder.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.builders;

--- a/src/main/java/org/wmn4j/notation/builders/DurationalBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/DurationalBuilder.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.builders;
@@ -8,24 +7,21 @@ import org.wmn4j.notation.elements.Duration;
 import org.wmn4j.notation.elements.Durational;
 
 /**
- * Interface for builders that build <code>Durational</code> objects.
- *
- * @author Otso Björklund
+ * Interface for builders that build {@link Durational} objects.
  */
 public interface DurationalBuilder {
 
 	/**
-	 * Create a <code>Durational</code> object with the values set in the builder.
+	 * Returns a durational notation element with the values set in the builder.
 	 *
-	 * @return a Durational object.
+	 * @return a durational notation element with the values set in the builder
 	 */
 	Durational build();
 
 	/**
-	 * Get the <code>Duration</code> set in the builder. Each
-	 * <code>DurationalBuilder</code> should always have at least a valid duration.
+	 * Returns the duration set in this builder.
 	 *
-	 * @return The <code>Duration</code> set in the builder.
+	 * @return the duration set in this builder
 	 */
 	Duration getDuration();
 }

--- a/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.builders;
@@ -25,16 +24,13 @@ import org.wmn4j.notation.elements.TimeSignature;
 import org.wmn4j.notation.elements.TimeSignatures;
 
 /**
- * Class for building <code>Measure</code> objects. The builder does not ensure
- * that the <code>DurationalBuilder</code> objects in the builder fill up
- * exactly a measure that has the set time signature. The methods
- * {@link #isFull() isFull} and {@link #isVoiceFull(int) isVoiceFull} should be
- * used for checking if the durations add up to the correct
+ * Class for building {@link Measure} objects. The methods {@link #isFull()
+ * isFull} and {@link #isVoiceFull(int) isVoiceFull} should be used for checking
+ * if the durations add up to the correct amount to fill up the measure
+ * according to the specified time signature.
  *
  * Default values: TimeSignature : 4/4 KeySignature : C-major/a-minor Clef: G
  * Barlines (right and left): Single. No clef changes.
- *
- * @author Otso Björklund
  */
 public class MeasureBuilder {
 
@@ -53,26 +49,27 @@ public class MeasureBuilder {
 	// TODO: If MeasureAttributes are given, then use those.
 
 	/**
-	 * Create a <code>MeasureBuilder</code> with the given
-	 * <code>MeasureAttributes</code>.
+	 * Create a measure builder with the given attributes.
 	 *
-	 * @param number      Measure number for measure being built.
-	 * @param measureAttr MeasureAttributes for measure.
+	 * @param number            measure number for measure being built
+	 * @param measureAttributes attributes for the measure
 	 */
-	public MeasureBuilder(int number, MeasureAttributes measureAttr) {
+	public MeasureBuilder(int number, MeasureAttributes measureAttributes) {
 		this.voices = new HashMap<>();
 		this.number = number;
 
-		this.timeSig = measureAttr.getTimeSignature();
-		this.keySig = measureAttr.getKeySignature();
-		this.clef = measureAttr.getClef();
-		this.leftBarline = measureAttr.getLeftBarline();
-		this.rightBarline = measureAttr.getRightBarline();
-		this.clefChanges = new HashMap<>(measureAttr.getClefChanges());
+		this.timeSig = measureAttributes.getTimeSignature();
+		this.keySig = measureAttributes.getKeySignature();
+		this.clef = measureAttributes.getClef();
+		this.leftBarline = measureAttributes.getLeftBarline();
+		this.rightBarline = measureAttributes.getRightBarline();
+		this.clefChanges = new HashMap<>(measureAttributes.getClefChanges());
 	}
 
 	/**
-	 * @param number Measure number for measure being built.
+	 * Constructor.
+	 *
+	 * @param number measure number for measure being built
 	 */
 	public MeasureBuilder(int number) {
 		this.voices = new HashMap<>();
@@ -80,15 +77,19 @@ public class MeasureBuilder {
 	}
 
 	/**
-	 * @return Measure number.
+	 * Returns the measure number set in this builder.
+	 *
+	 * @return the measure number set in this builder
 	 */
 	public int getNumber() {
 		return this.number;
 	}
 
 	/**
-	 * @param number measure number for the measure that can be built.
-	 * @return reference to this builder.
+	 * Sets the measure number in this builder.
+	 *
+	 * @param number the measure number to set in this builder
+	 * @return reference to this builder
 	 */
 	public MeasureBuilder setNumber(int number) {
 		this.number = number;
@@ -96,15 +97,19 @@ public class MeasureBuilder {
 	}
 
 	/**
-	 * @return time signature currently set for this builder.
+	 * Returns the time signature set in this builder.
+	 *
+	 * @return time signature set for this builder
 	 */
 	public TimeSignature getTimeSignature() {
 		return this.timeSig;
 	}
 
 	/**
-	 * @param timeSignature time signature for the measure that can be built.
-	 * @return reference to this builder.
+	 * Sets the time signature for this builder.
+	 *
+	 * @param timeSignature the time signature set in this builder
+	 * @return reference to this builder
 	 */
 	public MeasureBuilder setTimeSignature(TimeSignature timeSignature) {
 		this.timeSig = timeSignature;
@@ -112,15 +117,19 @@ public class MeasureBuilder {
 	}
 
 	/**
-	 * @return key signature that is currently set for this builder.
+	 * Returns the key signature set in this builder.
+	 *
+	 * @return key signature that is set in this builder
 	 */
 	public KeySignature getKeySignature() {
 		return this.keySig;
 	}
 
 	/**
-	 * @param keySignature key signature for the measure that can be built.
-	 * @return reference to this builder.
+	 * Sets the key signature for this builder.
+	 *
+	 * @param keySignature key signature set in this builder
+	 * @return reference to this builder
 	 */
 	public MeasureBuilder setKeySignature(KeySignature keySignature) {
 		this.keySig = keySignature;
@@ -128,15 +137,19 @@ public class MeasureBuilder {
 	}
 
 	/**
-	 * @return clef currently set for this builder.
+	 * Returns the clef set in this builder.
+	 *
+	 * @return the clef set in this builder
 	 */
 	public Clef getClef() {
 		return this.clef;
 	}
 
 	/**
-	 * @param clef clef for the measure that can be built.
-	 * @return reference to this builder.
+	 * Sets the clef in this builder.
+	 *
+	 * @param clef the clef to be set in this builder
+	 * @return reference to this builder
 	 */
 	public MeasureBuilder setClef(Clef clef) {
 		this.clef = clef;
@@ -144,15 +157,19 @@ public class MeasureBuilder {
 	}
 
 	/**
-	 * @return left barline currently set for this builder.
+	 * Returns the left barline set in this builder.
+	 *
+	 * @return left barline set in this builder
 	 */
 	public Barline getLeftBarline() {
 		return this.leftBarline;
 	}
 
 	/**
-	 * @param leftBarline left barline for the measure that can be built.
-	 * @return reference to this builder.
+	 * Sets the left barline in this builder.
+	 *
+	 * @param leftBarline left barline to set for this builder
+	 * @return reference to this builder
 	 */
 	public MeasureBuilder setLeftBarline(Barline leftBarline) {
 		this.leftBarline = leftBarline;
@@ -160,15 +177,19 @@ public class MeasureBuilder {
 	}
 
 	/**
-	 * @return right barline currently set for this builder.
+	 * Returns the right barline set in this builder.
+	 *
+	 * @return the right barline set in this builder
 	 */
 	public Barline getRightBarline() {
 		return rightBarline;
 	}
 
 	/**
-	 * @param rightBarline right barline for the measure that can be built.
-	 * @return reference to this builder.
+	 * Sets the right barline in this builder.
+	 *
+	 * @param rightBarline right barline to be set in this builder
+	 * @return reference to this builder
 	 */
 	public MeasureBuilder setRightBarline(Barline rightBarline) {
 		this.rightBarline = rightBarline;
@@ -176,6 +197,9 @@ public class MeasureBuilder {
 	}
 
 	/**
+	 * Returns the clef changes in this builder. The keys in the map are the offset
+	 * values of the clef changes measured from the beginning of the measure.
+	 *
 	 * @return clef changes currently set for this builder. Durations are offsets
 	 *         from the beginning of the measure.
 	 */
@@ -184,11 +208,11 @@ public class MeasureBuilder {
 	}
 
 	/**
-	 * Add clef change at offset.
+	 * Adds a clef change at the given offset.
 	 *
-	 * @param offset Offset of clef change from beginning of measure.
-	 * @param clef   clef starting from offset.
-	 * @return reference to this builder.
+	 * @param offset offset of clef change from beginning of measure
+	 * @param clef   clef starting from offset
+	 * @return reference to this builder
 	 */
 	public MeasureBuilder addClefChange(Duration offset, Clef clef) {
 		this.clefChanges.put(offset, clef);
@@ -196,7 +220,7 @@ public class MeasureBuilder {
 	}
 
 	/**
-	 * Add new empty voice to this <code>MeasureBuilder</code>.
+	 * Add new empty voice to this builder.
 	 *
 	 * @return reference to this builder.
 	 */
@@ -206,10 +230,10 @@ public class MeasureBuilder {
 	}
 
 	/**
-	 * Add possibly non-empty voice to this <code>MeasureBuilder</code>.
+	 * Add possibly voice to this builder.
 	 *
-	 * @param voice new voice to be added to this.
-	 * @return reference to this builder.
+	 * @param voice new voice to be added to this
+	 * @return reference to this builder
 	 */
 	public MeasureBuilder addVoice(List<DurationalBuilder> voice) {
 		this.voices.put(this.voices.keySet().size(), voice);
@@ -217,12 +241,12 @@ public class MeasureBuilder {
 	}
 
 	/**
-	 * Append <code>DurationalBuilder</code> object to voice with index
-	 * <code>voice</code>. If voice does not exist it is created.
+	 * Append a {@link DurationalBuilder} to the voice with the given number. If
+	 * voice does not exist it is created.
 	 *
-	 * @param voice   index of voice to which builder is appended.
-	 * @param builder DurationalBuilder object to be appended to voice.
-	 * @return reference to this builder.
+	 * @param voice   number of voice to which builder is appended
+	 * @param builder builder object to be appended to voice
+	 * @return reference to this builder
 	 */
 	public MeasureBuilder addToVoice(int voice, DurationalBuilder builder) {
 
@@ -235,51 +259,51 @@ public class MeasureBuilder {
 	}
 
 	/**
-	 * @return number or voices in this builder.
+	 * Returns the number of voices in this builder.
+	 *
+	 * @return number or voices in this builder
 	 */
 	public int getNumberOfVoices() {
 		return this.voices.size();
 	}
 
 	/**
-	 * Get the voice numbers. Voice numbers do not have to be contiguous.
+	 * Returns the voice numbers set in this builder. Voice numbers do not have to
+	 * be contiguous.
 	 *
-	 * @return the set of voice numbers in this builder.
+	 * @return the set of voice numbers in this builder
 	 */
 	public Set<Integer> getVoiceNumbers() {
 		return Collections.unmodifiableSet(this.voices.keySet());
 	}
 
 	/**
-	 * Set the element at specified location to given value.
+	 * Sets the element at specified location to given value.
 	 *
-	 * @param voice   the number of the voice to be modified.
-	 * @param index   the index in the voice.
-	 * @param builder element to be placed in index on voice.
+	 * @param voice   the number of the voice to be modified
+	 * @param index   the index in the voice
+	 * @param builder element to be placed in index on voice
 	 */
 	public void setElement(int voice, int index, DurationalBuilder builder) {
 		this.voices.get(voice).set(index, builder);
 	}
 
 	/**
-	 * Get a reference to the <code>DurationalBuilder</code> at the specified
-	 * position.
+	 * Returns the builder at the given position.
 	 *
-	 * @param voice the number of the voice from which to get the object.
-	 * @param index index in the voice.
-	 * @return reference to the <code>DurationalBuilder</code> at the position
-	 *         specified by the parameters.
+	 * @param voice the number of the voice from which to get the object
+	 * @param index index in the voice
+	 * @return reference to the builder at the position specified by the parameters
 	 */
 	public DurationalBuilder get(int voice, int index) {
 		return this.voices.get(voice).get(index);
 	}
 
 	/**
-	 * Get the sum of durations on a voice.
+	 * Returns the sum of durations in a voice.
 	 *
-	 * @param voice the index of the voice.
-	 * @return Sum of the durations of the <code>Durational</code> objects on the
-	 *         voice.
+	 * @param voice the index of the voice
+	 * @return sum of the durations of the in the voice
 	 */
 	public Duration totalDurationOfVoice(int voice) {
 		final List<Duration> durations = new ArrayList<>();
@@ -291,13 +315,12 @@ public class MeasureBuilder {
 	}
 
 	/**
-	 * Check if voice is full. A voice is considered full when it contains
-	 * <code>DurationalBuilder</code> objects whose combined duration is enough to
-	 * fill a measure that has the time signature that is set for this builder.
+	 * Returns true if the voice with the given number is full. A voice is
+	 * considered full when the durations in it are enough to fill a measure with
+	 * the time signature set in this builder.
 	 *
-	 * @param voice index of voice that is checked.
-	 * @return true if the durations in the voice add up to fill a measure. False
-	 *         otherwise.
+	 * @param voice index of voice that is checked
+	 * @return true if the durations in the voice add up to fill a measure
 	 */
 	public boolean isVoiceFull(int voice) {
 		final Duration voiceDuration = this.totalDurationOfVoice(voice);
@@ -305,7 +328,7 @@ public class MeasureBuilder {
 	}
 
 	/**
-	 * Check if any voice in this builder is full.
+	 * Returns true if any voice in this builder is full.
 	 *
 	 * @return true if even a single voice is full. False otherwise.
 	 */
@@ -317,14 +340,6 @@ public class MeasureBuilder {
 		}
 
 		return false;
-	}
-
-	private List<Durational> buildVoice(List<DurationalBuilder> buildersForVoice) {
-		final List<Durational> voice = new ArrayList<>();
-
-		buildersForVoice.forEach((builder) -> voice.add(builder.build()));
-
-		return voice;
 	}
 
 	private Map<Integer, List<Durational>> getBuiltVoices() {
@@ -341,11 +356,9 @@ public class MeasureBuilder {
 	}
 
 	/**
-	 * Create a <code>Measure</code> with the contents of this builder.
+	 * Returns a {@link Measure} with the values set in this builder.
 	 *
-	 * @return Measure that has the set attributes and contains
-	 *         <code>Durational</code> objects built using the contained
-	 *         <code>DurationalBuilder</code> objects.
+	 * @return a measure with the values set in this builder
 	 */
 	public Measure build() {
 		final MeasureAttributes measureAttr = MeasureAttributes.getMeasureAttr(this.timeSig, this.keySig,

--- a/src/main/java/org/wmn4j/notation/builders/NoteBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/NoteBuilder.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.builders;
@@ -17,8 +16,7 @@ import org.wmn4j.notation.elements.Note;
 import org.wmn4j.notation.elements.Pitch;
 
 /**
- * Class for building <code>Note</code> objects. The built note is cached. This
- * is used for ensuring that sequences of tied notes are built correctly.
+ * Class for building {@link Note} objects. The built note is cached.
  */
 public class NoteBuilder implements DurationalBuilder {
 
@@ -35,8 +33,8 @@ public class NoteBuilder implements DurationalBuilder {
 	/**
 	 * Constructor.
 	 *
-	 * @param pitch    The pitch set in this builder.
-	 * @param duration The duration set in this builder.
+	 * @param pitch    the pitch set in this builder
+	 * @param duration the duration set in this builder
 	 */
 	public NoteBuilder(Pitch pitch, Duration duration) {
 		this.pitch = pitch;
@@ -47,8 +45,8 @@ public class NoteBuilder implements DurationalBuilder {
 	}
 
 	/**
-	 * Copy constructor for NoteBuilder. Creates a new instance of NoteBuilder
-	 * that is a copy of the NoteBuilder given as an attribute.
+	 * Copy constructor for NoteBuilder. Creates a new instance of NoteBuilder that
+	 * is a copy of the NoteBuilder given as an attribute.
 	 *
 	 * @param builder the NoteBuilder to be copied
 	 */
@@ -209,30 +207,30 @@ public class NoteBuilder implements DurationalBuilder {
 	/**
 	 * Returns the NoteBuilder of the following tied note, if there is one.
 	 *
-	 * @return Optional containing the NoteBuilder of the following tied note
-	 *         if there is one, otherwise empty Optional.
+	 * @return Optional containing the NoteBuilder of the following tied note if
+	 *         there is one, otherwise empty Optional.
 	 */
 	public Optional<NoteBuilder> getFollowingTied() {
 		return Optional.ofNullable(followingTied);
 	}
 
 	/**
-	 * Removes the cached <code>Note</code> that was built on the previous call of
-	 * {@link #build build}.
+	 * Removes the cached note that was built on the previous call of {@link #build
+	 * build}.
 	 */
 	public void clearCache() {
 		this.cachedNote = null;
 	}
 
 	/**
-	 * Creates a <code>Note</code> with the values set in this builder. This method
-	 * has side effects. The method calls {@link #build build} recursively on the
-	 * following <code>NoteBuilder</code> objects to which this is tied. Calling
-	 * this method to create the first note in a sequence of tied notes builds all
-	 * the tied notes. The <code>Note</code> objects are cached in the builders. In
-	 * case of tied notes, the temporally first one should be built first.
+	 * Creates a note with the values set in this builder. This method has side
+	 * effects. The method calls {@link #build build} recursively on the following
+	 * {@link NoteBuilder} objects to which this is tied. Calling this method to
+	 * create the first note in a sequence of tied notes builds all the tied notes.
+	 * The {@link Note} objects are cached in the builders. In case of tied notes,
+	 * the temporally first one should be built first.
 	 *
-	 * @return <code>Note</code> instance with the values set in this builder.
+	 * @return a note instance with the values set in this builder.
 	 */
 	@Override
 	public Note build() {

--- a/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.builders;
@@ -18,9 +17,7 @@ import org.wmn4j.notation.elements.SingleStaffPart;
 import org.wmn4j.notation.elements.Staff;
 
 /**
- * Builder for building <code>Part</code> objects.
- *
- * @author Otso Björklund
+ * Builder for building {@link Part} objects.
  */
 public class PartBuilder {
 
@@ -29,26 +26,30 @@ public class PartBuilder {
 	private static final int SINGLE_STAFF_NUMBER = SingleStaffPart.STAFF_NUMBER;
 
 	/**
-	 * @param name Name of the <code>Part</code> to be built.
+	 * Constructor.
+	 *
+	 * @param name the name of the part to be built.
 	 */
 	public PartBuilder(String name) {
 		this.partAttributes.put(Part.Attribute.NAME, name);
 	}
 
 	/**
-	 * @return the number of staves in the <code>PartBuilder</code>.
+	 * Returns the number of staves set in this builder.
+	 *
+	 * @return the number of staves in this builder
 	 */
 	public int getStaffCount() {
 		return this.staveContents.size();
 	}
 
 	/**
-	 * Adds a <code>MeasureBuilder</code>. This is used for building parts with a
-	 * single staff.
+	 * Adds a {@link MeasureBuilder} to this builder. This is used for building
+	 * parts with a single staff.
 	 *
-	 * @param measureBuilder The measureBuilder that is added to the end of the
-	 *                       staff.
-	 * @return reference to this.
+	 * @param measureBuilder the measureBuilder that is added to the end of the
+	 *                       staff
+	 * @return reference to this
 	 */
 	public PartBuilder add(MeasureBuilder measureBuilder) {
 		this.addToStaff(SINGLE_STAFF_NUMBER, measureBuilder);
@@ -56,14 +57,14 @@ public class PartBuilder {
 	}
 
 	/**
-	 * Adds a <code>MeasureBuilder</code> to staff. This is used for building parts
-	 * with multiple staves.
+	 * Adds a {@link MeasureBuilder} to the staff with the given number. This is
+	 * used for building parts with multiple staves.
 	 *
-	 * @param staffNumber    The number of the staff to which measureBuilder is
-	 *                       added.
-	 * @param measureBuilder The measureBuilder that is added to the end of the
-	 *                       staff.
-	 * @return reference to this.
+	 * @param staffNumber    the number of the staff to which measureBuilder is
+	 *                       added
+	 * @param measureBuilder the measureBuilder that is added to the end of the
+	 *                       staff
+	 * @return reference to this
 	 */
 	public PartBuilder addToStaff(int staffNumber, MeasureBuilder measureBuilder) {
 		if (!this.staveContents.containsKey(staffNumber)) {
@@ -75,15 +76,19 @@ public class PartBuilder {
 	}
 
 	/**
-	 * @param attribute The attribute to be set.
-	 * @param value     The value that will be set for the attribute.
+	 * Sets the given attribute to the given value.
+	 *
+	 * @param attribute the attribute to be set
+	 * @param value     the value that will be set for the attribute
 	 */
 	public void setAttribute(Part.Attribute attribute, String value) {
 		this.partAttributes.put(attribute, value);
 	}
 
 	/**
-	 * @return The name of the <code>Part</code> being built.
+	 * Returns the name set in this builder.
+	 *
+	 * @return the name set in this builder
 	 */
 	public String getName() {
 		return this.partAttributes.get(Part.Attribute.NAME);
@@ -94,10 +99,9 @@ public class PartBuilder {
 	}
 
 	/**
-	 * Creates a part using the contained <code>MeasureBuilder</code> objects.
+	 * Returns a part with the contents set in this builder.
 	 *
-	 * @return A <code>Part</code> with the measures and attributes in the builder.
-	 *         The type of the part depends on the number of staves.
+	 * @return a part with the contents set in this builder
 	 */
 	public Part build() {
 		if (this.staveContents.size() == 1) {

--- a/src/main/java/org/wmn4j/notation/builders/RestBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/RestBuilder.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.builders;
@@ -10,9 +9,7 @@ import org.wmn4j.notation.elements.Duration;
 import org.wmn4j.notation.elements.Rest;
 
 /**
- * Class for building <code>Rest</code> objects.
- *
- * @author Otso Björklund
+ * Class for building {@link Rest} objects.
  */
 public final class RestBuilder implements DurationalBuilder {
 
@@ -28,7 +25,7 @@ public final class RestBuilder implements DurationalBuilder {
 	}
 
 	/**
-	 * Set the duration of the <code>Rest</code>.
+	 * Set the duration in this builder.
 	 *
 	 * @param duration the duration that is set to this builder
 	 */

--- a/src/main/java/org/wmn4j/notation/builders/ScoreBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/ScoreBuilder.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.builders;
@@ -13,9 +12,7 @@ import org.wmn4j.notation.elements.Part;
 import org.wmn4j.notation.elements.Score;
 
 /**
- * Class for building <code>Score</code> objects.
- *
- * @author Otso Björklund
+ * Class for building {@link Score} objects.
  */
 public class ScoreBuilder {
 
@@ -23,7 +20,7 @@ public class ScoreBuilder {
 	private final List<PartBuilder> partBuilders;
 
 	/**
-	 * Constructor that creates an empty ScoreBuilder.
+	 * Constructor that creates an empty builder.
 	 */
 	public ScoreBuilder() {
 		this.scoreAttr = new HashMap<>();
@@ -31,28 +28,28 @@ public class ScoreBuilder {
 	}
 
 	/**
-	 * Set attribute to given value.
+	 * Set the given attribute to given value.
 	 *
-	 * @param attribute the attribute to be set.
-	 * @param attrValue value for the attribute.
+	 * @param attribute      the attribute to be set
+	 * @param attributeValue value for the attribute
 	 */
-	public void setAttribute(Score.Attribute attribute, String attrValue) {
-		this.scoreAttr.put(attribute, attrValue);
+	public void setAttribute(Score.Attribute attribute, String attributeValue) {
+		this.scoreAttr.put(attribute, attributeValue);
 	}
 
 	/**
-	 * Add <code>PartBuilder</code> to builder.
+	 * Add {@link PartBuilder} to this builder.
 	 *
-	 * @param partBuilder partBuilder to added to this builder.
+	 * @param partBuilder partBuilder to add to this builder
 	 */
 	public void addPart(PartBuilder partBuilder) {
 		this.partBuilders.add(partBuilder);
 	}
 
 	/**
-	 * Build a <code>Score</code> with the values specified in this builder.
+	 * Returns a {@link Score} with the contents of this builder.
 	 *
-	 * @return a <code>Score</code> with the values specified in this builder.
+	 * @return a score with the contents of this builder
 	 */
 	public Score build() {
 		final List<Part> parts = new ArrayList<>();

--- a/src/main/java/org/wmn4j/notation/elements/Articulation.java
+++ b/src/main/java/org/wmn4j/notation/elements/Articulation.java
@@ -1,13 +1,10 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
 
 /**
  * Note specific articulations.
- *
- * @author Otso Björklund
  */
 public enum Articulation {
 	/**

--- a/src/main/java/org/wmn4j/notation/elements/Articulation.java
+++ b/src/main/java/org/wmn4j/notation/elements/Articulation.java
@@ -4,7 +4,7 @@
 package org.wmn4j.notation.elements;
 
 /**
- * Note specific articulations.
+ * Articulations that affect a single note.
  */
 public enum Articulation {
 	/**

--- a/src/main/java/org/wmn4j/notation/elements/Barline.java
+++ b/src/main/java/org/wmn4j/notation/elements/Barline.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;

--- a/src/main/java/org/wmn4j/notation/elements/Chord.java
+++ b/src/main/java/org/wmn4j/notation/elements/Chord.java
@@ -12,34 +12,32 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Class for chords. This class should be used for chords where the notes are
- * all of same length. For polyphonic textures add voices to the Measure. This
- * class is immutable.
+ * Represents a chord. This class should be used for chords where the notes are
+ * all of same length. For polyphonic textures add voices to the
+ * {@link Measure}. This class is immutable.
  */
 public final class Chord implements Durational, Iterable<Note> {
 	private final List<Note> notes;
 
 	/**
-	 * Get an instance of <code>Chord</code> with the given <code>Note</code>
-	 * objects.
+	 * Returns an instance of with the given {@link Note} objects.
 	 *
-	 * @param n A non-empty and non-null array of <code>Note</code> objects.
-	 * @return a chord with the given notes.
+	 * @param n A non-empty and non-null array of {@link Note} objects
+	 * @return a chord with the given notes
 	 *
-	 * @throws NullPointerException     if notes is null.
+	 * @throws NullPointerException     if notes is null
 	 * @throws IllegalArgumentException if notes is empty or all Note objects in
-	 *                                  notes are not of same duration.
+	 *                                  notes are not of same duration
 	 */
 	public static Chord getChord(Note... n) {
 		return new Chord(Arrays.asList(n));
 	}
 
 	/**
-	 * Get an instance of <code>Chord</code> with the given <code>Note</code>s.
+	 * Returns an instance with the given {@link Note}s.
 	 *
-	 * @param notes A non-empty and non-null Collection of <code>Note</code>
-	 *              objects.
-	 * @return a chord with the given notes.
+	 * @param notes A non-empty and non-null Collection of {@link Note} objects
+	 * @return a chord with the given notes
 	 *
 	 * @throws NullPointerException     if notes is null.
 	 * @throws IllegalArgumentException if notes is empty or all Note objects in
@@ -52,10 +50,10 @@ public final class Chord implements Durational, Iterable<Note> {
 	/**
 	 * Private constructor. Use static getters for getting an instance.
 	 *
-	 * @throws NullPointerException     if notes is null.
+	 * @throws NullPointerException     if notes is null
 	 * @throws IllegalArgumentException if notes is empty or all Note objects in
-	 *                                  notes are not of same duration.
-	 * @param notes the notes that are put in this Chord.
+	 *                                  notes are not of same duration
+	 * @param notes the notes that are put in this Chord
 	 */
 	private Chord(Collection<Note> notes) {
 
@@ -83,13 +81,13 @@ public final class Chord implements Durational, Iterable<Note> {
 	}
 
 	/**
-	 * Get the <code>Note</code> with the fromLowest lowest pitch from this
-	 * <code>Chord</code>.
+	 * Returns the {@link Note} at the given index counting from lowest pitch in
+	 * this {@link Chord}.
 	 *
 	 * @throws IllegalArgumentException if fromLowest is smaller than 0 or at least
-	 *                                  the number of notes in this Chord.
-	 * @param fromLowest index of note, 0 being the lowest note in the chord.
-	 * @return the note from index fromLowest.
+	 *                                  the number of notes in this Chord
+	 * @param fromLowest index of note, 0 being the lowest note in the chord
+	 * @return the note from index fromLowest
 	 */
 	public Note getNote(int fromLowest) {
 		if (fromLowest < 0 || fromLowest >= this.notes.size()) {
@@ -101,6 +99,8 @@ public final class Chord implements Durational, Iterable<Note> {
 	}
 
 	/**
+	 * Returns the lowest note in this chord.
+	 *
 	 * @return the note with the lowest pitch in this Chord.
 	 */
 	public Note getLowestNote() {
@@ -108,6 +108,8 @@ public final class Chord implements Durational, Iterable<Note> {
 	}
 
 	/**
+	 * Returns the highest note in this chord.
+	 *
 	 * @return the note with the highest pitch in this Chord.
 	 */
 	public Note getHighestNote() {
@@ -115,41 +117,43 @@ public final class Chord implements Durational, Iterable<Note> {
 	}
 
 	/**
-	 * @return number of notes in this Chord.
+	 * Returns the number of notes in this chord.
+	 *
+	 * @return number of notes in this chord.
 	 */
 	public int getNoteCount() {
 		return this.notes.size();
 	}
 
 	/**
-	 * Get a Chord with the added note.
+	 * Returns a chord with the notes of this chord and the given note.
 	 *
-	 * @param note note to be Added.
-	 * @return Chord with the notes of this and the added note.
+	 * @param note the note that is added
+	 * @return a chord with the notes of this and the added note
 	 */
-	public Chord addNote(Note note) {
+	public Chord add(Note note) {
 		final ArrayList<Note> noteList = new ArrayList<>(this.notes);
 		noteList.add(note);
 		return Chord.getChord(noteList);
 	}
 
 	/**
-	 * Get a Chord with the given note removed.
+	 * Returns a Chord with the given note removed.
 	 *
-	 * @param note note to be removed.
-	 * @return Chord without the given note.
+	 * @param note note to be removed
+	 * @return a chord without the given note
 	 */
-	public Chord removeNote(Note note) {
+	public Chord remove(Note note) {
 		final ArrayList<Note> noteList = new ArrayList<>(this.notes);
 		noteList.remove(note);
 		return Chord.getChord(noteList);
 	}
 
 	/**
-	 * Check if this contains the given pitch.
+	 * Returns true if this chord contains the given pitch.
 	 *
-	 * @param pitch pitch whose presence in this Chord is checked.
-	 * @return true if this contains the given pitch, false otherwise.
+	 * @param pitch pitch whose presence in this chord is checked
+	 * @return true if this contains the given pitch, false otherwise
 	 */
 	public boolean contains(Pitch pitch) {
 		for (Note note : this.notes) {
@@ -162,20 +166,20 @@ public final class Chord implements Durational, Iterable<Note> {
 	}
 
 	/**
-	 * Check if this contains the given note.
+	 * Returns true if this contains the given note.
 	 *
-	 * @param note Note whose presence in this Chord is checked.
-	 * @return true if this contains the given note, false otherwise.
+	 * @param note the note whose presence in this chord is checked
+	 * @return true if this contains the given note, false otherwise
 	 */
 	public boolean contains(Note note) {
 		return this.notes.contains(note);
 	}
 
 	/**
-	 * Get a Chord with the given pitch removed.
+	 * Returns a chord with the given pitch removed.
 	 *
-	 * @param pitch pitch of the note to be removed.
-	 * @return a chord without a note with the given pitch.
+	 * @param pitch pitch of the note to be removed
+	 * @return a chord without a note with the given pitch
 	 */
 	public Chord remove(Pitch pitch) {
 		if (this.contains(pitch)) {
@@ -188,7 +192,7 @@ public final class Chord implements Durational, Iterable<Note> {
 	}
 
 	/**
-	 * Check equality against <code>Object o</code>.
+	 * Returns true if the given Object is equal to this.
 	 *
 	 * @param o Object against which this is compared for equality.
 	 * @return true if o is an instance of Chord and contains all and no other notes
@@ -224,13 +228,6 @@ public final class Chord implements Durational, Iterable<Note> {
 		return hash;
 	}
 
-	/**
-	 * Get a String representation of this <code>Chord</code>. The string
-	 * representation of chord is of form: <code>[Note0, Note1, ...]</code> where
-	 * the notes are in order increasing order of pitch.
-	 *
-	 * @return string representation of this chord.
-	 */
 	@Override
 	public String toString() {
 		final StringBuilder strBuilder = new StringBuilder();
@@ -252,10 +249,6 @@ public final class Chord implements Durational, Iterable<Note> {
 		return false;
 	}
 
-	/**
-	 * @return Iterator that can be used to iterate through the notes in this Chord.
-	 *         The Iterator does not support removing.
-	 */
 	@Override
 	public Iterator<Note> iterator() {
 		return this.notes.iterator();

--- a/src/main/java/org/wmn4j/notation/elements/Chord.java
+++ b/src/main/java/org/wmn4j/notation/elements/Chord.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -16,8 +15,6 @@ import java.util.Objects;
  * Class for chords. This class should be used for chords where the notes are
  * all of same length. For polyphonic textures add voices to the Measure. This
  * class is immutable.
- *
- * @author Otso Björklund
  */
 public final class Chord implements Durational, Iterable<Note> {
 	private final List<Note> notes;

--- a/src/main/java/org/wmn4j/notation/elements/Clef.java
+++ b/src/main/java/org/wmn4j/notation/elements/Clef.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -10,8 +9,6 @@ import java.util.Objects;
  * Class for clefs. Clefs have a type which tells the shape of the clef and
  * position which is the line on which the center of the clef is situated. For
  * example, the center of a G-type clef is the part of the clef that denotes G4.
- *
- * @author Otso Björklund
  */
 public final class Clef {
 	public enum Type {

--- a/src/main/java/org/wmn4j/notation/elements/Clef.java
+++ b/src/main/java/org/wmn4j/notation/elements/Clef.java
@@ -6,12 +6,17 @@ package org.wmn4j.notation.elements;
 import java.util.Objects;
 
 /**
- * Class for clefs. Clefs have a type which tells the shape of the clef and
+ * Represents a clef. Clefs have a symbol which tells the shape of the clef and
  * position which is the line on which the center of the clef is situated. For
- * example, the center of a G-type clef is the part of the clef that denotes G4.
+ * example, the center of a G-symbol clef is the part of the clef that denotes
+ * G4.
  */
 public final class Clef {
-	public enum Type {
+
+	/**
+	 * Represents the type of clef symbol.
+	 */
+	public enum Symbol {
 		/**
 		 * The G clef.
 		 */
@@ -33,45 +38,45 @@ public final class Clef {
 		PERCUSSION
 	}
 
-	private final Type type;
+	private final Symbol symbol;
 	// The the center of the clef counted from bottom.
 	private final int line;
 
 	/**
-	 * Get an instance of <code>Clef</code>.
+	 * Returns an instance with the given symbol at the given line.
 	 *
-	 * @throws IllegalArgumentException if line is smaller than 1.
-	 * @throws NullPointerException     if type is null.
-	 * @param type type of the clef.
-	 * @param line counting from the bottom line, the line on which the clef is
-	 *             centered.
-	 * @return a Clef with the specified properties.
+	 * @throws IllegalArgumentException if line is smaller than 1
+	 * @throws NullPointerException     if symbol is null
+	 * @param symbol the symbol of the clef
+	 * @param line   counting from the bottom line, the line on which the clef is
+	 *               centered
+	 * @return a clef with the specified properties.
 	 */
-	public static Clef getClef(Type type, int line) {
+	public static Clef getClef(Symbol symbol, int line) {
 
 		if (line < 1) {
 			throw new IllegalArgumentException("line is smaller than 1");
 		}
 
-		return new Clef(Objects.requireNonNull(type), line);
+		return new Clef(Objects.requireNonNull(symbol), line);
 	}
 
-	private Clef(Type type, int line) {
-		this.type = type;
+	private Clef(Symbol symbol, int line) {
+		this.symbol = symbol;
 		this.line = line;
 	}
 
 	@Override
 	public String toString() {
-		return this.type + "-clef(" + this.line + ")";
+		return this.symbol + "-clef(" + this.line + ")";
 	}
 
 	/**
-	 * Compare this <code>Clef</code> with <code>Object o</code> for equality.
+	 * Returns true if this clef is equal to the given object.
 	 *
-	 * @param o the Object against which this is compared for equality.
-	 * @return true if o is an instance of Clef and has the same type and position
-	 *         as this.
+	 * @param o the Object against which this is compared for equality
+	 * @return true if o is an instance of Clef and has the same symbol and position
+	 *         as this
 	 */
 	@Override
 	public boolean equals(Object o) {
@@ -84,13 +89,13 @@ public final class Clef {
 		}
 
 		final Clef other = (Clef) o;
-		return this.type == other.type && this.line == other.line;
+		return this.symbol == other.symbol && this.line == other.line;
 	}
 
 	@Override
 	public int hashCode() {
 		int hash = 3;
-		hash = 71 * hash + Objects.hashCode(this.type);
+		hash = 71 * hash + Objects.hashCode(this.symbol);
 		hash = 71 * hash + this.line;
 		return hash;
 	}

--- a/src/main/java/org/wmn4j/notation/elements/Clefs.java
+++ b/src/main/java/org/wmn4j/notation/elements/Clefs.java
@@ -1,13 +1,10 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
 
 /**
  * Common clefs.
- *
- * @author Otso Björklund
  */
 public final class Clefs {
 	/**

--- a/src/main/java/org/wmn4j/notation/elements/Clefs.java
+++ b/src/main/java/org/wmn4j/notation/elements/Clefs.java
@@ -10,22 +10,22 @@ public final class Clefs {
 	/**
 	 * The basic G clef.
 	 */
-	public static final Clef G = Clef.getClef(Clef.Type.G, 2);
+	public static final Clef G = Clef.getClef(Clef.Symbol.G, 2);
 
 	/**
 	 * The basic F clef.
 	 */
-	public static final Clef F = Clef.getClef(Clef.Type.F, 4);
+	public static final Clef F = Clef.getClef(Clef.Symbol.F, 4);
 
 	/**
 	 * The basic alto clef.
 	 */
-	public static final Clef ALTO = Clef.getClef(Clef.Type.C, 3);
+	public static final Clef ALTO = Clef.getClef(Clef.Symbol.C, 3);
 
 	/**
 	 * The basic percussion clef.
 	 */
-	public static final Clef PERCUSSION = Clef.getClef(Clef.Type.PERCUSSION, 3);
+	public static final Clef PERCUSSION = Clef.getClef(Clef.Symbol.PERCUSSION, 3);
 
 	private Clefs() {
 		// Not meant to be instantiated

--- a/src/main/java/org/wmn4j/notation/elements/Duration.java
+++ b/src/main/java/org/wmn4j/notation/elements/Duration.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -14,8 +13,6 @@ import java.util.List;
  * normal music terminology. For example, the duration of a quarter note is
  * handled as the rational number 1/4. The rational number is always reduced to
  * the lowest possible numerator and denominator. This class is immutable.
- *
- * @author Otso Björklund
  */
 public final class Duration implements Comparable<Duration> {
 

--- a/src/main/java/org/wmn4j/notation/elements/Duration.java
+++ b/src/main/java/org/wmn4j/notation/elements/Duration.java
@@ -7,12 +7,12 @@ import java.math.BigInteger;
 import java.util.List;
 
 /**
- * The <code>Duration</code> class represents the duration of any musical object
- * with a duration such as a note or a rest. Durations are handled as rational
- * numbers that tell what fraction of a whole note the duration is just like in
- * normal music terminology. For example, the duration of a quarter note is
- * handled as the rational number 1/4. The rational number is always reduced to
- * the lowest possible numerator and denominator. This class is immutable.
+ * Represents the duration of any musical object with a duration such as a note
+ * or a rest. Durations are handled as rational numbers that tell what fraction
+ * of a whole note the duration is just like in normal music terminology. For
+ * example, the duration of a quarter note is handled as the rational number
+ * 1/4. The rational number is always reduced to the lowest possible numerator
+ * and denominator. This class is immutable.
  */
 public final class Duration implements Comparable<Duration> {
 
@@ -20,13 +20,13 @@ public final class Duration implements Comparable<Duration> {
 	private final int denominator;
 
 	/**
-	 * Returns a <code>Duration</code> object. The numerator and denominator must be
-	 * at least 1.
+	 * Returns an instance with the given numerator and denominator. The numerator
+	 * and denominator must be at least 1.
 	 *
-	 * @throws IllegalArgumentException if numerator or denominator are less than 1.
-	 * @param numerator   the numerator part of the duration.
-	 * @param denominator the denominator part of the duration.
-	 * @return a Duration object.
+	 * @throws IllegalArgumentException if numerator or denominator are less than 1
+	 * @param numerator   the numerator part of the duration
+	 * @param denominator the denominator part of the duration
+	 * @return an instance with the given numerator and denominator
 	 */
 	public static Duration getDuration(int numerator, int denominator) {
 
@@ -54,8 +54,8 @@ public final class Duration implements Comparable<Duration> {
 	 * Constructor for the class. The constructor is private, to get a Duration
 	 * object use the static method {@link #getDuration(int, int) getDuration}.
 	 *
-	 * @param numerator   the numerator part of the duration.
-	 * @param denominator the denominator part of the duration.
+	 * @param numerator   the numerator part of the duration
+	 * @param denominator the denominator part of the duration
 	 */
 	private Duration(int numerator, int denominator) {
 		this.numerator = numerator;
@@ -63,27 +63,29 @@ public final class Duration implements Comparable<Duration> {
 	}
 
 	/**
-	 * @return the numerator part of the duration.
+	 * Returns the numerator of this duration.
+	 *
+	 * @return the numerator of this duration
 	 */
 	public int getNumerator() {
 		return this.numerator;
 	}
 
 	/**
-	 * @return the denominator part of the duration.
+	 * Returns the denominator of this duration.
+	 *
+	 * @return the denominator of this duration.
 	 */
 	public int getDenominator() {
 		return this.denominator;
 	}
 
 	/**
-	 * Compares this <code>Duration</code> to <code>Object o</code> for equality. If
-	 * <code>Object o</code> is of class <code>Duration</code> and has the same
-	 * numerator and denominator as this, then <code>o</code> is equal to this.
+	 * Returns true if this is equal to the given object.
 	 *
-	 * @param o an object against which this Duration is compared for equality.
-	 * @return true if <code>Object o</code> is a <code>Duration</code> with the
-	 *         same numerator and denominator as this, false otherwise.
+	 * @param o an object against which this Duration is compared for equality
+	 * @return true if the given object is a {@link Duration} with the same
+	 *         numerator and denominator as this, false otherwise
 	 */
 	@Override
 	public boolean equals(Object o) {
@@ -108,22 +110,16 @@ public final class Duration implements Comparable<Duration> {
 		return hash;
 	}
 
-	/**
-	 * Durations are represented as strings of form
-	 * <code>(numerator/denominator)</code>.
-	 *
-	 * @return string representation of this Duration.
-	 */
 	@Override
 	public String toString() {
 		return "(" + this.numerator + "/" + this.denominator + ")";
 	}
 
 	/**
-	 * Extend this Duration by adding a dot (add half of this Duration to itself).
-	 * Does not change this Duration.
+	 * Returns a duration that is this duration with half of this duration added to
+	 * it.
 	 *
-	 * @return Duration that is this incremented by half of this.
+	 * @return duration that is this incremented by half of this
 	 */
 	public Duration addDot() {
 		return this.add(Duration.getDuration(this.numerator, 2 * this.denominator));
@@ -144,8 +140,7 @@ public final class Duration implements Comparable<Duration> {
 	}
 
 	/**
-	 * Returns a Duration that is the sum of this and other. Does not change this
-	 * Duration (this class is immutable).
+	 * Returns a duration that is the sum of this and other.
 	 *
 	 * @param other the Duration to be added to this.
 	 * @return a Duration that is the sum of this and other.
@@ -158,8 +153,8 @@ public final class Duration implements Comparable<Duration> {
 	}
 
 	/**
-	 * Returns a Duration that is the this other minus other given as parameter.
-	 * Does not change this Duration (this class is immutable).
+	 * Returns a duration that is this duration minus the duration given as
+	 * parameter.
 	 *
 	 * @param other the Duration to be subtracted from this.
 	 * @return a Duration that is this other minus other.
@@ -172,12 +167,12 @@ public final class Duration implements Comparable<Duration> {
 	}
 
 	/**
-	 * Returns a Duration that is this duration multiplied by multiplier. Multiplier
-	 * must be at least 1. Does not change this Duration (this class is immutable).
+	 * Returns a duration that is this duration multiplied by multiplier. Multiplier
+	 * must be at least 1.
 	 *
-	 * @throws IllegalArgumentException if multiplier is less than 1.
-	 * @param multiplier the factor by which this duration should be multiplied.
-	 * @return a Duration that is this duration multiplied by multiplier.
+	 * @throws IllegalArgumentException if multiplier is less than 1
+	 * @param multiplier the factor by which this duration should be multiplied
+	 * @return a Duration that is this duration multiplied by multiplier
 	 */
 	public Duration multiplyBy(int multiplier) {
 		if (multiplier < 1) {
@@ -188,12 +183,12 @@ public final class Duration implements Comparable<Duration> {
 	}
 
 	/**
-	 * Returns a Duration that is this duration divided by divider. Divider must be
-	 * at least 1. Does not change this Duration (this class is immutable).
+	 * Returns a duration that is this duration divided by divider. Divider must be
+	 * at least 1.
 	 *
-	 * @throws IllegalArgumentException if divider is less than 1.
-	 * @param divisor the factor by which this duration should be divided.
-	 * @return a Duration that is this duration divided by divider.
+	 * @throws IllegalArgumentException if divider is less than 1
+	 * @param divisor the factor by which this duration should be divided
+	 * @return a Duration that is this duration divided by divider
 	 */
 	public Duration divideBy(int divisor) {
 		if (divisor < 1) {
@@ -204,16 +199,20 @@ public final class Duration implements Comparable<Duration> {
 	}
 
 	/**
-	 * @param other Duration to which this is compared.
-	 * @return true if this is longer than other, otherwise false.
+	 * Returns true if this is longer than other, otherwise false.
+	 *
+	 * @param other Duration to which this is compared
+	 * @return true if this is longer than other, otherwise false
 	 */
 	public boolean isLongerThan(Duration other) {
 		return this.compareTo(other) > 0;
 	}
 
 	/**
-	 * @param other Duration to which this is compared.
-	 * @return true if this is shorter than other, otherwise false.
+	 * Returns true if this is shorter than other, otherwise false.
+	 *
+	 * @param other Duration to which this is compared
+	 * @return true if this is shorter than other, otherwise false
 	 */
 	public boolean isShorterThan(Duration other) {
 		return this.compareTo(other) < 0;
@@ -232,11 +231,11 @@ public final class Duration implements Comparable<Duration> {
 	}
 
 	/**
-	 * Get the total summed duration of the durations in the List.
+	 * Returns the total summed duration of the given durations.
 	 *
-	 * @throws IllegalArgumentException if durations is empty.
-	 * @param durations List of <code>Duration</code> objects.
-	 * @return The sum of durations in List.
+	 * @throws IllegalArgumentException if durations is empty
+	 * @param durations the durations whose sum is returned
+	 * @return The sum of the given durations
 	 */
 	public static Duration sumOf(List<Duration> durations) {
 		if (durations.isEmpty()) {

--- a/src/main/java/org/wmn4j/notation/elements/Duration.java
+++ b/src/main/java/org/wmn4j/notation/elements/Duration.java
@@ -4,7 +4,8 @@
 package org.wmn4j.notation.elements;
 
 import java.math.BigInteger;
-import java.util.List;
+import java.util.Collection;
+import java.util.Iterator;
 
 /**
  * Represents the duration of any musical object with a duration such as a note
@@ -237,19 +238,17 @@ public final class Duration implements Comparable<Duration> {
 	 * @param durations the durations whose sum is returned
 	 * @return The sum of the given durations
 	 */
-	public static Duration sumOf(List<Duration> durations) {
+	public static Duration sumOf(Collection<Duration> durations) {
 		if (durations.isEmpty()) {
 			throw new IllegalArgumentException("Cannot compute sum of durations from empty list");
 		}
 
-		if (durations.size() == 1) {
-			return durations.get(0);
-		}
+		Iterator<Duration> iterator = durations.iterator();
+		Duration cumulatedDur = iterator.next();
 
 		// TODO: Optimize this.
-		Duration cumulatedDur = durations.get(0);
-		for (int i = 1; i < durations.size(); ++i) {
-			cumulatedDur = cumulatedDur.add(durations.get(i));
+		while (iterator.hasNext()) {
+			cumulatedDur = cumulatedDur.add(iterator.next());
 		}
 
 		return cumulatedDur;

--- a/src/main/java/org/wmn4j/notation/elements/Durational.java
+++ b/src/main/java/org/wmn4j/notation/elements/Durational.java
@@ -9,12 +9,16 @@ package org.wmn4j.notation.elements;
 public interface Durational {
 
 	/**
-	 * @return <code>Duration</code> of this.
+	 * Returns the duration of this.
+	 *
+	 * @return the duration of this
 	 */
 	Duration getDuration();
 
 	/**
-	 * @return true if this is a rest, false otherwise.
+	 * Returns true if this is a rest, false otherwise.
+	 *
+	 * @return true if this is a rest, false otherwise
 	 */
 	boolean isRest();
 }

--- a/src/main/java/org/wmn4j/notation/elements/Durational.java
+++ b/src/main/java/org/wmn4j/notation/elements/Durational.java
@@ -1,13 +1,10 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
 
 /**
  * Interface for all the notation objects that have a duration.
- *
- * @author Otso Björklund
  */
 public interface Durational {
 

--- a/src/main/java/org/wmn4j/notation/elements/Durations.java
+++ b/src/main/java/org/wmn4j/notation/elements/Durations.java
@@ -4,7 +4,7 @@
 package org.wmn4j.notation.elements;
 
 /**
- * Collection of basic durations.
+ * Basic durations.
  */
 public final class Durations {
 	/**

--- a/src/main/java/org/wmn4j/notation/elements/Durations.java
+++ b/src/main/java/org/wmn4j/notation/elements/Durations.java
@@ -1,13 +1,10 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
 
 /**
  * Collection of basic durations.
- *
- * @author Otso Björklund
  */
 public final class Durations {
 	/**

--- a/src/main/java/org/wmn4j/notation/elements/Key.java
+++ b/src/main/java/org/wmn4j/notation/elements/Key.java
@@ -1,13 +1,10 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
 
 /**
  * Major and minor keys.
- *
- * @author Otso Björklund
  */
 public enum Key {
 	/**

--- a/src/main/java/org/wmn4j/notation/elements/KeySignature.java
+++ b/src/main/java/org/wmn4j/notation/elements/KeySignature.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Class for key signatures. This class is immutable.
+ * Represents a key signature. This class is immutable.
  */
 public class KeySignature {
 	private final List<Pitch.Base> sharps;
@@ -17,8 +17,8 @@ public class KeySignature {
 
 	/**
 	 * Constructor for KeySignature. For common key signatures use the ones defined
-	 * in <code>KeySignatures</code>. This is mostly intended for creating custom
-	 * key signatures.
+	 * in {@link KeySignatures}. This is mostly intended for creating custom key
+	 * signatures.
 	 *
 	 * @throws IllegalArgumentException if the same Pitch.Base is in both sharps and
 	 *                                  flats.
@@ -54,41 +54,41 @@ public class KeySignature {
 	}
 
 	/**
-	 * @return number of sharps in this KeySignature.
+	 * Returns the number of sharps in this key signature.
+	 *
+	 * @return the number of sharps in this key signature
 	 */
 	public int getNumberOfSharps() {
 		return this.sharps.size();
 	}
 
 	/**
-	 * @return number of flats in this KeySignature.
+	 * Returns the number of flats in this key signature.
+	 *
+	 * @return the number of flats in this key signature
 	 */
 	public int getNumberOfFlats() {
 		return this.flats.size();
 	}
 
 	/**
-	 * @return a copy of the sharps in this KeySignature.
+	 * Returns the sharps in this key signature.
+	 *
+	 * @return the sharps in this key signature.
 	 */
 	public List<Pitch.Base> getSharps() {
 		return new ArrayList<>(this.sharps);
 	}
 
 	/**
-	 * @return a copy of the flats in this KeySignature.
+	 * Returns the flats in this key signature.
+	 *
+	 * @return the flats in this key signature
 	 */
 	public List<Pitch.Base> getFlats() {
 		return new ArrayList<>(this.flats);
 	}
 
-	/**
-	 * String representation of <code>KeySignature</code>. String is of form:
-	 * <code>KeySig(sharps: ...)</code>, <code>KeySig(flats: ...)</code>, or
-	 * <code>KeySig(sharps: ... flats: ...)</code> where <code>...</code> refers to
-	 * the raised or flatted pitches.
-	 *
-	 * @return string representation of KeySignature.
-	 */
 	@Override
 	public String toString() {
 		final StringBuilder strBuilder = new StringBuilder();
@@ -115,7 +115,7 @@ public class KeySignature {
 	}
 
 	/**
-	 * Compare this to <code>Object o</code> for equality.
+	 * Returns true if this is equal to the given object.
 	 *
 	 * @param o Object against which this is compared for equality.
 	 * @return true if Object o is of class KeySignature and has the same sharps and

--- a/src/main/java/org/wmn4j/notation/elements/KeySignature.java
+++ b/src/main/java/org/wmn4j/notation/elements/KeySignature.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -11,8 +10,6 @@ import java.util.Objects;
 
 /**
  * Class for key signatures. This class is immutable.
- *
- * @author Otso Björklund
  */
 public class KeySignature {
 	private final List<Pitch.Base> sharps;

--- a/src/main/java/org/wmn4j/notation/elements/KeySignatures.java
+++ b/src/main/java/org/wmn4j/notation/elements/KeySignatures.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -8,8 +7,6 @@ import java.util.Arrays;
 
 /**
  * Collection of typical key signatures associated with major and minor keys.
- *
- * @author Otso Björklund
  */
 public final class KeySignatures {
 	/**

--- a/src/main/java/org/wmn4j/notation/elements/Measure.java
+++ b/src/main/java/org/wmn4j/notation/elements/Measure.java
@@ -14,9 +14,9 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 /**
- * Class that defines a measure. A measure may contain multiple voices that are
- * referred to using voice numbers. This class is immutable. Use the
- * MeasureBuilder class for easier creation of Measures.
+ * Represents a measure. A measure may contain multiple voices that are referred
+ * to using voice numbers. This class is immutable. Use the MeasureBuilder class
+ * for easier creation of Measures.
  */
 public class Measure implements Iterable<Durational> {
 
@@ -25,6 +25,8 @@ public class Measure implements Iterable<Durational> {
 	private final MeasureAttributes measureAttr;
 
 	/**
+	 * Constructor.
+	 *
 	 * @param number       number of the measure.
 	 * @param noteVoices   the notes on the different voices of the measure.
 	 * @param timeSig      TimeSignature of the measure.
@@ -38,6 +40,8 @@ public class Measure implements Iterable<Durational> {
 	}
 
 	/**
+	 * Constructor.
+	 *
 	 * @param number     number of the measure.
 	 * @param noteVoices the notes on the different voices of the measure.
 	 * @param timeSig    TimeSignature of the measure.
@@ -50,6 +54,8 @@ public class Measure implements Iterable<Durational> {
 	}
 
 	/**
+	 * Constructor.
+	 *
 	 * @param number      number of the measure.
 	 * @param noteVoices  the notes on the different voices of the measure.
 	 * @param measureAttr the attributes of the measure.
@@ -72,7 +78,7 @@ public class Measure implements Iterable<Durational> {
 	}
 
 	/**
-	 * Get the voice numbers in this measure. Voice numbers are not necessarily
+	 * Returns the voice numbers in this measure. Voice numbers are not necessarily
 	 * consecutive and do not begin from 0.
 	 *
 	 * @return list of the voice numbers used in this measure.
@@ -82,31 +88,38 @@ public class Measure implements Iterable<Durational> {
 	}
 
 	/**
-	 * Get a voiceNumber of the measure.
+	 * Returns the voice with the given measure.
 	 *
-	 * @param voiceNumber the number of the voice.
-	 * @return the voiceNumber at the given index voiceNumber.
+	 * @param voiceNumber the number of the voice
+	 * @return the voice at the given index voiceNumber
 	 */
 	public List<Durational> getVoice(int voiceNumber) {
 		return this.voices.get(voiceNumber);
 	}
 
 	/**
+	 * Returns the number of durational notation elements in the voice with the
+	 * given number.
+	 *
 	 * @param voiceNumber the voice for which the number of elements is returned
-	 * @return the number of elements on the voice with voiceNumber.
+	 * @return the number of elements in the voice with voiceNumber
 	 */
 	public int getVoiceSize(int voiceNumber) {
 		return this.voices.get(voiceNumber).size();
 	}
 
 	/**
-	 * @return number of voices in this measure.
+	 * Returns the number of voices in this measure.
+	 *
+	 * @return number of voices in this measure
 	 */
 	public int getVoiceCount() {
 		return this.voices.keySet().size();
 	}
 
 	/**
+	 * Returns true if this measure has only a single voice.
+	 *
 	 * @return true if this measure only has one voice, false otherwise.
 	 */
 	public boolean isSingleVoice() {
@@ -114,6 +127,8 @@ public class Measure implements Iterable<Durational> {
 	}
 
 	/**
+	 * Returns the measure number of this measure.
+	 *
 	 * @return the number of this measure.
 	 */
 	public int getNumber() {
@@ -121,20 +136,26 @@ public class Measure implements Iterable<Durational> {
 	}
 
 	/**
-	 * @return TimeSignature in effect in this measure.
+	 * Returns the time signature in effect in this measure.
+	 *
+	 * @return the time signature in effect in this measure
 	 */
 	public TimeSignature getTimeSignature() {
 		return this.measureAttr.getTimeSignature();
 	}
 
 	/**
-	 * @return KeySignature in effect in this measure.
+	 * Returns the key signature in effect in this measure.
+	 *
+	 * @return the key signature in effect in this measure
 	 */
 	public KeySignature getKeySignature() {
 		return this.measureAttr.getKeySignature();
 	}
 
 	/**
+	 * Returns the barline on the right side of this measure.
+	 *
 	 * @return right barline of this measure.
 	 */
 	public Barline getRightBarline() {
@@ -142,21 +163,28 @@ public class Measure implements Iterable<Durational> {
 	}
 
 	/**
-	 * @return left barline of this measure.
+	 * Returns the barline on the left side of this measure. For example, this can
+	 * be a barline that denotes the beginning of a repeat.
+	 *
+	 * @return left barline of this measure
 	 */
 	public Barline getLeftBarline() {
 		return this.measureAttr.getLeftBarline();
 	}
 
 	/**
-	 * @return The clef in effect in the beginning of this measure.
+	 * Returns the clef in effect in the beginning of this measure.
+	 *
+	 * @return the clef in effect in the beginning of this measure
 	 */
 	public Clef getClef() {
 		return this.measureAttr.getClef();
 	}
 
 	/**
-	 * @return a Map of clef changes in this measure, where the Duration key is the
+	 * Returns the clef changes in this measure.
+	 *
+	 * @return a map of clef changes in this measure, where the duration key is the
 	 *         offset counted from the beginning of the measure.
 	 */
 	public Map<Duration, Clef> getClefChanges() {
@@ -164,6 +192,8 @@ public class Measure implements Iterable<Durational> {
 	}
 
 	/**
+	 * Returns true if this measure contains clef changes.
+	 *
 	 * @return true if there are clef changes in this measure, false otherwise.
 	 */
 	public boolean containsClefChanges() {
@@ -171,19 +201,20 @@ public class Measure implements Iterable<Durational> {
 	}
 
 	/**
-	 * @return true if this <code>Measure</code> is a pickup measure.
+	 * Returns true if this measure is a pickup measure.
+	 *
+	 * @return true if this measure is a pickup measure.
 	 */
 	public boolean isPickUp() {
 		return this.getNumber() == 0;
 	}
 
 	/**
-	 * Returns the <code>Durational</code> at the given index on the given voice
-	 * number.
+	 * Returns the {@link Durational} at the given index on the given voice number.
 	 *
-	 * @param voiceNumber Number of the voice from which to get the element.
-	 * @param index       index of element on the voice.
-	 * @return <code>Durational</code> at the given index on the given voice.
+	 * @param voiceNumber the number of the voice from which to get the element
+	 * @param index       index of element on the voice
+	 * @return the {@link Durational} at the given index on the given voice
 	 * @throws NoSuchElementException if there is no voice with the given number of
 	 *                                if the index is out of range
 	 */
@@ -200,11 +231,6 @@ public class Measure implements Iterable<Durational> {
 		return voice.get(index);
 	}
 
-	/**
-	 * String representation of <code>Measure</code>. This is subject to change.
-	 *
-	 * @return string representation of measure.
-	 */
 	@Override
 	public String toString() {
 		final StringBuilder strBuilder = new StringBuilder();
@@ -224,28 +250,25 @@ public class Measure implements Iterable<Durational> {
 		return strBuilder.toString();
 	}
 
-	/**
-	 * @return iterator that goes through the Measure voice wise.
-	 */
 	@Override
 	public Iterator<Durational> iterator() {
 		return this.getMeasureIterator();
 	}
 
 	/**
-	 * Get an iterator as <code>Measure.Iter</code>.
+	 * Returns a measure iterator for this measure.
 	 *
-	 * @return an iterator of type <code>Measure.Iter</code>.
+	 * @return a measure iterator for this measure
 	 */
 	public Measure.Iter getMeasureIterator() {
 		return new Iter(this);
 	}
 
 	/**
-	 * Iterator for <code>Durational</code> objects in a <code>Measure</code>. The
-	 * iterator iterates through the notes in the Measure voice by voice going from
-	 * the earliest Durational in the voice to the last on each voice. The order of
-	 * voices is unspecified. The iterator does not support removing.
+	 * Iterator for {@link Durational} objects in a meusure. The iterator iterates
+	 * through the notes in the Measure voice by voice going from the earliest
+	 * durational in the voice to the last on each voice. The order of voices is
+	 * unspecified. The iterator does not support removing.
 	 */
 	public static class Iter implements Iterator<Durational> {
 		private final List<Integer> voiceNumbers;
@@ -266,18 +289,24 @@ public class Measure implements Iterable<Durational> {
 		}
 
 		/**
-		 * @return The voice of the <code>Durational</code> that was returned by the
-		 *         last call of {@link #next() next}. If next has not been called,
-		 *         return value is useless.
+		 * Returns the voice of the {@link Durational} that was returned by the last
+		 * call of {@link #next() next}.
+		 *
+		 * @return the voice of the {@link Durational} that was returned by the last
+		 *         call of {@link #next() next}. If next has not been called, return
+		 *         value is useless.
 		 */
 		public int getVoiceOfPrevious() {
 			return this.prevVoiceNumber;
 		}
 
 		/**
-		 * @return The index of the <code>Durational</code> that was returned by the
-		 *         last call of {@link #next() next}. If next has not been called,
-		 *         return value is useless.
+		 * Returns the index of the {@link Durational} that was returned by the last
+		 * call of {@link #next() next}.
+		 *
+		 * @return the index of the {@link Durational} that was returned by the last
+		 *         call of {@link #next() next}. If next has not been called, return
+		 *         value is useless.
 		 */
 		public int getIndexOfPrevious() {
 			return this.prevPositionInVoice;

--- a/src/main/java/org/wmn4j/notation/elements/Measure.java
+++ b/src/main/java/org/wmn4j/notation/elements/Measure.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -18,8 +17,6 @@ import java.util.TreeMap;
  * Class that defines a measure. A measure may contain multiple voices that are
  * referred to using voice numbers. This class is immutable. Use the
  * MeasureBuilder class for easier creation of Measures.
- *
- * @author Otso Björklund
  */
 public class Measure implements Iterable<Durational> {
 

--- a/src/main/java/org/wmn4j/notation/elements/MeasureAttributes.java
+++ b/src/main/java/org/wmn4j/notation/elements/MeasureAttributes.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -12,8 +11,6 @@ import java.util.Objects;
 /**
  * Class containing the attributes of measures that typically remain unchanged
  * from one measure to the next.
- *
- * @author Otso Björklund
  */
 public final class MeasureAttributes {
 

--- a/src/main/java/org/wmn4j/notation/elements/MeasureAttributes.java
+++ b/src/main/java/org/wmn4j/notation/elements/MeasureAttributes.java
@@ -9,8 +9,8 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Class containing the attributes of measures that typically remain unchanged
- * from one measure to the next.
+ * Represents the attributes of a measure that are often implicit in the
+ * measure, such as clef in effect, time signature, key signature and so on.
  */
 public final class MeasureAttributes {
 
@@ -22,50 +22,53 @@ public final class MeasureAttributes {
 	private final Map<Duration, Clef> clefChanges;
 
 	/**
-	 * Returns a MeasureAttributes instance with the given values. The left barline
-	 * type will be set to none.
+	 * Returns an instance with the given values. The left barline type will be set
+	 * to none.
 	 *
-	 * @param timeSig      the time signature
-	 * @param keySig       the key signature
-	 * @param rightBarline the type of the right barline
-	 * @param clef         the clef in effect at the beginning of the measure
-	 * @return a MeasureAttributes instance with the given values
+	 * @param timeSignature the time signature
+	 * @param keySignature  the key signature
+	 * @param rightBarline  the type of the right barline
+	 * @param clef          the clef in effect at the beginning of the measure
+	 * @return an instance with the given values
 	 */
-	public static MeasureAttributes getMeasureAttr(TimeSignature timeSig, KeySignature keySig, Barline rightBarline,
+	public static MeasureAttributes getMeasureAttr(TimeSignature timeSignature, KeySignature keySignature,
+			Barline rightBarline,
 			Clef clef) {
-		return getMeasureAttr(timeSig, keySig, rightBarline, Barline.NONE, clef);
+		return getMeasureAttr(timeSignature, keySignature, rightBarline, Barline.NONE, clef);
 	}
 
 	/**
-	 * Returns a MeasureAttributes instance with the given values.
+	 * Returns an instance with the given values.
 	 *
-	 * @param timeSig      the time signature
-	 * @param keySig       the key signature
-	 * @param rightBarline the type of the right barline
-	 * @param leftBarline  the type of the left barline
-	 * @param clef         the clef in effect at the beginning of the measure
-	 * @return a MeasureAttributes instance with the given values
+	 * @param timeSignature the time signature
+	 * @param keySignature  the key signature
+	 * @param rightBarline  the type of the right barline
+	 * @param leftBarline   the type of the left barline
+	 * @param clef          the clef in effect at the beginning of the measure
+	 * @return an instance with the given values
 	 */
-	public static MeasureAttributes getMeasureAttr(TimeSignature timeSig, KeySignature keySig, Barline rightBarline,
+	public static MeasureAttributes getMeasureAttr(TimeSignature timeSignature, KeySignature keySignature,
+			Barline rightBarline,
 			Barline leftBarline, Clef clef) {
-		return getMeasureAttr(timeSig, keySig, rightBarline, leftBarline, clef, null);
+		return getMeasureAttr(timeSignature, keySignature, rightBarline, leftBarline, clef, null);
 	}
 
 	/**
-	 * Returns a MeasureAttributes instance with the given values.
+	 * Returns an instance with the given values.
 	 *
-	 * @param timeSig      the time signature
-	 * @param keySig       the key signature
-	 * @param rightBarline the type of the right barline
-	 * @param leftBarline  the type of the left barline
-	 * @param clef         the clef in effect at the beginning of the measure
-	 * @param clefChanges  the clef changes within the measure
-	 * @return a MeasureAttributes instance with the given values
+	 * @param timeSignature the time signature
+	 * @param keySignature  the key signature
+	 * @param rightBarline  the type of the right barline
+	 * @param leftBarline   the type of the left barline
+	 * @param clef          the clef in effect at the beginning of the measure
+	 * @param clefChanges   the clef changes within the measure
+	 * @return an instance with the given values
 	 */
-	public static MeasureAttributes getMeasureAttr(TimeSignature timeSig, KeySignature keySig, Barline rightBarline,
+	public static MeasureAttributes getMeasureAttr(TimeSignature timeSignature, KeySignature keySignature,
+			Barline rightBarline,
 			Barline leftBarline, Clef clef, Map<Duration, Clef> clefChanges) {
 		// TODO: Potentially use interner pattern or similar for caching.
-		return new MeasureAttributes(timeSig, keySig, rightBarline, leftBarline, clef, clefChanges);
+		return new MeasureAttributes(timeSignature, keySignature, rightBarline, leftBarline, clef, clefChanges);
 	}
 
 	private MeasureAttributes(TimeSignature timeSig, KeySignature keySig, Barline rightBarline, Barline leftBarline,
@@ -84,36 +87,36 @@ public final class MeasureAttributes {
 	}
 
 	/**
-	 * Returns the time signature specified in the attributes.
+	 * Returns the time signature specified in these attributes.
 	 *
-	 * @return the time signature specified in the attributes
+	 * @return the time signature specified in these attributes
 	 */
 	public TimeSignature getTimeSignature() {
 		return this.timeSig;
 	}
 
 	/**
-	 * Returns the key signature specified in the attributes.
+	 * Returns the key signature specified in these attributes.
 	 *
-	 * @return the key signature specified in the attributes
+	 * @return the key signature specified in these attributes
 	 */
 	public KeySignature getKeySignature() {
 		return this.keySig;
 	}
 
 	/**
-	 * Returns the type of the right barline specified in the attributes.
+	 * Returns the type of the right barline specified in these attributes.
 	 *
-	 * @return the type of the right barline specified in the attributes
+	 * @return the type of the right barline specified in these attributes
 	 */
 	public Barline getRightBarline() {
 		return this.rightBarline;
 	}
 
 	/**
-	 * Returns the type of the left barline specified in the attributes.
+	 * Returns the type of the left barline specified in these attributes.
 	 *
-	 * @return the type of the left barline specified in the attributes
+	 * @return the type of the left barline specified in these attributes
 	 */
 	public Barline getLeftBarline() {
 		return this.leftBarline;

--- a/src/main/java/org/wmn4j/notation/elements/MultiNoteArticulation.java
+++ b/src/main/java/org/wmn4j/notation/elements/MultiNoteArticulation.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -7,8 +6,6 @@ package org.wmn4j.notation.elements;
 /**
  * Class that represents markings that span across multiple notes, such as slurs
  * and glissando. Is immutable.
- *
- * @author Otso Björklund
  */
 public class MultiNoteArticulation {
 
@@ -16,15 +13,15 @@ public class MultiNoteArticulation {
 	 * The type of the articulation.
 	 */
 	public enum Type {
-	/**
-	 * Specifies a slur.
-	 */
-	SLUR,
+		/**
+		 * Specifies a slur.
+		 */
+		SLUR,
 
-	/**
-	 * Specifies a glissando marking.
-	 */
-	GLISSANDO
+		/**
+		 * Specifies a glissando marking.
+		 */
+		GLISSANDO
 	}
 
 	private final Type type;

--- a/src/main/java/org/wmn4j/notation/elements/MultiStaffPart.java
+++ b/src/main/java/org/wmn4j/notation/elements/MultiStaffPart.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -17,8 +16,6 @@ import java.util.TreeMap;
 /**
  * Class for parts that have multiple staves such as keyboard instruments. This
  * class is immutable.
- *
- * @author Otso Björklund
  */
 public class MultiStaffPart implements Part {
 

--- a/src/main/java/org/wmn4j/notation/elements/MultiStaffPart.java
+++ b/src/main/java/org/wmn4j/notation/elements/MultiStaffPart.java
@@ -14,8 +14,8 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 /**
- * Class for parts that have multiple staves such as keyboard instruments. This
- * class is immutable.
+ * Represents a score part with multiple staves such as are often used with
+ * keyboard instruments. This class is immutable.
  */
 public class MultiStaffPart implements Part {
 
@@ -73,17 +73,19 @@ public class MultiStaffPart implements Part {
 	}
 
 	/**
-	 * Returns the <code>Staff</code> with the number.
+	 * Returns the {@link Staff} with the given number in this part.
 	 *
-	 * @param number number of staff.
-	 * @return <code>Staff</code> associated with the number.
+	 * @param number number of staff
+	 * @return the staff associated with the number
 	 */
 	public Staff getStaff(int number) {
 		return this.staves.get(number);
 	}
 
 	/**
-	 * @return the numbers of the staves in the part.
+	 * Returns the numbers in this part that are used to denote the staves.
+	 *
+	 * @return the staff numbers in this part
 	 */
 	public List<Integer> getStaffNumbers() {
 		return new ArrayList<>(this.staves.keySet());
@@ -130,10 +132,10 @@ public class MultiStaffPart implements Part {
 	}
 
 	/**
-	 * Iterator for <code>MultiStaffPart</code> Iterates through the measures by
-	 * going through all staves for a certain measure number before going on to the
-	 * next measure. Staves are iterated through from smallest staff number to
-	 * greatest. Does not support removing.
+	 * Iterator for {@link MultiStaffPart}. Iterates through the measures by going
+	 * through all staves for a certain measure number before going on to the next
+	 * measure. Staves are iterated through from smallest staff number to greatest.
+	 * Does not support removing.
 	 */
 	public static class Iter implements Part.Iter {
 		private final MultiStaffPart part;

--- a/src/main/java/org/wmn4j/notation/elements/Note.java
+++ b/src/main/java/org/wmn4j/notation/elements/Note.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -18,8 +17,6 @@ import java.util.Set;
  * objects. Notes have pitch, duration, articulations, and can be tied. A
  * sequence of tied notes functions like a singly linked list where a previous
  * note keeps track of the following tied note.
- *
- * @author otsobjorklund
  */
 public final class Note implements Durational, Pitched {
 

--- a/src/main/java/org/wmn4j/notation/elements/Note.java
+++ b/src/main/java/org/wmn4j/notation/elements/Note.java
@@ -12,11 +12,10 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * Class that defines a note. This class is immutable. The
- * <code>NoteBuilder</code> class can be used for creating <code>Note</code>
- * objects. Notes have pitch, duration, articulations, and can be tied. A
- * sequence of tied notes functions like a singly linked list where a previous
- * note keeps track of the following tied note.
+ * Represents a note. This class is immutable. Notes have pitch, duration,
+ * articulations, and can be tied. A sequence of tied notes functions like a
+ * singly linked list where a previous note keeps track of the following tied
+ * note.
  */
 public final class Note implements Durational, Pitched {
 
@@ -29,52 +28,50 @@ public final class Note implements Durational, Pitched {
 	private final boolean isTiedFrom;
 
 	/**
-	 * Get a <code>Note</code> object with specified parameters.
+	 * Returns an instance with the given parameters.
 	 *
-	 * @param pitchName the letter in the pitch name.
+	 * @param pitchName the letter part of the pitch name
 	 * @param alter     how many half-steps the pitch is altered up (positive) or
-	 *                  down (negative).
-	 * @param octave    octave number of the pitch.
-	 * @param duration  the duration of the note. Must not be null.
-	 * @return a Note object with the given parameters.
+	 *                  down (negative)
+	 * @param octave    octave number of the pitch
+	 * @param duration  the duration of the note. Must not be null
+	 * @return an instance with the given parameters
 	 */
 	public static Note getNote(Pitch.Base pitchName, int alter, int octave, Duration duration) {
 		return getNote(Pitch.getPitch(pitchName, alter, octave), duration, null);
 	}
 
 	/**
-	 * Get a <code>Note</code> object with specified parameters.
+	 * Returns an instance with the given parameters.
 	 *
-	 * @param pitch    the pitch of the note. Must not be null.
-	 * @param duration the duration of the note. Must not be null.
-	 * @return a Note object with the given parameters.
+	 * @param pitch    the pitch of the note
+	 * @param duration the duration of the note
+	 * @return an instance with the given parameters
 	 */
 	public static Note getNote(Pitch pitch, Duration duration) {
 		return getNote(pitch, duration, null);
 	}
 
 	/**
-	 * Get a <code>Note</code> object with specified parameters.
+	 * Returns an instance with the given parameters.
 	 *
-	 * @param pitch         the pitch of the note. Must not be null.
-	 * @param duration      the duration of the note. Must not be null.
-	 * @param articulations a set of Articulations associated with the note.
-	 * @return a Note object with the given parameters.
+	 * @param pitch         the pitch of the note
+	 * @param duration      the duration of the note
+	 * @param articulations a set of Articulations associated with the note
+	 * @return an instance with the given parameters
 	 */
 	public static Note getNote(Pitch pitch, Duration duration, Set<Articulation> articulations) {
 		return new Note(pitch, duration, articulations, null, null, false);
 	}
 
 	/**
-	 * Get a <code>Note</code> object with specified parameters.
+	 * Returns an instance with the given parameters.
 	 *
-	 * @param pitch                  the pitch of the note. Must not be null.
-	 * @param duration               the duration of the note. Must not be null.
-	 * @param articulations          a set of Articulations associated with the
-	 *                               note.
-	 * @param multiNoteArticulations list of the MultiNoteArticulations for the
-	 *                               note.
-	 * @return a Note object with the given parameters.
+	 * @param pitch                  the pitch of the note
+	 * @param duration               the duration of the note
+	 * @param articulations          a set of Articulations associated with the note
+	 * @param multiNoteArticulations list of the MultiNoteArticulations for the note
+	 * @return an instance with the given parameters
 	 */
 	public static Note getNote(Pitch pitch, Duration duration, Set<Articulation> articulations,
 			List<MultiNoteArticulation> multiNoteArticulations) {
@@ -82,17 +79,15 @@ public final class Note implements Durational, Pitched {
 	}
 
 	/**
-	 * Get a <code>Note</code> object with specified parameters.
+	 * Returns an instance with the given parameters.
 	 *
-	 * @param pitch                  the pitch of the note. Must not be null.
-	 * @param duration               the duration of the note. Must not be null.
-	 * @param articulations          a set of Articulations associated with the
-	 *                               note.
-	 * @param multiNoteArticulations list of the MultiNoteArticulations for the
-	 *                               note.
-	 * @param tiedTo                 A tie from a previous note that ends in this.
-	 * @param isTiedFromPrevious     A tie that originates from this note.
-	 * @return a Note object with the given parameters.
+	 * @param pitch                  the pitch of the note
+	 * @param duration               the duration of the note
+	 * @param articulations          a set of Articulations associated with the note
+	 * @param multiNoteArticulations list of the MultiNoteArticulations for the note
+	 * @param tiedTo                 the following note to which this is tied
+	 * @param isTiedFromPrevious     true if this is tied from the previous note
+	 * @return an instance with the given parameters
 	 */
 	public static Note getNote(Pitch pitch, Duration duration, Set<Articulation> articulations,
 			List<MultiNoteArticulation> multiNoteArticulations, Note tiedTo, boolean isTiedFromPrevious) {
@@ -100,13 +95,7 @@ public final class Note implements Durational, Pitched {
 	}
 
 	/**
-	 * Private constructor. Use the static <code>getNote</code> methods or
-	 * <code>NoteBuilder</code> to get an instance.
-	 *
-	 * @throws NullPointerException if duration or pitch is null.
-	 * @param pitch         the pitch of the note.
-	 * @param duration      the duration of the note.
-	 * @param articulations a set of Articulations associated with the note.
+	 * Private constructor.
 	 */
 	private Note(Pitch pitch, Duration duration, Set<Articulation> articulations,
 			List<MultiNoteArticulation> multiNoteArticulations, Note tiedTo, boolean isTiedFromPrevious) {
@@ -130,9 +119,9 @@ public final class Note implements Durational, Pitched {
 	}
 
 	/**
-	 * Get the <code>Pitch</code> of this <code>Note</code>.
+	 * Returns the pitch of this note.
 	 *
-	 * @return the Pitch of this Note.
+	 * @return the pitch of this note
 	 */
 	@Override
 	public Pitch getPitch() {
@@ -140,97 +129,104 @@ public final class Note implements Durational, Pitched {
 	}
 
 	/**
-	 * Get the <code>Duration</code> of this <code>Note</code>.
+	 * Returns the duration of this note.
 	 *
-	 * @return the Duration of this Note.
+	 * @return the duration of this note
 	 */
 	@Override
 	public Duration getDuration() {
 		return this.duration;
 	}
 
-	/**
-	 * @return false.
-	 */
 	@Override
 	public boolean isRest() {
 		return false;
 	}
 
 	/**
-	 * Get the articulations of this <code>Note</code> as a <code>Set</code>.
+	 * Returns the articulations defined for this note.
 	 *
-	 * @return the articulations of this <code>Note</code>.
+	 * @return the articulations defined for this note
 	 */
 	public Set<Articulation> getArticulations() {
 		return this.articulations;
 	}
 
 	/**
-	 * Check if this <code>Note</code> has any articulations.
+	 * Returns true if this note has articulations that only affect this note, such
+	 * as staccato or tenuto.
 	 *
-	 * @return true if this Note has any articulations, otherwise false.
+	 * @return true if this note has articulations
 	 */
 	public boolean hasArticulations() {
 		return !this.articulations.isEmpty();
 	}
 
 	/**
-	 * Check if this <code>Note</code> has a particular articulation.
+	 * Returns true if this note has the given articulation.
 	 *
-	 * @param articulation the articulation whose presence is checked.
-	 * @return true if this Note has the given articulation, otherwise false.
+	 * @param articulation the articulation whose presence is checked
+	 * @return true if this note has the given articulation
 	 */
 	public boolean hasArticulation(Articulation articulation) {
 		return this.articulations.contains(articulation);
 	}
 
 	/**
-	 * @return The <code>MultiNoteArticulation</code> objects of this
-	 *         <code>Note</code>.
+	 * Returns the multinote articulations defined for this note. These are
+	 * articulations such as slurs or glissando.
+	 *
+	 * @return the multinote articulations defined for this note
 	 */
 	public List<MultiNoteArticulation> getMultiNoteArticulations() {
 		return this.multiNoteArticulations;
 	}
 
 	/**
-	 * @return true if this <code>Note</code> has any
-	 *         <code>MultiNoteArticulations</code>, false otherwise.
+	 * Returns true if this note is affected by any multinote articulations.
+	 *
+	 * @return true if this note is affected by any multinote articulations
 	 */
 	public boolean hasMultiNoteArticulations() {
 		return !this.multiNoteArticulations.isEmpty();
 	}
 
 	/**
-	 * @return True if this note is tied to a following note. False otherwise.
+	 * Returns true if this note is tied to a following note.
+	 *
+	 * @return true if this note is tied to a following note
 	 */
 	public boolean isTiedToFollowing() {
 		return this.tiedTo != null;
 	}
 
 	/**
-	 * @return True if this note is the end of a tie originating from a previous
-	 *         note. False otherwise.
+	 * Returns true if this note is tied to a previous note.
+	 *
+	 * @return true if this note is tied to a previous note
 	 */
 	public boolean isTiedFromPrevious() {
 		return this.isTiedFrom;
 	}
 
 	/**
-	 * @return True if there are any ties attached to this note. False otherwise.
+	 * Returns true if this note is tied to a previous or to a following note.
+	 *
+	 * @return true if this note is tied to a previous or to a following note
 	 */
 	public boolean isTied() {
 		return this.isTiedFromPrevious() || this.isTiedToFollowing();
 	}
 
 	/**
-	 * Get the total duration of tied notes starting from the onset of this note.
+	 * Returns the total duration of tied notes starting from the onset of this
+	 * note.
+	 *
 	 * For example, if three quarter notes are tied together, then the tied duration
 	 * of the first note is a dotted half note. For a note that is not tied to a
 	 * following note this is equal to the note's duration.
 	 *
-	 * @return The total duration of consecutive tied notes starting from the onset
-	 *         of this <code>Note</code>.
+	 * @return the total duration of tied notes starting from the onset of this note
 	 */
 	public Duration getTiedDuration() {
 		final List<Duration> tiedDurations = new ArrayList<>();
@@ -245,18 +241,20 @@ public final class Note implements Durational, Pitched {
 	}
 
 	/**
-	 * @return The following <code>Note</code> that this is tied to wrapped in an
-	 *         <code>Optional</code>. Returns empty <code>Optional</code> if this
-	 *         note is not tied to a following note.
+	 * Returns the following note to which this note is tied. If this note is not
+	 * tied to a following note, then returns empty.
+	 *
+	 * @return the following note to which this note is tied
 	 */
 	public Optional<Note> getFollowingTiedNote() {
 		return Optional.ofNullable(this.tiedTo);
 	}
 
 	/**
-	 * Compare notes by pitch.
+	 * Returns an integer that specifies if this note is higher than, lower than, or
+	 * equal in pitch to the given note.
 	 *
-	 * @param other the note to which this is compared
+	 * @param other the note to which this is compared for pitch
 	 * @return negative integer if this note is lower than other, positive integer
 	 *         if this is higher than other, 0 if notes are (enharmonically) of same
 	 *         height.
@@ -265,11 +263,6 @@ public final class Note implements Durational, Pitched {
 		return this.pitch.compareTo(other.getPitch());
 	}
 
-	/**
-	 * Returns a string representation of this <code>Note</code>.
-	 *
-	 * @return string representation of this Note.
-	 */
 	@Override
 	public String toString() {
 		final StringBuilder strBuilder = new StringBuilder();
@@ -300,23 +293,22 @@ public final class Note implements Durational, Pitched {
 	}
 
 	/**
-	 * Compare this to other <code>Note</code> for equality of pitch and duration.
+	 * Returns true if this note is equal to the given note in pitch and duration.
 	 *
-	 * @param other Note with which this is compared.
-	 * @return True if pitch and duration are equal, false otherwise.
+	 * @param other note with which this is compared for pitch and duration equality
+	 * @return true if this note is equal to the given note in pitch and duration
 	 */
 	public boolean equalsInPitchAndDuration(Note other) {
 		return this.pitch.equals(other.pitch) && this.duration.equals(other.duration);
 	}
 
 	/**
-	 * Check this <code>Note</code> for equality against <code>Object o</code>.
-	 * Notes are equal if they have the same Pitch, Duration, and set of
-	 * Articulations.
+	 * Returns true if this note is equal to the given object. Notes are equal if
+	 * they have the same pitch, duration, and set of articulations.
 	 *
-	 * @param o the Object against which this Note is compared for equality.
+	 * @param o the Object with which this Note is compared for equality
 	 * @return true if Object o is of class Note and has the same Pitch, Duration,
-	 *         and Articulations as this Node. false otherwise.
+	 *         and Articulations as this Node. false otherwise
 	 */
 	@Override
 	public boolean equals(Object o) {

--- a/src/main/java/org/wmn4j/notation/elements/Part.java
+++ b/src/main/java/org/wmn4j/notation/elements/Part.java
@@ -7,44 +7,52 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 /**
- * Interface for parts in a score. The class <code>PartBuilder</code> can be
- * used for constructing <code>Part</code> objects.
+ * Represents a part in a score.
  */
 public interface Part extends Iterable<Measure> {
 
 	/**
-	 * Attribute types that a <code>Part</code> can have.
+	 * Attribute types that a part can have.
 	 */
 	enum Attribute {
 		NAME, ABBREVIATED_NAME
 	};
 
 	/**
-	 * @return name of this <code>Part</code>.
+	 * Returns the name of this part.
+	 *
+	 * @return name of this part
 	 */
 	String getName();
 
 	/**
-	 * @return true if this <code>Part</code> has multiple staves. False otherwise.
+	 * Returns true if this part has multiple staves.
+	 *
+	 * @return true if this part has multiple staves
 	 */
 	boolean isMultiStaff();
 
 	/**
-	 * @return number of staves in this part.
+	 * Returns the number of staves in this part.
+	 *
+	 * @return number of staves in this part
 	 */
 	int getStaffCount();
 
 	/**
-	 * @param attribute the Attribute to get from this <code>Part</code>.
-	 * @return the String associated with the attribute, or an empty string if the
-	 *         attribute is not set.
+	 * Returns the given attribute. If the attribute is not present, returns an
+	 * empty string.
+	 *
+	 * @param attribute the attribute to return from this part
+	 * @return the value of the attribute, or an empty string if the attribute is
+	 *         not set
 	 */
 	String getPartAttribute(Attribute attribute);
 
 	/**
-	 * Get the number of measures in the part. The count is based on the measure
-	 * numbers, so even if a part has multiple staves its measure count is the
-	 * largest measure number.
+	 * Returns the number of measures in this part. The count is based on the
+	 * measure numbers, so even if a part has multiple staves its measure count is
+	 * the largest measure number.
 	 *
 	 * @return number of measures in the part. If there is a pickup measure, it is
 	 *         included in the count.
@@ -52,17 +60,18 @@ public interface Part extends Iterable<Measure> {
 	int getMeasureCount();
 
 	/**
-	 * Get the number of complete measures.
+	 * Returns the the number of complete measures. Does not include the measure
+	 * number if there is one.
 	 *
-	 * @return the number of measures excluding the pickup measure.
+	 * @return the number of measures excluding the pickup measure
 	 */
 	int getFullMeasureCount();
 
 	/**
-	 * Returns the measure with the staff and measure number.
+	 * Returns the measure with the given number from the staff with the given
+	 * number.
 	 *
-	 * @param staffNumber   Number of staff. Is not used when accessing a single
-	 *                      staff part.
+	 * @param staffNumber   the number of the staff from which the get the measure
 	 * @param measureNumber the number of the measure
 	 * @return the measure with measureNumber from the staff with staffNumber
 	 * @throws NoSuchElementException if there is no staff of measure with the given
@@ -71,7 +80,11 @@ public interface Part extends Iterable<Measure> {
 	Measure getMeasure(int staffNumber, int measureNumber) throws NoSuchElementException;
 
 	/**
-	 * @return An iterator that implements the Part.Iter interface.
+	 * Returns a part iterator that can be used to iterate through the measures in
+	 * this part.
+	 *
+	 * @return an iterator that can be used to iterate through the measures in this
+	 *         part
 	 */
 	Part.Iter getPartIterator();
 
@@ -81,14 +94,18 @@ public interface Part extends Iterable<Measure> {
 	public interface Iter extends Iterator<Measure> {
 
 		/**
-		 * @return The number of the <code>Staff</code> from which the
-		 *         <code>Measure</code> on the previous call of next was returned.
+		 * Returns the staff number of the measure that was returned on the previous
+		 * call of next.
+		 *
+		 * @return the staff number of the previous measure
 		 */
 		int getStaffNumberOfPrevious();
 
 		/**
-		 * @return The number of the <code>Measure</code> that was returned by the
-		 *         previous call of next.
+		 * Returns the measure number of the measure that was returned on the previous
+		 * call of next.
+		 *
+		 * @return the measure number of the previous measure
 		 */
 		int getMeasureNumberOfPrevious();
 	}

--- a/src/main/java/org/wmn4j/notation/elements/Part.java
+++ b/src/main/java/org/wmn4j/notation/elements/Part.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -10,8 +9,6 @@ import java.util.NoSuchElementException;
 /**
  * Interface for parts in a score. The class <code>PartBuilder</code> can be
  * used for constructing <code>Part</code> objects.
- *
- * @author Otso Björklund
  */
 public interface Part extends Iterable<Measure> {
 
@@ -19,7 +16,7 @@ public interface Part extends Iterable<Measure> {
 	 * Attribute types that a <code>Part</code> can have.
 	 */
 	enum Attribute {
-	NAME, ABBREVIATED_NAME
+		NAME, ABBREVIATED_NAME
 	};
 
 	/**

--- a/src/main/java/org/wmn4j/notation/elements/Pitch.java
+++ b/src/main/java/org/wmn4j/notation/elements/Pitch.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -20,40 +19,40 @@ public final class Pitch implements Comparable<Pitch> {
 	 * The letter in a pitch name.
 	 */
 	public enum Base {
-	/**
-	 * The base letter C in the pitch name.
-	 */
-	C(0),
+		/**
+		 * The base letter C in the pitch name.
+		 */
+		C(0),
 
-	/**
-	 * The base letter D in the pitch name.
-	 */
-	D(2),
+		/**
+		 * The base letter D in the pitch name.
+		 */
+		D(2),
 
-	/**
-	 * The base letter E in the pitch name.
-	 */
-	E(4),
+		/**
+		 * The base letter E in the pitch name.
+		 */
+		E(4),
 
-	/**
-	 * The base letter F in the pitch name.
-	 */
-	F(5),
+		/**
+		 * The base letter F in the pitch name.
+		 */
+		F(5),
 
-	/**
-	 * The base letter G in the pitch name.
-	 */
-	G(7),
+		/**
+		 * The base letter G in the pitch name.
+		 */
+		G(7),
 
-	/**
-	 * The base letter A in the pitch name.
-	 */
-	A(9),
+		/**
+		 * The base letter A in the pitch name.
+		 */
+		A(9),
 
-	/**
-	 * The base letter B in the pitch name.
-	 */
-	B(11);
+		/**
+		 * The base letter B in the pitch name.
+		 */
+		B(11);
 
 		private final int pitchAsInt;
 

--- a/src/main/java/org/wmn4j/notation/elements/Pitch.java
+++ b/src/main/java/org/wmn4j/notation/elements/Pitch.java
@@ -6,10 +6,10 @@ package org.wmn4j.notation.elements;
 import java.util.Objects;
 
 /**
- * The <code>Pitch</code> class represents a pitch. Pitches consist of the basic
- * pitch letter <code>Pitch.Base</code>, alter number which tells by how many
- * half-steps the pitch is altered, and octave number which tells the octave of
- * the note. Octave number is based on
+ * Represents a pitch. Pitches consist of the basic pitch letter
+ * {@link Pitch.Base}, alter number which tells by how many half-steps the pitch
+ * is altered, and octave number which tells the octave of the note. Octave
+ * number is based on
  * <a href="http://en.wikipedia.org/wiki/Scientific_pitch_notation">scientific
  * pitch notation</a>. This class is immutable.
  */
@@ -65,6 +65,7 @@ public final class Pitch implements Comparable<Pitch> {
 	 * The limit for altering notes in half-steps (=3).
 	 */
 	public static final int ALTER_LIMIT = 3;
+
 	/**
 	 * Highest allowed octave number (=10).
 	 */
@@ -75,18 +76,18 @@ public final class Pitch implements Comparable<Pitch> {
 	private final int octave;
 
 	/**
-	 * Returns a <code>Pitch</code> object.
+	 * Returns an instance.
 	 *
 	 * @throws IllegalArgumentException if alter is greater than {@link #ALTER_LIMIT
 	 *                                  ALTER_LIMIT} of smaller than
 	 *                                  {@link #ALTER_LIMIT -1*ALTER_LIMIT}, or if
 	 *                                  octave is negative or larger than
 	 *                                  {@link #MAX_OCTAVE MAX_OCTAVE}.
-	 * @param pitchName the letter on which the name of the pitch is based.
+	 * @param pitchName the letter on which the name of the pitch is based
 	 * @param alter     by how many half-steps the pitch is altered up (positive
-	 *                  values) or down (negative values).
-	 * @param octave    the octave of the pitch.
-	 * @return Pitch object with the specified attributes.
+	 *                  values) or down (negative values)
+	 * @param octave    the octave of the pitch
+	 * @return Pitch object with the specified attributes
 	 */
 	public static Pitch getPitch(Base pitchName, int alter, int octave) {
 		if (alter > ALTER_LIMIT || alter < -1 * ALTER_LIMIT) {
@@ -98,12 +99,11 @@ public final class Pitch implements Comparable<Pitch> {
 			throw new IllegalArgumentException("octave was " + octave + ". octave must be between 0 and " + MAX_OCTAVE);
 		}
 
-		return new Pitch(pitchName, alter, octave);
+		return new Pitch(Objects.requireNonNull(pitchName), alter, octave);
 	}
 
 	/**
-	 * Private constructor. To get a <code>Pitch</code> object use the method
-	 * {@link #getPitch(wmnlibnotation.Pitch.Base, int, int) getPitch}.
+	 * Private constructor.
 	 *
 	 * @param pitchName the letter on which the name of the pitch is based.
 	 * @param alter     by how many half-steps the pitch is altered up or down.
@@ -116,41 +116,40 @@ public final class Pitch implements Comparable<Pitch> {
 	}
 
 	/**
-	 * Returns the letter in the pitch name.
+	 * Returns the letter in the name of this pitch.
 	 *
-	 * @return the letter on which the name of the pitch is based.
+	 * @return the letter on which the name of the pitch is based
 	 */
 	public Base getBase() {
 		return this.pitchBase;
 	}
 
 	/**
-	 * Returns by how many half-steps the pitch is altered.
+	 * Returns by how many half-steps this pitch is altered.
 	 *
 	 * @return by how many half-steps the pitch is altered up (positive value) or
-	 *         down (negative value).
+	 *         down (negative value)
 	 */
 	public int getAlter() {
 		return this.alter;
 	}
 
 	/**
-	 * Returns the octave number.
+	 * Returns the octave number of this pitch.
 	 *
-	 * @return octave number of this pitch.
+	 * @return octave number of this pitch
 	 */
 	public int getOctave() {
 		return this.octave;
 	}
 
 	/**
-	 * Get an integer representation of this <code>Pitch</code>. This is the MIDI
-	 * number of the pitch (middle-C, C4, being 60). A <code>Pitch</code> is
-	 * transformed into an integer using the formula
-	 * <code> pitchAsInteger = base + alter + (octave + 1) * 12 </code>, where base
-	 * is defined by the letter in the pitch name: C = 0, D = 2, E = 4, F = 5, G =
-	 * 7, A = 9, B = 11. Alter is the number of sharps, or the number of flats * -1.
-	 * For example, <code>C#4 = 0 + 1 + 5 * 12 = 61</code> and
+	 * Get an integer representation of this pitch. This is the MIDI number of the
+	 * pitch (middle-C, C4, being 60). A pitch is transformed into an integer using
+	 * the formula <code> pitchAsInteger = base + alter + (octave + 1) * 12 </code>,
+	 * where base is defined by the letter in the pitch name: C = 0, D = 2, E = 4, F
+	 * = 5, G = 7, A = 9, B = 11. Alter is the number of sharps, or the number of
+	 * flats * -1. For example, <code>C#4 = 0 + 1 + 5 * 12 = 61</code> and
 	 * <code>Db4 = 2 - 1 + 5 * 12 = 61</code>.
 	 *
 	 * @return this Pitch as an integer.
@@ -160,10 +159,10 @@ public final class Pitch implements Comparable<Pitch> {
 	}
 
 	/**
-	 * Returns the PitchClass of this Pitch.
+	 * Returns the <a href="http://en.wikipedia.org/wiki/Pitch_class">pitch
+	 * class</a> of this pitch.
 	 *
-	 * @return the <a href="http://en.wikipedia.org/wiki/Pitch_class">pitch
-	 *         class</a> of this Pitch.
+	 * @return the pitch class of this pitch
 	 */
 	public PitchClass getPitchClass() {
 		return PitchClass.fromInt(this.toInt());
@@ -172,32 +171,24 @@ public final class Pitch implements Comparable<Pitch> {
 	/**
 	 * Returns the pitch class number of this pitch.
 	 *
-	 * @return pitch class number of this pitch.
+	 * @return the pitch class number of this pitch
 	 */
 	public int getPitchClassNumber() {
 		return this.toInt() % 12;
 	}
 
 	/**
-	 * Test enharmonic equality. Compare this to other for
-	 * <a href="http://en.wikipedia.org/wiki/Enharmonic">enharmonic</a> equality.
+	 * Returns true if this pitch is
+	 * <a href="http://en.wikipedia.org/wiki/Enharmonic">enharmonically</a> equal to
+	 * the given pitch.
 	 *
-	 * @param other Pitch against which this is compared.
-	 * @return true if this is enharmonically equal to other, otherwise false.
+	 * @param other the pitch with which this is compared for enharmonic equality
+	 * @return true if this is enharmonically equal to other, otherwise false
 	 */
 	public boolean equalsEnharmonically(Pitch other) {
 		return this.toInt() == other.toInt();
 	}
 
-	/**
-	 * String representation of <code>Pitch</code>. <code>Pitch</code> objects are
-	 * represented as strings of form <code>bao</code>, where <code>b</code> is the
-	 * base letter in the pitch name, <code>a</code> is the alteration (sharps # or
-	 * flats b), and <code>o</code> is the octave number. For example middle C-sharp
-	 * is represented as the string <code>C#4</code>.
-	 *
-	 * @return the string representation of this Pitch.
-	 */
 	@Override
 	public String toString() {
 		String pitchName = this.pitchBase.toString();
@@ -216,11 +207,10 @@ public final class Pitch implements Comparable<Pitch> {
 	}
 
 	/**
-	 * Compare this <code>Pitch</code> for equality with <code>Object o</code>. Two
-	 * objects of class <code>Pitch</code> are equal if they have the same ' base
-	 * letter, alterations (sharps or flats), and same octave. Pitches that are
-	 * enharmonically the same but spelt differently are not equal. For example,
-	 * <code>C#4 != Db4</code>.
+	 * Returns true if this pitch is equal to the given object. Two pitches are
+	 * equal if they have the same base letter, alteration (sharps or flats), and
+	 * same octave. Pitches that are enharmonically equal but spelt differently are
+	 * not equal. For example, <code>C#4 != Db4</code>.
 	 *
 	 * @param o Object against which this is compared for equality.
 	 * @return true if Object o is of class Pitch and has the same, pitch base,
@@ -263,12 +253,13 @@ public final class Pitch implements Comparable<Pitch> {
 	}
 
 	/**
-	 * Compare this pitch against other for pitch height.
+	 * Returns an integer that denotes if this pitch is higher than, lower than, or
+	 * equal to the given pitch.
 	 *
-	 * @param other the Pitch against which this is compared.
+	 * @param other the pitch with which this is compared
 	 * @return negative integer if this is lower than other, positive integer if
 	 *         this is higher than other, 0 if pitches are (enharmonically) of same
-	 *         height.
+	 *         height
 	 */
 	@Override
 	public int compareTo(Pitch other) {
@@ -276,16 +267,20 @@ public final class Pitch implements Comparable<Pitch> {
 	}
 
 	/**
-	 * @param other the Pitch against which this is compared.
-	 * @return true if this is higher than other, false otherwise.
+	 * Returns true if this is higher than the given pitch.
+	 *
+	 * @param other the pitch with which this is compared for height
+	 * @return true if this is higher than other, false otherwise
 	 */
 	public boolean isHigherThan(Pitch other) {
 		return this.toInt() > other.toInt();
 	}
 
 	/**
-	 * @param other the Pitch against which this is compared.
-	 * @return true if this is lower than other, false otherwise.
+	 * Returns true if this is lower than the given pitch.
+	 *
+	 * @param other the pitch with which this is compared for height
+	 * @return true if this is lower than other, false otherwise
 	 */
 	public boolean isLowerThan(Pitch other) {
 		return this.toInt() < other.toInt();

--- a/src/main/java/org/wmn4j/notation/elements/PitchClass.java
+++ b/src/main/java/org/wmn4j/notation/elements/PitchClass.java
@@ -78,18 +78,22 @@ public enum PitchClass {
 	}
 
 	/**
-	 * @return the <a href="http://en.wikipedia.org/wiki/Pitch_class">pitch class
-	 *         number</a> of this pitch class.
+	 * Returns the <a href="http://en.wikipedia.org/wiki/Pitch_class">pitch class
+	 * number</a> of this pitch class.
+	 *
+	 * @return the pitch class number of this pitch class
 	 */
 	public int toInt() {
 		return this.number;
 	}
 
 	/**
-	 * Computes the pitch class from the pitch number.
+	 * Returns the pitch class that corresponds to the given non-negative pitch
+	 * number.
 	 *
-	 * @param pitchNumber The MIDI number of the pitch.
-	 * @return pitch class corresponding to the pitchNumber.
+	 * @param pitchNumber The MIDI number of the pitch for which the pitch class is
+	 *                    returned
+	 * @return pitch class corresponding to the given pitch number
 	 */
 	public static PitchClass fromInt(int pitchNumber) {
 		if (pitchNumber < 0) {

--- a/src/main/java/org/wmn4j/notation/elements/PitchClass.java
+++ b/src/main/java/org/wmn4j/notation/elements/PitchClass.java
@@ -1,13 +1,10 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
 
 /**
  * Represents the 12 pitch classes in equal-temperament tuning.
- *
- * @author Otso Björklund
  */
 public enum PitchClass {
 	/**

--- a/src/main/java/org/wmn4j/notation/elements/Rest.java
+++ b/src/main/java/org/wmn4j/notation/elements/Rest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -8,8 +7,6 @@ import java.util.Objects;
 
 /**
  * This class represents a rest. This class is immutable.
- *
- * @author Otso Björklund
  */
 public final class Rest implements Durational {
 	private final Duration duration;

--- a/src/main/java/org/wmn4j/notation/elements/Rest.java
+++ b/src/main/java/org/wmn4j/notation/elements/Rest.java
@@ -6,18 +6,17 @@ package org.wmn4j.notation.elements;
 import java.util.Objects;
 
 /**
- * This class represents a rest. This class is immutable.
+ * Represents a rest. This class is immutable.
  */
 public final class Rest implements Durational {
 	private final Duration duration;
 
 	/**
-	 * Get a <code>Rest</code> with duration specified by
-	 * <code>Duration duration</code>.
+	 * Returns a rest with the given duration.
 	 *
-	 * @throws NullPointerException if duration is null.
-	 * @param duration the duration of the rest.
-	 * @return Rest with specified duration.
+	 * @throws NullPointerException if duration is null
+	 * @param duration the duration of the rest
+	 * @return Rest with specified duration
 	 */
 	public static Rest getRest(Duration duration) {
 
@@ -37,38 +36,28 @@ public final class Rest implements Durational {
 	}
 
 	/**
-	 * Get the <code>Duration</code> of this.
+	 * Returns the duration of this rest.
 	 *
-	 * @return the duration of this Rest.
+	 * @return the duration of this rest
 	 */
 	@Override
 	public Duration getDuration() {
 		return this.duration;
 	}
 
-	/**
-	 * Method for checking if the Durational is a Rest.
-	 *
-	 * @return true.
-	 */
 	@Override
 	public boolean isRest() {
 		return true;
 	}
 
-	/**
-	 * Get the String representation of Rest.
-	 *
-	 * @return String of form <code>RD</code> where <code>D</code> is the String
-	 *         representation of the Duration of this Rest.
-	 */
 	@Override
 	public String toString() {
 		return "R" + this.duration.toString();
 	}
 
 	/**
-	 * Compare this <code>Rest</code> for equality against <code>Object o</code>.
+	 * Returns true if the given object is a rest with the same duration as this
+	 * rest.
 	 *
 	 * @param o Object against which this is compared for equality.
 	 * @return true if Object o is a Rest and the Duration of o is equal to the

--- a/src/main/java/org/wmn4j/notation/elements/Score.java
+++ b/src/main/java/org/wmn4j/notation/elements/Score.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -18,8 +17,6 @@ import org.wmn4j.notation.iterators.ScorePosition;
  * Class that describes a score. This class is immutable.
  * <code>ScoreBuilder</code> can be used for creating <code>Score</code>
  * objects.
- *
- * @author Otso Björklund
  */
 public class Score implements Iterable<Part> {
 
@@ -27,23 +24,23 @@ public class Score implements Iterable<Part> {
 	 * Type for the different text attributes a score can have.
 	 */
 	public enum Attribute {
-	/**
-	 * The name (main title) of the score.
-	 */
-	NAME,
-	/**
-	 * The composer name.
-	 */
-	COMPOSER,
+		/**
+		 * The name (main title) of the score.
+		 */
+		NAME,
+		/**
+		 * The composer name.
+		 */
+		COMPOSER,
 
-	/**
-	 * The arranger.
-	 */
-	ARRANGER,
-	/**
-	 * The year of publication.
-	 */
-	YEAR
+		/**
+		 * The arranger.
+		 */
+		ARRANGER,
+		/**
+		 * The year of publication.
+		 */
+		YEAR
 	}
 
 	private final Map<Attribute, String> scoreAttr;

--- a/src/main/java/org/wmn4j/notation/elements/Score.java
+++ b/src/main/java/org/wmn4j/notation/elements/Score.java
@@ -14,9 +14,8 @@ import java.util.NoSuchElementException;
 import org.wmn4j.notation.iterators.ScorePosition;
 
 /**
- * Class that describes a score. This class is immutable.
- * <code>ScoreBuilder</code> can be used for creating <code>Score</code>
- * objects.
+ * Represents a score. This class is immutable.
+ *
  */
 public class Score implements Iterable<Part> {
 
@@ -47,8 +46,10 @@ public class Score implements Iterable<Part> {
 	private final List<Part> parts;
 
 	/**
-	 * @param attributes The attributes of the score.
-	 * @param parts      The parts in the score.
+	 * Constructor.
+	 *
+	 * @param attributes the attributes of the score
+	 * @param parts      the parts in the score
 	 */
 	public Score(Map<Attribute, String> attributes, List<Part> parts) {
 		this.parts = Collections.unmodifiableList(new ArrayList<>(parts));
@@ -60,37 +61,47 @@ public class Score implements Iterable<Part> {
 	}
 
 	/**
-	 * @return Name of this <code>Score</code>.
+	 * Returns the name of this score.
+	 *
+	 * @return the name of this score
 	 */
 	public String getName() {
 		return this.getAttribute(Attribute.NAME);
 	}
 
 	/**
-	 * @return number of parts in this <code>Score</code>.
+	 * Returns the number of parts in this score.
+	 *
+	 * @return number of parts in this score
 	 */
 	public int getPartCount() {
 		return this.parts.size();
 	}
 
 	/**
-	 * @return the parts in this <code>Score</code> as list in no particular order.
+	 * Returns the parts in this score.
+	 *
+	 * @return the parts in this score
 	 */
 	public List<Part> getParts() {
 		return this.parts;
 	}
 
 	/**
-	 * @param index the number of the <code>Part</code> in the <code>Score</code>.
-	 * @return <code>Part</code> associated with index.
+	 * Returns the part at the index.
+	 *
+	 * @param index the number of the part in this score
+	 * @return the part at the index
 	 */
 	public Part getPart(int index) {
 		return this.parts.get(index);
 	}
 
 	/**
-	 * @param attribute the type of the attribute.
-	 * @return the text associated with attribute if the attribute is set. Empty
+	 * Returns the value of the given attribute.
+	 *
+	 * @param attribute the type of the attribute
+	 * @return the text associated with attribute if the attribute is present. Empty
 	 *         string otherwise.
 	 */
 	public String getAttribute(Attribute attribute) {
@@ -102,11 +113,11 @@ public class Score implements Iterable<Part> {
 	}
 
 	/**
-	 * Get the <code>Durational</code> at position.
+	 * Returns the durational notation object at the given position.
 	 *
-	 * @param position the <code>ScorePosition</code> from which to get the element.
-	 * @return the <code>Durational</code> at position.
-	 * @throws NoSuchElementException if the position is not found.
+	 * @param position the position from which to get the element
+	 * @return the notation object with duration at the given position
+	 * @throws NoSuchElementException if the position is not found in this score
 	 */
 	public Durational getAtPosition(ScorePosition position) throws NoSuchElementException {
 		final Part part = this.parts.get(position.getPartNumber());
@@ -138,9 +149,6 @@ public class Score implements Iterable<Part> {
 		return strBuilder.toString();
 	}
 
-	/**
-	 * @return iterator that does not support modifying the <code>Score</code>.
-	 */
 	@Override
 	public Iterator<Part> iterator() {
 		return this.parts.iterator();

--- a/src/main/java/org/wmn4j/notation/elements/SingleStaffPart.java
+++ b/src/main/java/org/wmn4j/notation/elements/SingleStaffPart.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -14,8 +13,6 @@ import java.util.NoSuchElementException;
 /**
  * Class for representing a part consisting of a single staff in a score. This
  * class is immutable.
- *
- * @author Otso Björklund
  */
 public class SingleStaffPart implements Part {
 

--- a/src/main/java/org/wmn4j/notation/elements/SingleStaffPart.java
+++ b/src/main/java/org/wmn4j/notation/elements/SingleStaffPart.java
@@ -11,8 +11,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 
 /**
- * Class for representing a part consisting of a single staff in a score. This
- * class is immutable.
+ * Represents a part with a single staff in a score. This class is immutable.
  */
 public class SingleStaffPart implements Part {
 
@@ -26,8 +25,8 @@ public class SingleStaffPart implements Part {
 	/**
 	 * Constructor.
 	 *
-	 * @param name     the name of the part.
-	 * @param measures the measures in this part.
+	 * @param name     the name of the part
+	 * @param measures the measures in this part
 	 */
 	public SingleStaffPart(String name, List<Measure> measures) {
 		this.staff = new Staff(measures);
@@ -39,8 +38,8 @@ public class SingleStaffPart implements Part {
 	/**
 	 * Constructor.
 	 *
-	 * @param partAttributes a map of attributes to be set for this part.
-	 * @param measures       the measures in this part.
+	 * @param partAttributes a map of attributes to be set for this part
+	 * @param measures       the measures in this part
 	 */
 	public SingleStaffPart(Map<Part.Attribute, String> partAttributes, List<Measure> measures) {
 		this.staff = new Staff(measures);
@@ -63,10 +62,10 @@ public class SingleStaffPart implements Part {
 	}
 
 	/**
-	 * Get the <code>Measure</code> with the given number.
+	 * Returns the measure with the given number.
 	 *
-	 * @param number number of measure.
-	 * @return measure with the given number.
+	 * @param number number of measure to return
+	 * @return measure with the given number
 	 */
 	public Measure getMeasure(int number) {
 		return this.staff.getMeasure(number);
@@ -80,7 +79,7 @@ public class SingleStaffPart implements Part {
 	/**
 	 * Returns the staff in this part.
 	 *
-	 * @return the only staff in this part.
+	 * @return the only staff in this part
 	 */
 	public Staff getStaff() {
 		return this.staff;
@@ -132,8 +131,8 @@ public class SingleStaffPart implements Part {
 	}
 
 	/**
-	 * Iterator for <code>SingleStaffPart</code>. Iterates through measures starting
-	 * from smallest measure number. Does not support removing.
+	 * Iterator for {@link SingleStaffPart}. Iterates through measures starting from
+	 * smallest measure number. Does not support removing.
 	 */
 	public static class Iter implements Part.Iter {
 

--- a/src/main/java/org/wmn4j/notation/elements/Staff.java
+++ b/src/main/java/org/wmn4j/notation/elements/Staff.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 /**
- * Class for representing a staff in a score. This class is immutable.
+ * Represents a staff in a score. This class is immutable.
  */
 public class Staff implements Iterable<Measure> {
 
@@ -53,10 +53,10 @@ public class Staff implements Iterable<Measure> {
 	}
 
 	/**
-	 * Get <code>Measure</code> by measure number.
+	 * Returns the measure with the given number.
 	 *
-	 * @param number the number of the measure to get from this staff.
-	 * @return the measure with number
+	 * @param number the number of the measure to get from this staff
+	 * @return the measure with the given number
 	 */
 	public Measure getMeasure(int number) {
 		if (!this.hasPickupMeasure() && number < 1) {
@@ -67,7 +67,10 @@ public class Staff implements Iterable<Measure> {
 	}
 
 	/**
-	 * @return number of measures in this <code>Staff</code>.
+	 * Returns the number of measures in this staff. Includes the pickup measure if
+	 * one is present.
+	 *
+	 * @return the number of measures in this staff
 	 */
 	public int getMeasureCount() {
 		int measureCount = this.getFullMeasureCount();
@@ -80,15 +83,20 @@ public class Staff implements Iterable<Measure> {
 	}
 
 	/**
-	 * @return number of full measures in this <code>Staff</code>. Pickup measure is
-	 *         not included.
+	 * Returns the number of full measures in this staff. Pickup measure is
+	 * excluded.
+	 *
+	 * @return the number of full measures in this staff
 	 */
 	public int getFullMeasureCount() {
 		return this.measures.size() - 1;
 	}
 
 	/**
-	 * @return List of measures in this staff in order from first measure to last.
+	 * Returns the measures in this staff as a list from smallest measure number to
+	 * greatest.
+	 *
+	 * @return the measures in this staff
 	 */
 	public List<Measure> getMeasures() {
 		if (!this.hasPickupMeasure()) {
@@ -99,14 +107,18 @@ public class Staff implements Iterable<Measure> {
 	}
 
 	/**
-	 * @return true if this staff begins with a pickup measure. false otherwise.
+	 * Returns true if this staff contains a pickup measure.
+	 *
+	 * @return true if this staff begins with a pickup measure, false otherwise
 	 */
 	public boolean hasPickupMeasure() {
 		return this.measures.get(0) != null;
 	}
 
 	/**
-	 * @return type of this <code>Staff</code>.
+	 * Returns the type of this staff.
+	 *
+	 * @return type of this staff
 	 */
 	public Type getType() {
 		return this.type;
@@ -124,9 +136,6 @@ public class Staff implements Iterable<Measure> {
 		return strBuilder.toString();
 	}
 
-	/**
-	 * @return iterator that does not support modifying this <code>Staff</code>.
-	 */
 	@Override
 	public Iterator<Measure> iterator() {
 		final Iterator<Measure> iter = this.measures.iterator();

--- a/src/main/java/org/wmn4j/notation/elements/Staff.java
+++ b/src/main/java/org/wmn4j/notation/elements/Staff.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -12,8 +11,6 @@ import java.util.NoSuchElementException;
 
 /**
  * Class for representing a staff in a score. This class is immutable.
- *
- * @author Otso Björklund
  */
 public class Staff implements Iterable<Measure> {
 
@@ -21,14 +18,14 @@ public class Staff implements Iterable<Measure> {
 	 * Type of staff.
 	 */
 	public enum Type {
-	/**
-	 * Normal five line staff.
-	 */
-	NORMAL,
-	/**
-	 * A single line percussion staff.
-	 */
-	SINGLE_LINE
+		/**
+		 * Normal five line staff.
+		 */
+		NORMAL,
+		/**
+		 * A single line percussion staff.
+		 */
+		SINGLE_LINE
 	};
 
 	private final List<Measure> measures;

--- a/src/main/java/org/wmn4j/notation/elements/TimeSignature.java
+++ b/src/main/java/org/wmn4j/notation/elements/TimeSignature.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
@@ -10,8 +9,6 @@ import java.util.Objects;
  * Class for time signatures. Time signatures consist of the number of beats and
  * the duration of each beat. For example, for the time signature 4/4 the number
  * of beats is 4 and the duration of beat is <code>Durations.QUARTER</code>.
- *
- * @author Otso Björklund
  */
 public final class TimeSignature {
 

--- a/src/main/java/org/wmn4j/notation/elements/TimeSignatures.java
+++ b/src/main/java/org/wmn4j/notation/elements/TimeSignatures.java
@@ -1,13 +1,10 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
 
 /**
  * Common time signatures.
- *
- * @author Otso Björklund
  */
 public final class TimeSignatures {
 

--- a/src/main/java/org/wmn4j/notation/iterators/PartWiseScoreIterator.java
+++ b/src/main/java/org/wmn4j/notation/iterators/PartWiseScoreIterator.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.iterators;
@@ -13,11 +12,9 @@ import org.wmn4j.notation.elements.Part;
 import org.wmn4j.notation.elements.Score;
 
 /**
- * Iterates through a <code>Score</code> in part wise order. Starts by iterating
+ * Iterates through a {@link Score} in part wise order. Starts by iterating
  * through the part with the smallest number. Iterates through parts starting
  * from smallest measure number. Iterates through measure voice by voice.
- *
- * @author Otso Björklund
  */
 public class PartWiseScoreIterator implements ScoreIterator {
 
@@ -33,7 +30,9 @@ public class PartWiseScoreIterator implements ScoreIterator {
 	private int prevIndex;
 
 	/**
-	 * @param score The score that this iterates through.
+	 * Constructor.
+	 *
+	 * @param score the score that this iterates through.
 	 */
 	public PartWiseScoreIterator(Score score) {
 		this.scoreIterator = score.iterator();

--- a/src/main/java/org/wmn4j/notation/iterators/ScoreIterator.java
+++ b/src/main/java/org/wmn4j/notation/iterators/ScoreIterator.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.iterators;
@@ -10,39 +9,37 @@ import java.util.NoSuchElementException;
 import org.wmn4j.notation.elements.Durational;
 
 /**
- * Interface for iterators that iterate through the <code>Durational</code>
- * objects in a <code>Score</code>.
- *
- * @author Otso Björklund
+ * Interface for iterators that iterate through the
+ * {@link org.wmn4j.notation.elements.Durational} objects in a
+ * {@link org.wmn4j.notation.elements.Score}.
  */
 public interface ScoreIterator extends Iterator<Durational> {
 
 	/**
-	 * Checks if the <code>ScoreIterator</code> is at the end of the score.
+	 * Returns true if this iterator has elements left.
 	 *
-	 * @return true if not at the end, false otherwise.
+	 * @return true if not at the end, false otherwise
 	 */
 	@Override
 	boolean hasNext();
 
 	/**
-	 * Get the next <code>Durational</code> from the score. Order of iteration
+	 * Get the next durational notation element from the score. Order of iteration
 	 * depends on the implementation.
 	 *
-	 * @return next <code>Durational</code>.
-	 * @throws NoSuchElementException if next <code>Durational</code> is not
-	 *                                available.
+	 * @return next durational element
+	 * @throws NoSuchElementException if this iterator has already reached the end
+	 *                                of the score
 	 */
 	@Override
 	Durational next() throws NoSuchElementException;
 
 	/**
-	 * Returns the position of the <code>Durational</code> returned by the last call
-	 * of {@link #next() next}. This method should only be called after
-	 * {@link #next() next} has been called.
+	 * Returns the position of the {@link Durational} returned by the last call of
+	 * {@link #next() next}. This method should only be called after {@link #next()
+	 * next} has been called.
 	 *
-	 * @return <code>ScorePosition</code> of the previously returned
-	 *         <code>Durational</code>.
+	 * @return the position of the previously returned duration notation element
 	 * @throws IllegalStateException if {@link #next() next} has not been called on
 	 *                               the iterator
 	 */

--- a/src/main/java/org/wmn4j/notation/iterators/ScorePosition.java
+++ b/src/main/java/org/wmn4j/notation/iterators/ScorePosition.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.iterators;
@@ -7,10 +6,8 @@ package org.wmn4j.notation.iterators;
 import org.wmn4j.notation.elements.SingleStaffPart;
 
 /**
- * Defines the position of a <code>Durational</code> in a <code>Score</code>. Is
- * immutable.
- *
- * @author Otso Björklund
+ * Represents the position of a {@link org.wmn4j.notation.elements.Durational}
+ * in a {@link org.wmn4j.notation.elements.Score}. Is immutable.
  */
 public class ScorePosition {
 
@@ -24,16 +21,15 @@ public class ScorePosition {
 	private static final int NOT_IN_CHORD = -1;
 
 	/**
-	 * Constructor for <code>ScorePosition</code> for parts with multiple staves.
+	 * Constructor for positions in parts with multiple staves.
 	 *
-	 * @param partNumber    The number (index) of the part in the
-	 *                      <code>Score</code>.
-	 * @param staffNumber   The number of the staff in the <code>Part</code>. For
-	 *                      <code>SingleStaffPart</code> objects use the constructor
-	 *                      without the staffNumber parameter.
-	 * @param measureNumber The measure number.
-	 * @param voiceNumber   The voice number in the measure.
-	 * @param indexInVoice  The index in the voice specified by voiceNumber.
+	 * @param partNumber    the number (index) of the part in the the score
+	 * @param staffNumber   the number of the staff in the part. For parts with a
+	 *                      single staff use the constructor without the staffNumber
+	 *                      parameter
+	 * @param measureNumber the measure number
+	 * @param voiceNumber   the voice number in the measure
+	 * @param indexInVoice  the index in the voice specified by voiceNumber
 	 */
 	public ScorePosition(int partNumber, int staffNumber, int measureNumber, int voiceNumber, int indexInVoice) {
 		this.partNumber = partNumber;
@@ -45,19 +41,17 @@ public class ScorePosition {
 	}
 
 	/**
-	 * Constructor for <code>ScorePosition</code> that can be used to access a note
-	 * in a chord.
+	 * Constructor for positions that can be used to access a note in a chord.
 	 *
-	 * @param partNumber    The number (index) of the part in the
-	 *                      <code>Score</code>.
-	 * @param staffNumber   The number of the staff in the <code>Part</code>. For
-	 *                      <code>SingleStaffPart</code> objects use the constructor
-	 *                      without the staffNumber parameter.
-	 * @param measureNumber The measure number.
-	 * @param voiceNumber   The voice number in the measure.
-	 * @param indexInVoice  The index in the voice specified by voiceNumber.
+	 * @param partNumber    The number (index) of the part in the score
+	 * @param staffNumber   The number of the staff in the part. For single staff
+	 *                      parts use the constructor without the staffNumber
+	 *                      parameter
+	 * @param measureNumber The measure number
+	 * @param voiceNumber   The voice number in the measure
+	 * @param indexInVoice  The index in the voice specified by voiceNumber
 	 * @param indexInChord  Starting from the bottom of the chord, the index of the
-	 *                      Note.
+	 *                      note
 	 */
 	public ScorePosition(int partNumber, int staffNumber, int measureNumber, int voiceNumber, int indexInVoice,
 			int indexInChord) {
@@ -72,11 +66,10 @@ public class ScorePosition {
 	/**
 	 * Constructor for position in a part with only a single staff.
 	 *
-	 * @param partNumber    The number (index) of the part in the
-	 *                      <code>Score</code>.
-	 * @param measureNumber The measure number.
-	 * @param voiceNumber   The voice number in the measure.
-	 * @param indexInVoice  The index in the voice specified by voiceNumber.
+	 * @param partNumber    the number (index) of the part in the score
+	 * @param measureNumber the measure number
+	 * @param voiceNumber   the voice number in the measure
+	 * @param indexInVoice  the index in the voice specified by voiceNumber
 	 */
 	public ScorePosition(int partNumber, int measureNumber, int voiceNumber, int indexInVoice) {
 		this.partNumber = partNumber;
@@ -88,66 +81,75 @@ public class ScorePosition {
 	}
 
 	/**
-	 * @return The number (index) of the part in the score.
+	 * Returns the part number of this position.
+	 *
+	 * @return The number (index) of the part in the score
 	 */
 	public int getPartNumber() {
 		return this.partNumber;
 	}
 
 	/**
-	 * @return The number of the staff in the part.
+	 * Returns the staff number in the part pointed to by this position.
+	 *
+	 * @return the number of the staff in the part
 	 */
 	public int getStaffNumber() {
 		return this.staffNumber;
 	}
 
 	/**
-	 * @return The measure number specified by this position.
+	 * Returns the number of the measure to which this position points.
+	 *
+	 * @return the measure number specified by this position
 	 */
 	public int getMeasureNumber() {
 		return this.measureNumber;
 	}
 
 	/**
-	 * @return The number of the voice in the measure.
+	 * Returns the number of the voice to which this position points.
+	 *
+	 * @return the number of the voice in the measure
 	 */
 	public int getVoiceNumber() {
 		return this.voiceNumber;
 	}
 
 	/**
-	 * @return The index of the <code>Durational</code> in the voice.
+	 * Returns the index in the voice to which this position points.
+	 *
+	 * @return the index in the voice to which this position points
 	 */
 	public int getIndexInVoice() {
 		return this.indexInVoice;
 	}
 
 	/**
-	 * Check if this position refers to note in a chord.
+	 * Returns true if this position points to a note in a chord.
 	 *
-	 * @return true if this position is for a note in a chord.
+	 * @return true if this position is for a note in a chord
 	 */
 	public boolean isInChord() {
 		return this.indexInChord != NOT_IN_CHORD;
 	}
 
 	/**
-	 * Get the index of the note in a chord specified by this position.
+	 * Returns the index of the note in a chord to which this position points.
 	 *
 	 * @return the index, counting from the bottom of the chord, of a note in a
-	 *         chord.
+	 *         chord
 	 */
 	public int getIndexInChord() {
 		return this.indexInChord;
 	}
 
 	/**
-	 * Compares this <code>ScorePosition</code> with equality against
-	 * <code>Object o</code>. Two positions are equal if and only if all of their
-	 * properties are equal.
+	 * Returns true if this position is equal to the given object. Two positions are
+	 * equal if and only if they are equal in all fields.
 	 *
-	 * @param o Object with which this is compared for equality.
-	 * @return True if o is equal to this, false otherwise.
+	 * @param o Object with which this is compared for equality
+	 * @return true if o is equal to this, false otherwise
 	 */
 	@Override
 	public boolean equals(Object o) {
@@ -199,8 +201,8 @@ public class ScorePosition {
 	public String toString() {
 		final StringBuilder strBuilder = new StringBuilder();
 		strBuilder.append("Part: ").append(this.partNumber).append(", Staff: ").append(this.staffNumber)
-		.append(", Measure: ").append(this.measureNumber).append(", Voice: ").append(this.voiceNumber)
-		.append(", Index: ").append(this.indexInVoice);
+				.append(", Measure: ").append(this.measureNumber).append(", Voice: ").append(this.voiceNumber)
+				.append(", Index: ").append(this.indexInVoice);
 
 		return strBuilder.toString();
 	}

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
@@ -282,10 +282,10 @@ public class MusicXmlReaderDomTest {
 		assertEquals(Clefs.ALTO, part.getMeasure(2).getClef());
 		assertFalse(part.getMeasure(2).containsClefChanges());
 
-		assertEquals(Clef.getClef(Clef.Type.C, 4), part.getMeasure(3).getClef());
+		assertEquals(Clef.getClef(Clef.Symbol.C, 4), part.getMeasure(3).getClef());
 		assertFalse(part.getMeasure(3).containsClefChanges());
 
-		assertEquals(Clef.getClef(Clef.Type.C, 4), part.getMeasure(4).getClef());
+		assertEquals(Clef.getClef(Clef.Symbol.C, 4), part.getMeasure(4).getClef());
 		assertTrue(part.getMeasure(4).containsClefChanges());
 		final Map<Duration, Clef> clefChanges = part.getMeasure(4).getClefChanges();
 		assertEquals(2, clefChanges.size());

--- a/src/test/java/org/wmn4j/notation/elements/ChordTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/ChordTest.java
@@ -129,7 +129,7 @@ public class ChordTest {
 		final HashSet<Articulation> articulations = new HashSet<>();
 		articulations.add(Articulation.STACCATO);
 		final Note staccatoC5 = Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER, articulations);
-		final Chord staccatoC = this.cMajor.addNote(staccatoC5);
+		final Chord staccatoC = this.cMajor.add(staccatoC5);
 		assertTrue(staccatoC.contains(staccatoC5));
 		assertFalse(staccatoC.contains(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER)));
 		assertFalse(this.cMajor.contains(staccatoC5));
@@ -190,13 +190,13 @@ public class ChordTest {
 
 	@Test
 	public void testAddNote() {
-		final Chord cMaj = this.cMajor.addNote(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER));
+		final Chord cMaj = this.cMajor.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER));
 		assertFalse(this.cMajor.equals(cMaj));
 		assertEquals(4, cMaj.getNoteCount());
 		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER), cMaj.getHighestNote());
 
 		try {
-			final Chord illegalCMaj = this.cMajor.addNote(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT));
+			final Chord illegalCMaj = this.cMajor.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT));
 			fail("Failed to throw expected exception");
 		} catch (final IllegalArgumentException e) {
 			assertTrue(e instanceof IllegalArgumentException);
@@ -205,7 +205,7 @@ public class ChordTest {
 
 	@Test
 	public void testRemoveNote() {
-		final Chord D_FSharp = this.dMajor.removeNote(Note.getNote(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.QUARTER));
+		final Chord D_FSharp = this.dMajor.remove(Note.getNote(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.QUARTER));
 		assertFalse(this.dMajor.equals(D_FSharp));
 		assertEquals(2, D_FSharp.getNoteCount());
 		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.F, 1, 3), Durations.QUARTER), D_FSharp.getHighestNote());


### PR DESCRIPTION
* Remove author tags and names from copyright statements as this project is not a single person thing anymore.
* Unify style in documentation
* Replace abbreviated parameter names with full words