### PR TITLE
Issue #80: Improve static factory method naming

### DIFF
--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
@@ -684,7 +684,7 @@ class MusicXmlReaderDom implements MusicXmlReader {
 					.map(alterNode -> Integer.parseInt(alterNode.getTextContent()))
 					.orElse(0);
 
-			pitch = Pitch.getPitch(pitchBase, alter, octave);
+			pitch = Pitch.of(pitchBase, alter, octave);
 		} else {
 			final Optional<Node> unpitchedNode = DocHelper.findChild(noteNode, MusicXmlTags.NOTE_UNPITCHED);
 			if (unpitchedNode.isPresent()) {
@@ -695,7 +695,7 @@ class MusicXmlReaderDom implements MusicXmlReader {
 				if (stepNode.isPresent() && octaveNode.isPresent()) {
 					final Pitch.Base pitchBase = getPitchBase(stepNode.get());
 					final int octave = Integer.parseInt(octaveNode.get().getTextContent());
-					pitch = Pitch.getPitch(pitchBase, 0, octave);
+					pitch = Pitch.of(pitchBase, 0, octave);
 				}
 			}
 		}

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
@@ -592,7 +592,7 @@ class MusicXmlReaderDom implements MusicXmlReader {
 			break;
 		}
 
-		return Clef.getClef(type, clefLine);
+		return Clef.of(type, clefLine);
 	}
 
 	private Barline getBarline(Node barlineNode) {

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
@@ -513,12 +513,12 @@ class MusicXmlReaderDom implements MusicXmlReader {
 			if (staffNumberNode != null) {
 				final int staffNumberAttr = Integer.parseInt(staffNumberNode.getTextContent());
 				if (staffNumberAttr == staffNumber) {
-					timeSig = TimeSignature.getTimeSignature(beats, beatType);
+					timeSig = TimeSignature.of(beats, beatType);
 				} else {
 					timeSig = previous.getTimeSig();
 				}
 			} else {
-				timeSig = TimeSignature.getTimeSignature(beats, beatType);
+				timeSig = TimeSignature.of(beats, beatType);
 			}
 		} else {
 			timeSig = previous.getTimeSig();

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
@@ -734,7 +734,7 @@ class MusicXmlReaderDom implements MusicXmlReader {
 			final int nominator = Integer.parseInt(durationNode.get().getTextContent());
 			// In MusicXml divisions is the number of parts into which a quarter note
 			// is divided. Therefore divisions needs to be multiplied by 4.
-			return Duration.getDuration(nominator, divisions * 4);
+			return Duration.of(nominator, divisions * 4);
 		}
 
 		return null;

--- a/src/main/java/org/wmn4j/notation/builders/ChordBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/ChordBuilder.java
@@ -90,7 +90,7 @@ public class ChordBuilder implements DurationalBuilder, Iterable<NoteBuilder> {
 	public Chord build() {
 		final List<Note> notes = new ArrayList<>();
 		this.noteBuilders.forEach((builder) -> notes.add(builder.build()));
-		return Chord.getChord(notes);
+		return Chord.of(notes);
 	}
 
 }

--- a/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
@@ -361,7 +361,7 @@ public class MeasureBuilder {
 	 * @return a measure with the values set in this builder
 	 */
 	public Measure build() {
-		final MeasureAttributes measureAttr = MeasureAttributes.getMeasureAttr(this.timeSig, this.keySig,
+		final MeasureAttributes measureAttr = MeasureAttributes.of(this.timeSig, this.keySig,
 				this.rightBarline, this.leftBarline, this.clef, this.clefChanges);
 
 		return new Measure(this.number, this.getBuiltVoices(), measureAttr);

--- a/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
@@ -364,6 +364,6 @@ public class MeasureBuilder {
 		final MeasureAttributes measureAttr = MeasureAttributes.of(this.timeSig, this.keySig,
 				this.rightBarline, this.leftBarline, this.clef, this.clefChanges);
 
-		return new Measure(this.number, this.getBuiltVoices(), measureAttr);
+		return Measure.of(this.number, this.getBuiltVoices(), measureAttr);
 	}
 }

--- a/src/main/java/org/wmn4j/notation/builders/NoteBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/NoteBuilder.java
@@ -240,7 +240,7 @@ public class NoteBuilder implements DurationalBuilder {
 				this.tiedTo = this.followingTied.build();
 			}
 
-			this.cachedNote = Note.getNote(this.pitch, this.duration, this.articulations, this.multiNoteArticulations,
+			this.cachedNote = Note.of(this.pitch, this.duration, this.articulations, this.multiNoteArticulations,
 					this.tiedTo, this.isTiedFromPrevious);
 		}
 

--- a/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
@@ -110,7 +110,7 @@ public class PartBuilder {
 		} else {
 			final Map<Integer, Staff> staves = new HashMap<>();
 			for (int staffNumber : this.staveContents.keySet()) {
-				staves.put(staffNumber, new Staff(getBuiltMeasures(this.staveContents.get(staffNumber))));
+				staves.put(staffNumber, Staff.of(getBuiltMeasures(this.staveContents.get(staffNumber))));
 			}
 
 			return MultiStaffPart.of(this.partAttributes, staves);

--- a/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
@@ -105,7 +105,7 @@ public class PartBuilder {
 	 */
 	public Part build() {
 		if (this.staveContents.size() == 1) {
-			return new SingleStaffPart(this.partAttributes,
+			return SingleStaffPart.of(this.partAttributes,
 					getBuiltMeasures(this.staveContents.get(SINGLE_STAFF_NUMBER)));
 		} else {
 			final Map<Integer, Staff> staves = new HashMap<>();

--- a/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
@@ -113,7 +113,7 @@ public class PartBuilder {
 				staves.put(staffNumber, new Staff(getBuiltMeasures(this.staveContents.get(staffNumber))));
 			}
 
-			return new MultiStaffPart(this.partAttributes, staves);
+			return MultiStaffPart.of(this.partAttributes, staves);
 		}
 	}
 }

--- a/src/main/java/org/wmn4j/notation/builders/RestBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/RestBuilder.java
@@ -40,6 +40,6 @@ public final class RestBuilder implements DurationalBuilder {
 
 	@Override
 	public Rest build() {
-		return Rest.getRest(this.duration);
+		return Rest.of(this.duration);
 	}
 }

--- a/src/main/java/org/wmn4j/notation/builders/ScoreBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/ScoreBuilder.java
@@ -54,6 +54,6 @@ public class ScoreBuilder {
 	public Score build() {
 		final List<Part> parts = new ArrayList<>();
 		this.partBuilders.forEach((builder) -> parts.add(builder.build()));
-		return new Score(this.scoreAttr, parts);
+		return Score.of(this.scoreAttr, parts);
 	}
 }

--- a/src/main/java/org/wmn4j/notation/elements/Chord.java
+++ b/src/main/java/org/wmn4j/notation/elements/Chord.java
@@ -184,7 +184,7 @@ public final class Chord implements Durational, Iterable<Note> {
 	public Chord remove(Pitch pitch) {
 		if (this.contains(pitch)) {
 			final List<Note> newNotes = new ArrayList<>(this.notes);
-			newNotes.remove(Note.getNote(pitch, this.getDuration()));
+			newNotes.remove(Note.of(pitch, this.getDuration()));
 			return Chord.of(newNotes);
 		}
 

--- a/src/main/java/org/wmn4j/notation/elements/Chord.java
+++ b/src/main/java/org/wmn4j/notation/elements/Chord.java
@@ -29,7 +29,7 @@ public final class Chord implements Durational, Iterable<Note> {
 	 * @throws IllegalArgumentException if notes is empty or all Note objects in
 	 *                                  notes are not of same duration
 	 */
-	public static Chord getChord(Note... n) {
+	public static Chord of(Note... n) {
 		return new Chord(Arrays.asList(n));
 	}
 
@@ -43,7 +43,7 @@ public final class Chord implements Durational, Iterable<Note> {
 	 * @throws IllegalArgumentException if notes is empty or all Note objects in
 	 *                                  notes are not of same duration.
 	 */
-	public static Chord getChord(Collection<Note> notes) {
+	public static Chord of(Collection<Note> notes) {
 		return new Chord(notes);
 	}
 
@@ -134,7 +134,7 @@ public final class Chord implements Durational, Iterable<Note> {
 	public Chord add(Note note) {
 		final ArrayList<Note> noteList = new ArrayList<>(this.notes);
 		noteList.add(note);
-		return Chord.getChord(noteList);
+		return Chord.of(noteList);
 	}
 
 	/**
@@ -146,7 +146,7 @@ public final class Chord implements Durational, Iterable<Note> {
 	public Chord remove(Note note) {
 		final ArrayList<Note> noteList = new ArrayList<>(this.notes);
 		noteList.remove(note);
-		return Chord.getChord(noteList);
+		return Chord.of(noteList);
 	}
 
 	/**
@@ -185,7 +185,7 @@ public final class Chord implements Durational, Iterable<Note> {
 		if (this.contains(pitch)) {
 			final List<Note> newNotes = new ArrayList<>(this.notes);
 			newNotes.remove(Note.getNote(pitch, this.getDuration()));
-			return Chord.getChord(newNotes);
+			return Chord.of(newNotes);
 		}
 
 		return this;

--- a/src/main/java/org/wmn4j/notation/elements/Clef.java
+++ b/src/main/java/org/wmn4j/notation/elements/Clef.java
@@ -52,7 +52,7 @@ public final class Clef {
 	 *               centered
 	 * @return a clef with the specified properties.
 	 */
-	public static Clef getClef(Symbol symbol, int line) {
+	public static Clef of(Symbol symbol, int line) {
 
 		if (line < 1) {
 			throw new IllegalArgumentException("line is smaller than 1");

--- a/src/main/java/org/wmn4j/notation/elements/Clefs.java
+++ b/src/main/java/org/wmn4j/notation/elements/Clefs.java
@@ -10,22 +10,22 @@ public final class Clefs {
 	/**
 	 * The basic G clef.
 	 */
-	public static final Clef G = Clef.getClef(Clef.Symbol.G, 2);
+	public static final Clef G = Clef.of(Clef.Symbol.G, 2);
 
 	/**
 	 * The basic F clef.
 	 */
-	public static final Clef F = Clef.getClef(Clef.Symbol.F, 4);
+	public static final Clef F = Clef.of(Clef.Symbol.F, 4);
 
 	/**
 	 * The basic alto clef.
 	 */
-	public static final Clef ALTO = Clef.getClef(Clef.Symbol.C, 3);
+	public static final Clef ALTO = Clef.of(Clef.Symbol.C, 3);
 
 	/**
 	 * The basic percussion clef.
 	 */
-	public static final Clef PERCUSSION = Clef.getClef(Clef.Symbol.PERCUSSION, 3);
+	public static final Clef PERCUSSION = Clef.of(Clef.Symbol.PERCUSSION, 3);
 
 	private Clefs() {
 		// Not meant to be instantiated

--- a/src/main/java/org/wmn4j/notation/elements/Duration.java
+++ b/src/main/java/org/wmn4j/notation/elements/Duration.java
@@ -29,7 +29,7 @@ public final class Duration implements Comparable<Duration> {
 	 * @param denominator the denominator part of the duration
 	 * @return an instance with the given numerator and denominator
 	 */
-	public static Duration getDuration(int numerator, int denominator) {
+	public static Duration of(int numerator, int denominator) {
 
 		if (numerator < 1) {
 			throw new IllegalArgumentException("numerator must be at least 1");
@@ -53,7 +53,7 @@ public final class Duration implements Comparable<Duration> {
 
 	/**
 	 * Constructor for the class. The constructor is private, to get a Duration
-	 * object use the static method {@link #getDuration(int, int) getDuration}.
+	 * object use the static method {@link #of(int, int) getDuration}.
 	 *
 	 * @param numerator   the numerator part of the duration
 	 * @param denominator the denominator part of the duration
@@ -123,7 +123,7 @@ public final class Duration implements Comparable<Duration> {
 	 * @return duration that is this incremented by half of this
 	 */
 	public Duration addDot() {
-		return this.add(Duration.getDuration(this.numerator, 2 * this.denominator));
+		return this.add(Duration.of(this.numerator, 2 * this.denominator));
 	}
 
 	/**
@@ -150,7 +150,7 @@ public final class Duration implements Comparable<Duration> {
 		final int nom = this.numerator * other.denominator + this.denominator * other.numerator;
 		final int denom = this.denominator * other.denominator;
 
-		return getDuration(nom, denom);
+		return of(nom, denom);
 	}
 
 	/**
@@ -164,7 +164,7 @@ public final class Duration implements Comparable<Duration> {
 		final int nom = this.numerator * other.denominator - this.denominator * other.numerator;
 		final int denom = this.denominator * other.denominator;
 
-		return getDuration(nom, denom);
+		return of(nom, denom);
 	}
 
 	/**
@@ -180,7 +180,7 @@ public final class Duration implements Comparable<Duration> {
 			throw new IllegalArgumentException("multiplier must be at least 1. Was " + multiplier);
 		}
 
-		return getDuration(this.numerator * multiplier, this.denominator);
+		return of(this.numerator * multiplier, this.denominator);
 	}
 
 	/**
@@ -196,7 +196,7 @@ public final class Duration implements Comparable<Duration> {
 			throw new IllegalArgumentException("divider must be at least 1. Was " + divisor);
 		}
 
-		return getDuration(this.numerator, this.denominator * divisor);
+		return of(this.numerator, this.denominator * divisor);
 	}
 
 	/**

--- a/src/main/java/org/wmn4j/notation/elements/Durations.java
+++ b/src/main/java/org/wmn4j/notation/elements/Durations.java
@@ -10,52 +10,52 @@ public final class Durations {
 	/**
 	 * Constant value for whole note duration.
 	 */
-	public static final Duration WHOLE = Duration.getDuration(1, 1);
+	public static final Duration WHOLE = Duration.of(1, 1);
 
 	/**
 	 * Constant value for half note duration.
 	 */
-	public static final Duration HALF = Duration.getDuration(1, 2);
+	public static final Duration HALF = Duration.of(1, 2);
 
 	/**
 	 * Constant value for quarter note duration.
 	 */
-	public static final Duration QUARTER = Duration.getDuration(1, 4);
+	public static final Duration QUARTER = Duration.of(1, 4);
 
 	/**
 	 * Constant value for eight note duration.
 	 */
-	public static final Duration EIGHT = Duration.getDuration(1, 8);
+	public static final Duration EIGHT = Duration.of(1, 8);
 
 	/**
 	 * Constant value for sixteenth note duration.
 	 */
-	public static final Duration SIXTEENTH = Duration.getDuration(1, 16);
+	public static final Duration SIXTEENTH = Duration.of(1, 16);
 
 	/**
 	 * Constant value for thirtysecond note duration.
 	 */
-	public static final Duration THIRTYSECOND = Duration.getDuration(1, 32);
+	public static final Duration THIRTYSECOND = Duration.of(1, 32);
 
 	/**
 	 * Constant value for sixtyfourth note duration.
 	 */
-	public static final Duration SIXTYFOURTH = Duration.getDuration(1, 64);
+	public static final Duration SIXTYFOURTH = Duration.of(1, 64);
 
 	/**
 	 * Constant value for quarter note triplet duration.
 	 */
-	public static final Duration QUARTER_TRIPLET = Duration.getDuration(1, 6);
+	public static final Duration QUARTER_TRIPLET = Duration.of(1, 6);
 
 	/**
 	 * Constant value for eight note triplet duration.
 	 */
-	public static final Duration EIGHT_TRIPLET = Duration.getDuration(1, 12);
+	public static final Duration EIGHT_TRIPLET = Duration.of(1, 12);
 
 	/**
 	 * Constant value for sixteenth note triplet duration.
 	 */
-	public static final Duration SIXTEENTH_TRIPLET = Duration.getDuration(1, 24);
+	public static final Duration SIXTEENTH_TRIPLET = Duration.of(1, 24);
 
 	private Durations() {
 		// Not meant to be instantiated.

--- a/src/main/java/org/wmn4j/notation/elements/KeySignature.java
+++ b/src/main/java/org/wmn4j/notation/elements/KeySignature.java
@@ -11,9 +11,26 @@ import java.util.Objects;
 /**
  * Represents a key signature. This class is immutable.
  */
-public class KeySignature {
+public final class KeySignature {
 	private final List<Pitch.Base> sharps;
 	private final List<Pitch.Base> flats;
+
+	/**
+	 * Returns a key signature with the given sharps and flats. For common key
+	 * signatures use the ones defined in {@link KeySignatures}. This is mostly
+	 * intended for creating custom key signatures.
+	 *
+	 * @throws IllegalArgumentException if the same Pitch.Base is in both sharps and
+	 *                                  flats.
+	 * @param sharps the Pitch.Base names that should be raised. For example, for
+	 *               G-major this list consists only of Pitch.Base.F.
+	 * @param flats  the Pitch.Base names that should be flattened. For example, for
+	 *               F-major this list consists only of Pitch.Base.B.
+	 * @return a key signature with the given sharps and flats
+	 */
+	public static KeySignature of(List<Pitch.Base> sharps, List<Pitch.Base> flats) {
+		return new KeySignature(sharps, flats);
+	}
 
 	/**
 	 * Constructor for KeySignature. For common key signatures use the ones defined
@@ -27,7 +44,7 @@ public class KeySignature {
 	 * @param flats  the Pitch.Base names that should be flattened. For example, for
 	 *               F-major this list consists only of Pitch.Base.B.
 	 */
-	public KeySignature(List<Pitch.Base> sharps, List<Pitch.Base> flats) {
+	private KeySignature(List<Pitch.Base> sharps, List<Pitch.Base> flats) {
 		if (sharps != null && !sharps.isEmpty()) {
 			this.sharps = new ArrayList<>(sharps);
 		} else {

--- a/src/main/java/org/wmn4j/notation/elements/KeySignatures.java
+++ b/src/main/java/org/wmn4j/notation/elements/KeySignatures.java
@@ -12,74 +12,74 @@ public final class KeySignatures {
 	/**
 	 * The key signature for C major or a minor.
 	 */
-	public static final KeySignature CMAJ_AMIN = new KeySignature(null, null);
+	public static final KeySignature CMAJ_AMIN = KeySignature.of(null, null);
 
 	/**
 	 * The key signature for G major or e minor.
 	 */
-	public static final KeySignature GMAJ_EMIN = new KeySignature(Arrays.asList(Pitch.Base.F), null);
+	public static final KeySignature GMAJ_EMIN = KeySignature.of(Arrays.asList(Pitch.Base.F), null);
 
 	/**
 	 * The key signature for D major or b minor.
 	 */
-	public static final KeySignature DMAJ_BMIN = new KeySignature(Arrays.asList(Pitch.Base.F, Pitch.Base.C), null);
+	public static final KeySignature DMAJ_BMIN = KeySignature.of(Arrays.asList(Pitch.Base.F, Pitch.Base.C), null);
 
 	/**
 	 * The key signature for A major or f# minor.
 	 */
-	public static final KeySignature AMAJ_FSHARPMIN = new KeySignature(
+	public static final KeySignature AMAJ_FSHARPMIN = KeySignature.of(
 			Arrays.asList(Pitch.Base.F, Pitch.Base.C, Pitch.Base.G), null);
 
 	/**
 	 * The key signature for E major or c# minor.
 	 */
-	public static final KeySignature EMAJ_CSHARPMIN = new KeySignature(
+	public static final KeySignature EMAJ_CSHARPMIN = KeySignature.of(
 			Arrays.asList(Pitch.Base.F, Pitch.Base.C, Pitch.Base.G, Pitch.Base.D), null);
 
 	/**
 	 * The key signature for B major or g# minor.
 	 */
-	public static final KeySignature BMAJ_GSHARPMIN = new KeySignature(
+	public static final KeySignature BMAJ_GSHARPMIN = KeySignature.of(
 			Arrays.asList(Pitch.Base.F, Pitch.Base.C, Pitch.Base.G, Pitch.Base.D, Pitch.Base.A), null);
 
 	/**
 	 * The key signature for F# major or d# minor.
 	 */
-	public static final KeySignature FSHARPMAJ_DSHARPMIN = new KeySignature(
+	public static final KeySignature FSHARPMAJ_DSHARPMIN = KeySignature.of(
 			Arrays.asList(Pitch.Base.F, Pitch.Base.C, Pitch.Base.G, Pitch.Base.D, Pitch.Base.A, Pitch.Base.E), null);
 
 	/**
 	 * The key signature for F major or d minor.
 	 */
-	public static final KeySignature FMAJ_DMIN = new KeySignature(null, Arrays.asList(Pitch.Base.B));
+	public static final KeySignature FMAJ_DMIN = KeySignature.of(null, Arrays.asList(Pitch.Base.B));
 
 	/**
 	 * The key signature for Bb major or g minor.
 	 */
-	public static final KeySignature BFLATMAJ_GMIN = new KeySignature(null, Arrays.asList(Pitch.Base.B, Pitch.Base.E));
+	public static final KeySignature BFLATMAJ_GMIN = KeySignature.of(null, Arrays.asList(Pitch.Base.B, Pitch.Base.E));
 
 	/**
 	 * The key signature for Eb major or c minor.
 	 */
-	public static final KeySignature EFLATMAJ_CMIN = new KeySignature(null,
+	public static final KeySignature EFLATMAJ_CMIN = KeySignature.of(null,
 			Arrays.asList(Pitch.Base.B, Pitch.Base.E, Pitch.Base.A));
 
 	/**
 	 * The key signature for Ab major or f minor.
 	 */
-	public static final KeySignature AFLATMAJ_FMIN = new KeySignature(null,
+	public static final KeySignature AFLATMAJ_FMIN = KeySignature.of(null,
 			Arrays.asList(Pitch.Base.B, Pitch.Base.E, Pitch.Base.A, Pitch.Base.D));
 
 	/**
 	 * The key signature for Db major or bb minor.
 	 */
-	public static final KeySignature DFLATMAJ_BFLATMIN = new KeySignature(null,
+	public static final KeySignature DFLATMAJ_BFLATMIN = KeySignature.of(null,
 			Arrays.asList(Pitch.Base.B, Pitch.Base.E, Pitch.Base.A, Pitch.Base.D, Pitch.Base.G));
 
 	/**
 	 * The key signature for Gb major or eb minor.
 	 */
-	public static final KeySignature GFLATMAJ_EFLATMIN = new KeySignature(null,
+	public static final KeySignature GFLATMAJ_EFLATMIN = KeySignature.of(null,
 			Arrays.asList(Pitch.Base.B, Pitch.Base.E, Pitch.Base.A, Pitch.Base.D, Pitch.Base.G, Pitch.Base.C));
 
 	private KeySignatures() {

--- a/src/main/java/org/wmn4j/notation/elements/Measure.java
+++ b/src/main/java/org/wmn4j/notation/elements/Measure.java
@@ -18,39 +18,55 @@ import java.util.TreeMap;
  * to using voice numbers. This class is immutable. Use the MeasureBuilder class
  * for easier creation of Measures.
  */
-public class Measure implements Iterable<Durational> {
+public final class Measure implements Iterable<Durational> {
 
 	private final int number;
 	private final SortedMap<Integer, List<Durational>> voices;
 	private final MeasureAttributes measureAttr;
 
 	/**
-	 * Constructor.
+	 * Returns a measure with the given values.
 	 *
-	 * @param number       number of the measure.
-	 * @param noteVoices   the notes on the different voices of the measure.
-	 * @param timeSig      TimeSignature of the measure.
-	 * @param keySig       KeySignature in effect in the measure.
-	 * @param rightBarLine barline on the right side (left side is NONE by default).
-	 * @param clef         Clef in effect in the measure.
+	 * @param number       number of the measure
+	 * @param noteVoices   the notes on the different voices of the measure
+	 * @param timeSig      TimeSignature of the measure
+	 * @param keySig       KeySignature in effect in the measure
+	 * @param rightBarLine barline on the right side (left side is NONE by default)
+	 * @param clef         Clef in effect in the measure
+	 * @return a measure with the given values
 	 */
-	public Measure(int number, Map<Integer, List<Durational>> noteVoices, TimeSignature timeSig, KeySignature keySig,
+	public static Measure of(int number, Map<Integer, List<Durational>> noteVoices, TimeSignature timeSig,
+			KeySignature keySig,
 			Barline rightBarLine, Clef clef) {
-		this(number, noteVoices, MeasureAttributes.of(timeSig, keySig, rightBarLine, clef));
+		return new Measure(number, noteVoices, MeasureAttributes.of(timeSig, keySig, rightBarLine, clef));
 	}
 
 	/**
-	 * Constructor.
+	 * Returns a measure with the given values.
 	 *
-	 * @param number     number of the measure.
-	 * @param noteVoices the notes on the different voices of the measure.
-	 * @param timeSig    TimeSignature of the measure.
-	 * @param keySig     KeySignature in effect in the measure.
-	 * @param clef       Clef in effect in the measure.
+	 * @param number     number of the measure
+	 * @param noteVoices the notes on the different voices of the measure
+	 * @param timeSig    TimeSignature of the measure
+	 * @param keySig     KeySignature in effect in the measure
+	 * @param clef       Clef in effect in the measure
+	 * @return a measure with the given values
 	 */
-	public Measure(int number, Map<Integer, List<Durational>> noteVoices, TimeSignature timeSig, KeySignature keySig,
+	public static Measure of(int number, Map<Integer, List<Durational>> noteVoices, TimeSignature timeSig,
+			KeySignature keySig,
 			Clef clef) {
-		this(number, noteVoices, MeasureAttributes.of(timeSig, keySig, Barline.SINGLE, clef));
+		return new Measure(number, noteVoices, MeasureAttributes.of(timeSig, keySig, Barline.SINGLE, clef));
+	}
+
+	/**
+	 * Returns a measure with the given values.
+	 *
+	 * @param number      number of the measure
+	 * @param noteVoices  the notes on the different voices of the measure
+	 * @param measureAttr the attributes of the measure
+	 * @return a measure with the given values
+	 */
+	public static Measure of(int number, Map<Integer, List<Durational>> noteVoices, MeasureAttributes measureAttr) {
+		return new Measure(number, noteVoices, measureAttr);
 	}
 
 	/**
@@ -60,7 +76,7 @@ public class Measure implements Iterable<Durational> {
 	 * @param noteVoices  the notes on the different voices of the measure.
 	 * @param measureAttr the attributes of the measure.
 	 */
-	public Measure(int number, Map<Integer, List<Durational>> noteVoices, MeasureAttributes measureAttr) {
+	private Measure(int number, Map<Integer, List<Durational>> noteVoices, MeasureAttributes measureAttr) {
 		this.number = number;
 		final SortedMap<Integer, List<Durational>> voicesCopy = new TreeMap<>();
 

--- a/src/main/java/org/wmn4j/notation/elements/Measure.java
+++ b/src/main/java/org/wmn4j/notation/elements/Measure.java
@@ -36,7 +36,7 @@ public class Measure implements Iterable<Durational> {
 	 */
 	public Measure(int number, Map<Integer, List<Durational>> noteVoices, TimeSignature timeSig, KeySignature keySig,
 			Barline rightBarLine, Clef clef) {
-		this(number, noteVoices, MeasureAttributes.getMeasureAttr(timeSig, keySig, rightBarLine, clef));
+		this(number, noteVoices, MeasureAttributes.of(timeSig, keySig, rightBarLine, clef));
 	}
 
 	/**
@@ -50,7 +50,7 @@ public class Measure implements Iterable<Durational> {
 	 */
 	public Measure(int number, Map<Integer, List<Durational>> noteVoices, TimeSignature timeSig, KeySignature keySig,
 			Clef clef) {
-		this(number, noteVoices, MeasureAttributes.getMeasureAttr(timeSig, keySig, Barline.SINGLE, clef));
+		this(number, noteVoices, MeasureAttributes.of(timeSig, keySig, Barline.SINGLE, clef));
 	}
 
 	/**

--- a/src/main/java/org/wmn4j/notation/elements/MeasureAttributes.java
+++ b/src/main/java/org/wmn4j/notation/elements/MeasureAttributes.java
@@ -31,10 +31,10 @@ public final class MeasureAttributes {
 	 * @param clef          the clef in effect at the beginning of the measure
 	 * @return an instance with the given values
 	 */
-	public static MeasureAttributes getMeasureAttr(TimeSignature timeSignature, KeySignature keySignature,
+	public static MeasureAttributes of(TimeSignature timeSignature, KeySignature keySignature,
 			Barline rightBarline,
 			Clef clef) {
-		return getMeasureAttr(timeSignature, keySignature, rightBarline, Barline.NONE, clef);
+		return of(timeSignature, keySignature, rightBarline, Barline.NONE, clef);
 	}
 
 	/**
@@ -47,10 +47,10 @@ public final class MeasureAttributes {
 	 * @param clef          the clef in effect at the beginning of the measure
 	 * @return an instance with the given values
 	 */
-	public static MeasureAttributes getMeasureAttr(TimeSignature timeSignature, KeySignature keySignature,
+	public static MeasureAttributes of(TimeSignature timeSignature, KeySignature keySignature,
 			Barline rightBarline,
 			Barline leftBarline, Clef clef) {
-		return getMeasureAttr(timeSignature, keySignature, rightBarline, leftBarline, clef, null);
+		return of(timeSignature, keySignature, rightBarline, leftBarline, clef, null);
 	}
 
 	/**
@@ -64,7 +64,7 @@ public final class MeasureAttributes {
 	 * @param clefChanges   the clef changes within the measure
 	 * @return an instance with the given values
 	 */
-	public static MeasureAttributes getMeasureAttr(TimeSignature timeSignature, KeySignature keySignature,
+	public static MeasureAttributes of(TimeSignature timeSignature, KeySignature keySignature,
 			Barline rightBarline,
 			Barline leftBarline, Clef clef, Map<Duration, Clef> clefChanges) {
 		// TODO: Potentially use interner pattern or similar for caching.

--- a/src/main/java/org/wmn4j/notation/elements/MultiStaffPart.java
+++ b/src/main/java/org/wmn4j/notation/elements/MultiStaffPart.java
@@ -61,7 +61,7 @@ public final class MultiStaffPart implements Part {
 
 	@Override
 	public String getName() {
-		return this.getPartAttribute(Part.Attribute.NAME);
+		return this.getAttribute(Part.Attribute.NAME);
 	}
 
 	@Override
@@ -104,7 +104,7 @@ public final class MultiStaffPart implements Part {
 	}
 
 	@Override
-	public String getPartAttribute(Attribute attribute) {
+	public String getAttribute(Attribute attribute) {
 		if (this.partAttributes.containsKey(attribute)) {
 			return this.partAttributes.get(attribute);
 		} else {

--- a/src/main/java/org/wmn4j/notation/elements/MultiStaffPart.java
+++ b/src/main/java/org/wmn4j/notation/elements/MultiStaffPart.java
@@ -17,22 +17,34 @@ import java.util.TreeMap;
  * Represents a score part with multiple staves such as are often used with
  * keyboard instruments. This class is immutable.
  */
-public class MultiStaffPart implements Part {
+public final class MultiStaffPart implements Part {
 
 	private final Map<Part.Attribute, String> partAttributes;
 	private final SortedMap<Integer, Staff> staves;
 
 	/**
-	 * Constructor. The staves are associated with numbers which are to be given as
-	 * keys in the map parameter.
+	 * Returns a part with multiple staves with the given values. The staves are
+	 * associated with numbers which are to be given as keys in the map parameter.
 	 *
 	 * @param name   the name of the part
 	 * @param staves the staves in the part
+	 * @return a part with multiple staves with the given values
 	 */
-	public MultiStaffPart(String name, Map<Integer, Staff> staves) {
-		this.partAttributes = new HashMap<>();
-		this.partAttributes.put(Part.Attribute.NAME, name);
-		this.staves = Collections.unmodifiableSortedMap(new TreeMap<>(staves));
+	public static MultiStaffPart of(String name, Map<Integer, Staff> staves) {
+		Map<Part.Attribute, String> attributes = new HashMap<>();
+		return new MultiStaffPart(attributes, staves);
+	}
+
+	/**
+	 * Returns a part with multiple staves with the given values. The staves are
+	 * associated with numbers which are to be given as keys in the map parameter.
+	 *
+	 * @param attributes the attributes of the part
+	 * @param staves     the staves in the part
+	 * @return a part with multiple staves with the given values
+	 */
+	public static MultiStaffPart of(Map<Part.Attribute, String> attributes, Map<Integer, Staff> staves) {
+		return new MultiStaffPart(attributes, staves);
 	}
 
 	/**
@@ -42,7 +54,7 @@ public class MultiStaffPart implements Part {
 	 * @param attributes the attributes of the part
 	 * @param staves     the staves in the part
 	 */
-	public MultiStaffPart(Map<Part.Attribute, String> attributes, Map<Integer, Staff> staves) {
+	private MultiStaffPart(Map<Part.Attribute, String> attributes, Map<Integer, Staff> staves) {
 		this.partAttributes = Collections.unmodifiableMap(new HashMap<>(attributes));
 		this.staves = Collections.unmodifiableSortedMap(new TreeMap<>(staves));
 	}

--- a/src/main/java/org/wmn4j/notation/elements/Note.java
+++ b/src/main/java/org/wmn4j/notation/elements/Note.java
@@ -37,8 +37,8 @@ public final class Note implements Durational, Pitched {
 	 * @param duration  the duration of the note. Must not be null
 	 * @return an instance with the given parameters
 	 */
-	public static Note getNote(Pitch.Base pitchName, int alter, int octave, Duration duration) {
-		return getNote(Pitch.getPitch(pitchName, alter, octave), duration, null);
+	public static Note of(Pitch.Base pitchName, int alter, int octave, Duration duration) {
+		return of(Pitch.getPitch(pitchName, alter, octave), duration, null);
 	}
 
 	/**
@@ -48,8 +48,8 @@ public final class Note implements Durational, Pitched {
 	 * @param duration the duration of the note
 	 * @return an instance with the given parameters
 	 */
-	public static Note getNote(Pitch pitch, Duration duration) {
-		return getNote(pitch, duration, null);
+	public static Note of(Pitch pitch, Duration duration) {
+		return of(pitch, duration, null);
 	}
 
 	/**
@@ -60,7 +60,7 @@ public final class Note implements Durational, Pitched {
 	 * @param articulations a set of Articulations associated with the note
 	 * @return an instance with the given parameters
 	 */
-	public static Note getNote(Pitch pitch, Duration duration, Set<Articulation> articulations) {
+	public static Note of(Pitch pitch, Duration duration, Set<Articulation> articulations) {
 		return new Note(pitch, duration, articulations, null, null, false);
 	}
 
@@ -73,7 +73,7 @@ public final class Note implements Durational, Pitched {
 	 * @param multiNoteArticulations list of the MultiNoteArticulations for the note
 	 * @return an instance with the given parameters
 	 */
-	public static Note getNote(Pitch pitch, Duration duration, Set<Articulation> articulations,
+	public static Note of(Pitch pitch, Duration duration, Set<Articulation> articulations,
 			List<MultiNoteArticulation> multiNoteArticulations) {
 		return new Note(pitch, duration, articulations, multiNoteArticulations, null, false);
 	}
@@ -89,7 +89,7 @@ public final class Note implements Durational, Pitched {
 	 * @param isTiedFromPrevious     true if this is tied from the previous note
 	 * @return an instance with the given parameters
 	 */
-	public static Note getNote(Pitch pitch, Duration duration, Set<Articulation> articulations,
+	public static Note of(Pitch pitch, Duration duration, Set<Articulation> articulations,
 			List<MultiNoteArticulation> multiNoteArticulations, Note tiedTo, boolean isTiedFromPrevious) {
 		return new Note(pitch, duration, articulations, multiNoteArticulations, tiedTo, isTiedFromPrevious);
 	}

--- a/src/main/java/org/wmn4j/notation/elements/Note.java
+++ b/src/main/java/org/wmn4j/notation/elements/Note.java
@@ -38,7 +38,7 @@ public final class Note implements Durational, Pitched {
 	 * @return an instance with the given parameters
 	 */
 	public static Note of(Pitch.Base pitchName, int alter, int octave, Duration duration) {
-		return of(Pitch.getPitch(pitchName, alter, octave), duration, null);
+		return of(Pitch.of(pitchName, alter, octave), duration, null);
 	}
 
 	/**

--- a/src/main/java/org/wmn4j/notation/elements/Part.java
+++ b/src/main/java/org/wmn4j/notation/elements/Part.java
@@ -47,7 +47,7 @@ public interface Part extends Iterable<Measure> {
 	 * @return the value of the attribute, or an empty string if the attribute is
 	 *         not set
 	 */
-	String getPartAttribute(Attribute attribute);
+	String getAttribute(Attribute attribute);
 
 	/**
 	 * Returns the number of measures in this part. The count is based on the

--- a/src/main/java/org/wmn4j/notation/elements/Pitch.java
+++ b/src/main/java/org/wmn4j/notation/elements/Pitch.java
@@ -89,7 +89,7 @@ public final class Pitch implements Comparable<Pitch> {
 	 * @param octave    the octave of the pitch
 	 * @return Pitch object with the specified attributes
 	 */
-	public static Pitch getPitch(Base pitchName, int alter, int octave) {
+	public static Pitch of(Base pitchName, int alter, int octave) {
 		if (alter > ALTER_LIMIT || alter < -1 * ALTER_LIMIT) {
 			throw new IllegalArgumentException(
 					"alter was " + alter + ". alter must be between -" + ALTER_LIMIT + " and " + ALTER_LIMIT);

--- a/src/main/java/org/wmn4j/notation/elements/Rest.java
+++ b/src/main/java/org/wmn4j/notation/elements/Rest.java
@@ -18,7 +18,7 @@ public final class Rest implements Durational {
 	 * @param duration the duration of the rest
 	 * @return Rest with specified duration
 	 */
-	public static Rest getRest(Duration duration) {
+	public static Rest of(Duration duration) {
 
 		// TODO: Use interner pattern for caching.
 		return new Rest(Objects.requireNonNull(duration));
@@ -26,7 +26,7 @@ public final class Rest implements Durational {
 
 	/**
 	 * Private constructor. Use the static method
-	 * {@link #getRest(wmnlibnotation.Duration) getRest} to get a <code>Rest</code>
+	 * {@link #of(wmnlibnotation.Duration) getRest} to get a <code>Rest</code>
 	 * object.
 	 *
 	 * @param duration the duration of the rest.

--- a/src/main/java/org/wmn4j/notation/elements/Score.java
+++ b/src/main/java/org/wmn4j/notation/elements/Score.java
@@ -17,7 +17,7 @@ import org.wmn4j.notation.iterators.ScorePosition;
  * Represents a score. This class is immutable.
  *
  */
-public class Score implements Iterable<Part> {
+public final class Score implements Iterable<Part> {
 
 	/**
 	 * Type for the different text attributes a score can have.
@@ -46,12 +46,23 @@ public class Score implements Iterable<Part> {
 	private final List<Part> parts;
 
 	/**
+	 * Returns a score with the given attributes and parts.
+	 *
+	 * @param attributes the attributes of the score
+	 * @param parts      the parts in the score
+	 * @return a score with the given attributes and parts
+	 */
+	public static Score of(Map<Attribute, String> attributes, List<Part> parts) {
+		return new Score(attributes, parts);
+	}
+
+	/**
 	 * Constructor.
 	 *
 	 * @param attributes the attributes of the score
 	 * @param parts      the parts in the score
 	 */
-	public Score(Map<Attribute, String> attributes, List<Part> parts) {
+	private Score(Map<Attribute, String> attributes, List<Part> parts) {
 		this.parts = Collections.unmodifiableList(new ArrayList<>(parts));
 		this.scoreAttr = Collections.unmodifiableMap(new HashMap<>(attributes));
 

--- a/src/main/java/org/wmn4j/notation/elements/SingleStaffPart.java
+++ b/src/main/java/org/wmn4j/notation/elements/SingleStaffPart.java
@@ -53,7 +53,7 @@ public final class SingleStaffPart implements Part {
 	 * @param measures       the measures in this part
 	 */
 	private SingleStaffPart(Map<Part.Attribute, String> partAttributes, List<Measure> measures) {
-		this.staff = new Staff(measures);
+		this.staff = Staff.of(measures);
 		this.partAttributes = Collections.unmodifiableMap(new HashMap<>(partAttributes));
 	}
 

--- a/src/main/java/org/wmn4j/notation/elements/SingleStaffPart.java
+++ b/src/main/java/org/wmn4j/notation/elements/SingleStaffPart.java
@@ -48,7 +48,7 @@ public class SingleStaffPart implements Part {
 
 	@Override
 	public String getName() {
-		return this.getPartAttribute(Attribute.NAME);
+		return this.getAttribute(Attribute.NAME);
 	}
 
 	@Override
@@ -96,7 +96,7 @@ public class SingleStaffPart implements Part {
 	}
 
 	@Override
-	public String getPartAttribute(Attribute attribute) {
+	public String getAttribute(Attribute attribute) {
 		if (this.partAttributes.containsKey(attribute)) {
 			return this.partAttributes.get(attribute);
 		} else {

--- a/src/main/java/org/wmn4j/notation/elements/SingleStaffPart.java
+++ b/src/main/java/org/wmn4j/notation/elements/SingleStaffPart.java
@@ -13,7 +13,7 @@ import java.util.NoSuchElementException;
 /**
  * Represents a part with a single staff in a score. This class is immutable.
  */
-public class SingleStaffPart implements Part {
+public final class SingleStaffPart implements Part {
 
 	/**
 	 * The default staff number for the staff in a single staff part.
@@ -23,16 +23,27 @@ public class SingleStaffPart implements Part {
 	private final Staff staff;
 
 	/**
-	 * Constructor.
+	 * Returns a part with a single staff with the given name and measures.
 	 *
 	 * @param name     the name of the part
 	 * @param measures the measures in this part
+	 * @return a part with a single staff with the given name and measures
 	 */
-	public SingleStaffPart(String name, List<Measure> measures) {
-		this.staff = new Staff(measures);
+	public static SingleStaffPart of(String name, List<Measure> measures) {
 		final Map<Part.Attribute, String> attributes = new HashMap<>();
 		attributes.put(Attribute.NAME, name);
-		this.partAttributes = Collections.unmodifiableMap(attributes);
+		return new SingleStaffPart(attributes, measures);
+	}
+
+	/**
+	 * Returns a part with a single staff with the given attributes and measures.
+	 *
+	 * @param partAttributes a map of attributes to be set for this part
+	 * @param measures       the measures in this part
+	 * @return a part with a single staff with the given attributes and measures
+	 */
+	public static SingleStaffPart of(Map<Part.Attribute, String> partAttributes, List<Measure> measures) {
+		return new SingleStaffPart(partAttributes, measures);
 	}
 
 	/**
@@ -41,7 +52,7 @@ public class SingleStaffPart implements Part {
 	 * @param partAttributes a map of attributes to be set for this part
 	 * @param measures       the measures in this part
 	 */
-	public SingleStaffPart(Map<Part.Attribute, String> partAttributes, List<Measure> measures) {
+	private SingleStaffPart(Map<Part.Attribute, String> partAttributes, List<Measure> measures) {
 		this.staff = new Staff(measures);
 		this.partAttributes = Collections.unmodifiableMap(new HashMap<>(partAttributes));
 	}

--- a/src/main/java/org/wmn4j/notation/elements/Staff.java
+++ b/src/main/java/org/wmn4j/notation/elements/Staff.java
@@ -12,7 +12,7 @@ import java.util.NoSuchElementException;
 /**
  * Represents a staff in a score. This class is immutable.
  */
-public class Staff implements Iterable<Measure> {
+public final class Staff implements Iterable<Measure> {
 
 	/**
 	 * Type of staff.
@@ -32,11 +32,21 @@ public class Staff implements Iterable<Measure> {
 	private final Type type;
 
 	/**
+	 * Returns a staff with the given measures.
+	 *
+	 * @param measures the measures in the staff
+	 * @return a staff with the given measures
+	 */
+	public static Staff of(List<Measure> measures) {
+		return new Staff(measures);
+	}
+
+	/**
 	 * Constructor.
 	 *
 	 * @param measures the measures in the staff.
 	 */
-	public Staff(List<Measure> measures) {
+	private Staff(List<Measure> measures) {
 		// TODO: Add constructor that allows setting staff type.
 		this.type = Type.NORMAL;
 

--- a/src/main/java/org/wmn4j/notation/elements/TimeSignature.java
+++ b/src/main/java/org/wmn4j/notation/elements/TimeSignature.java
@@ -22,8 +22,8 @@ public final class TimeSignature {
 	 * @param denominator the bottom number of the time signature.
 	 * @return a TimeSignature with the specified properties.
 	 */
-	public static TimeSignature getTimeSignature(int numerator, int denominator) {
-		return getTimeSignature(numerator, Duration.of(1, denominator));
+	public static TimeSignature of(int numerator, int denominator) {
+		return of(numerator, Duration.of(1, denominator));
 	}
 
 	/**
@@ -35,7 +35,7 @@ public final class TimeSignature {
 	 * @param beatDur the Duration of the beats.
 	 * @return a TimeSignature with the specified properties.
 	 */
-	public static TimeSignature getTimeSignature(int beats, Duration beatDur) {
+	public static TimeSignature of(int beats, Duration beatDur) {
 		if (beats < 1) {
 			throw new IllegalArgumentException("beats must be at least 1.");
 		}

--- a/src/main/java/org/wmn4j/notation/elements/TimeSignature.java
+++ b/src/main/java/org/wmn4j/notation/elements/TimeSignature.java
@@ -23,7 +23,7 @@ public final class TimeSignature {
 	 * @return a TimeSignature with the specified properties.
 	 */
 	public static TimeSignature getTimeSignature(int numerator, int denominator) {
-		return getTimeSignature(numerator, Duration.getDuration(1, denominator));
+		return getTimeSignature(numerator, Duration.of(1, denominator));
 	}
 
 	/**

--- a/src/main/java/org/wmn4j/notation/elements/TimeSignature.java
+++ b/src/main/java/org/wmn4j/notation/elements/TimeSignature.java
@@ -16,31 +16,31 @@ public final class TimeSignature {
 	private final Duration beatDuration;
 
 	/**
-	 * Get an instance of <code>TimeSignature</code>.
+	 * Returns a time signature with the given numerator and denominator.
 	 *
-	 * @param numerator   the top number of the time signature.
-	 * @param denominator the bottom number of the time signature.
-	 * @return a TimeSignature with the specified properties.
+	 * @param numerator   the top number of the time signature
+	 * @param denominator the bottom number of the time signature
+	 * @return a time signature with the given numerator and denominator
 	 */
 	public static TimeSignature of(int numerator, int denominator) {
 		return of(numerator, Duration.of(1, denominator));
 	}
 
 	/**
-	 * Get an instance of <code>TimeSignature</code>.
+	 * Returns a time signature with the given numerator and beat duration.
 	 *
-	 * @throws IllegalArgumentException if beats is less than 1.
-	 * @throws NullPointerException     if beatDur is null.
-	 * @param beats   number of beats in measure.
-	 * @param beatDur the Duration of the beats.
-	 * @return a TimeSignature with the specified properties.
+	 * @throws IllegalArgumentException if beats is less than 1
+	 * @throws NullPointerException     if beatDuration is null
+	 * @param beats        number of beats in measure
+	 * @param beatDuration the Duration of the beats
+	 * @return a time signature with the given numerator and beat duration
 	 */
-	public static TimeSignature of(int beats, Duration beatDur) {
+	public static TimeSignature of(int beats, Duration beatDuration) {
 		if (beats < 1) {
 			throw new IllegalArgumentException("beats must be at least 1.");
 		}
 
-		return new TimeSignature(beats, Objects.requireNonNull(beatDur));
+		return new TimeSignature(beats, Objects.requireNonNull(beatDuration));
 	}
 
 	private TimeSignature(int beats, Duration beatDuration) {

--- a/src/main/java/org/wmn4j/notation/elements/TimeSignatures.java
+++ b/src/main/java/org/wmn4j/notation/elements/TimeSignatures.java
@@ -11,27 +11,27 @@ public final class TimeSignatures {
 	/**
 	 * The time signature 4/4.
 	 */
-	public static final TimeSignature FOUR_FOUR = TimeSignature.getTimeSignature(4, 4);
+	public static final TimeSignature FOUR_FOUR = TimeSignature.of(4, 4);
 
 	/**
 	 * The time signature 3/4.
 	 */
-	public static final TimeSignature THREE_FOUR = TimeSignature.getTimeSignature(3, 4);
+	public static final TimeSignature THREE_FOUR = TimeSignature.of(3, 4);
 
 	/**
 	 * The time signature "/4.
 	 */
-	public static final TimeSignature TWO_FOUR = TimeSignature.getTimeSignature(2, 4);
+	public static final TimeSignature TWO_FOUR = TimeSignature.of(2, 4);
 
 	/**
 	 * The time signature 3/8.
 	 */
-	public static final TimeSignature THREE_EIGHT = TimeSignature.getTimeSignature(3, 8);
+	public static final TimeSignature THREE_EIGHT = TimeSignature.of(3, 8);
 
 	/**
 	 * The time signature 6/8.
 	 */
-	public static final TimeSignature SIX_EIGHT = TimeSignature.getTimeSignature(6, 8);
+	public static final TimeSignature SIX_EIGHT = TimeSignature.of(6, 8);
 
 	private TimeSignatures() {
 		// Not meant to be instantiated.

--- a/src/test/java/org/wmn4j/analysis/harmony/PCProfileTest.java
+++ b/src/test/java/org/wmn4j/analysis/harmony/PCProfileTest.java
@@ -25,10 +25,10 @@ public class PCProfileTest {
 	// By how much values are allowed fo differ
 	static final double EPS = 0.0000000001;
 
-	static final Note C4 = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
-	static final Note E4 = Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT);
-	static final Note G4 = Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT);
-	static final Note Csharp4 = Note.of(Pitch.getPitch(Pitch.Base.C, 1, 4), Durations.SIXTEENTH);
+	static final Note C4 = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+	static final Note E4 = Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT);
+	static final Note G4 = Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHT);
+	static final Note Csharp4 = Note.of(Pitch.of(Pitch.Base.C, 1, 4), Durations.SIXTEENTH);
 
 	public PCProfileTest() {
 	}

--- a/src/test/java/org/wmn4j/analysis/harmony/PCProfileTest.java
+++ b/src/test/java/org/wmn4j/analysis/harmony/PCProfileTest.java
@@ -25,10 +25,10 @@ public class PCProfileTest {
 	// By how much values are allowed fo differ
 	static final double EPS = 0.0000000001;
 
-	static final Note C4 = Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
-	static final Note E4 = Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT);
-	static final Note G4 = Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT);
-	static final Note Csharp4 = Note.getNote(Pitch.getPitch(Pitch.Base.C, 1, 4), Durations.SIXTEENTH);
+	static final Note C4 = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+	static final Note E4 = Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT);
+	static final Note G4 = Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT);
+	static final Note Csharp4 = Note.of(Pitch.getPitch(Pitch.Base.C, 1, 4), Durations.SIXTEENTH);
 
 	public PCProfileTest() {
 	}

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
@@ -381,10 +381,10 @@ public class MusicXmlReaderDomTest {
 		final Score score = readScore("timesigs.xml");
 		assertEquals(1, score.getPartCount());
 		final SingleStaffPart part = (SingleStaffPart) score.getParts().get(0);
-		assertEquals(TimeSignature.getTimeSignature(2, 2), part.getMeasure(1).getTimeSignature());
-		assertEquals(TimeSignature.getTimeSignature(3, 4), part.getMeasure(2).getTimeSignature());
-		assertEquals(TimeSignature.getTimeSignature(6, 8), part.getMeasure(3).getTimeSignature());
-		assertEquals(TimeSignature.getTimeSignature(15, 16), part.getMeasure(4).getTimeSignature());
+		assertEquals(TimeSignature.of(2, 2), part.getMeasure(1).getTimeSignature());
+		assertEquals(TimeSignature.of(3, 4), part.getMeasure(2).getTimeSignature());
+		assertEquals(TimeSignature.of(6, 8), part.getMeasure(3).getTimeSignature());
+		assertEquals(TimeSignature.of(15, 16), part.getMeasure(4).getTimeSignature());
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
@@ -128,7 +128,7 @@ public class MusicXmlReaderDomTest {
 		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voiceOne.get(1));
 		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voiceOne.get(2));
 		assertEquals(Rest.getRest(Durations.EIGHT), voiceOne.get(3));
-		final Chord cMajor = Chord.getChord(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT),
+		final Chord cMajor = Chord.of(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT),
 				Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT),
 				Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT));
 		assertEquals(cMajor, voiceOne.get(4));

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
@@ -127,7 +127,7 @@ public class MusicXmlReaderDomTest {
 		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceOne.get(0));
 		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT), voiceOne.get(1));
 		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT), voiceOne.get(2));
-		assertEquals(Rest.getRest(Durations.EIGHT), voiceOne.get(3));
+		assertEquals(Rest.of(Durations.EIGHT), voiceOne.get(3));
 		final Chord cMajor = Chord.of(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT),
 				Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT),
 				Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHT));
@@ -154,7 +154,7 @@ public class MusicXmlReaderDomTest {
 		final List<Durational> voiceTwo = measureTwo.getVoice(2);
 		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(0));
 		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(1));
-		assertEquals(Rest.getRest(Durations.QUARTER), voiceTwo.get(2));
+		assertEquals(Rest.of(Durations.QUARTER), voiceTwo.get(2));
 		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(3));
 	}
 
@@ -198,7 +198,7 @@ public class MusicXmlReaderDomTest {
 		// Verify contents of measure one of staff one
 		assertEquals(1, staffOneMeasureTwo.getVoiceCount());
 		final List<Durational> voiceM2 = staffOneMeasureTwo.getVoice(1);
-		assertEquals(Rest.getRest(Durations.QUARTER), voiceM2.get(0));
+		assertEquals(Rest.of(Durations.QUARTER), voiceM2.get(0));
 		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF), voiceM2.get(1));
 
 		final SingleStaffPart partTwo = (SingleStaffPart) score.getParts().get(1);

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
@@ -282,10 +282,10 @@ public class MusicXmlReaderDomTest {
 		assertEquals(Clefs.ALTO, part.getMeasure(2).getClef());
 		assertFalse(part.getMeasure(2).containsClefChanges());
 
-		assertEquals(Clef.getClef(Clef.Symbol.C, 4), part.getMeasure(3).getClef());
+		assertEquals(Clef.of(Clef.Symbol.C, 4), part.getMeasure(3).getClef());
 		assertFalse(part.getMeasure(3).containsClefChanges());
 
-		assertEquals(Clef.getClef(Clef.Symbol.C, 4), part.getMeasure(4).getClef());
+		assertEquals(Clef.of(Clef.Symbol.C, 4), part.getMeasure(4).getClef());
 		assertTrue(part.getMeasure(4).containsClefChanges());
 		final Map<Duration, Clef> clefChanges = part.getMeasure(4).getClefChanges();
 		assertEquals(2, clefChanges.size());

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
@@ -94,7 +94,7 @@ public class MusicXmlReaderDomTest {
 
 		final List<Durational> voice = measure.getVoice(1);
 		assertEquals(1, voice.size());
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.WHOLE), voice.get(0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.WHOLE), voice.get(0));
 	}
 
 	@Test
@@ -124,17 +124,17 @@ public class MusicXmlReaderDomTest {
 		// Verify notes of measure one
 		List<Durational> voiceOne = measureOne.getVoice(1);
 		assertEquals(8, voiceOne.size());
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceOne.get(0));
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voiceOne.get(1));
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voiceOne.get(2));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceOne.get(0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT), voiceOne.get(1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT), voiceOne.get(2));
 		assertEquals(Rest.getRest(Durations.EIGHT), voiceOne.get(3));
-		final Chord cMajor = Chord.of(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT),
-				Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT),
-				Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT));
+		final Chord cMajor = Chord.of(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT),
+				Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT),
+				Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHT));
 		assertEquals(cMajor, voiceOne.get(4));
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT_TRIPLET), voiceOne.get(5));
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT_TRIPLET), voiceOne.get(6));
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT_TRIPLET), voiceOne.get(7));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHT_TRIPLET), voiceOne.get(5));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHT_TRIPLET), voiceOne.get(6));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHT_TRIPLET), voiceOne.get(7));
 
 		// Verify data of measure two
 		final Measure measureTwo = staff.getMeasures().get(1);
@@ -148,14 +148,14 @@ public class MusicXmlReaderDomTest {
 		// Verify notes of measure two
 		voiceOne = measureTwo.getVoice(1);
 		assertEquals(2, voiceOne.size());
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.HALF), voiceOne.get(0));
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.HALF), voiceOne.get(1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.HALF), voiceOne.get(0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.HALF), voiceOne.get(1));
 
 		final List<Durational> voiceTwo = measureTwo.getVoice(2);
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(0));
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(1));
 		assertEquals(Rest.getRest(Durations.QUARTER), voiceTwo.get(2));
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(3));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(3));
 	}
 
 	@Test
@@ -183,8 +183,8 @@ public class MusicXmlReaderDomTest {
 		// Verify contents of measure one of staff one
 		assertEquals(1, staffOneMeasureOne.getVoiceCount());
 		final List<Durational> voiceMOne = staffOneMeasureOne.getVoice(1);
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.HALF), voiceMOne.get(0));
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER), voiceMOne.get(1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF), voiceMOne.get(0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER), voiceMOne.get(1));
 
 		// Verify data of measure two of staff one
 		final Measure staffOneMeasureTwo = staffOne.getMeasures().get(1);
@@ -199,7 +199,7 @@ public class MusicXmlReaderDomTest {
 		assertEquals(1, staffOneMeasureTwo.getVoiceCount());
 		final List<Durational> voiceM2 = staffOneMeasureTwo.getVoice(1);
 		assertEquals(Rest.getRest(Durations.QUARTER), voiceM2.get(0));
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.HALF), voiceM2.get(1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF), voiceM2.get(1));
 
 		final SingleStaffPart partTwo = (SingleStaffPart) score.getParts().get(1);
 		final Staff staffTwo = partTwo.getStaff();
@@ -218,7 +218,7 @@ public class MusicXmlReaderDomTest {
 		// Verify contents of measure one of staff two
 		assertEquals(1, staffTwoMeasureOne.getVoiceCount());
 		final List<Durational> voiceMOneS2 = staffTwoMeasureOne.getVoice(1);
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 3), Durations.HALF.addDot()), voiceMOneS2.get(0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 3), Durations.HALF.addDot()), voiceMOneS2.get(0));
 
 		// Verify data of measure two of staff two
 		final Measure staffTwoMeasureTwo = staffTwo.getMeasures().get(1);
@@ -232,7 +232,7 @@ public class MusicXmlReaderDomTest {
 		// Verify contents of measure two of staff two
 		assertEquals(1, staffTwoMeasureTwo.getVoiceCount());
 		final List<Durational> voiceM2S2 = staffTwoMeasureTwo.getVoice(1);
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 3), Durations.HALF.addDot()), voiceM2S2.get(0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 3), Durations.HALF.addDot()), voiceM2S2.get(0));
 	}
 
 	@Test
@@ -363,7 +363,7 @@ public class MusicXmlReaderDomTest {
 		assertEquals(2, multiStaff.getStaffCount());
 
 		int measureCount = 0;
-		final Note expectedNote = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.WHOLE);
+		final Note expectedNote = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.WHOLE);
 
 		for (Measure measure : multiStaff) {
 			assertTrue(measure.isSingleVoice());
@@ -403,7 +403,7 @@ public class MusicXmlReaderDomTest {
 		final Measure firstMeasure = part.getMeasure(1);
 		final Note first = (Note) firstMeasure.get(1, 0);
 		assertTrue(first.isTiedToFollowing());
-		assertEquals(Pitch.getPitch(Pitch.Base.C, 0, 4), first.getFollowingTiedNote().get().getPitch());
+		assertEquals(Pitch.of(Pitch.Base.C, 0, 4), first.getFollowingTiedNote().get().getPitch());
 
 		final Note second = (Note) firstMeasure.get(1, 1);
 		assertTrue(second.isTiedFromPrevious());

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
@@ -94,7 +94,7 @@ public class MusicXmlReaderDomTest {
 
 		final List<Durational> voice = measure.getVoice(1);
 		assertEquals(1, voice.size());
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.WHOLE), voice.get(0));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.WHOLE), voice.get(0));
 	}
 
 	@Test
@@ -124,17 +124,17 @@ public class MusicXmlReaderDomTest {
 		// Verify notes of measure one
 		List<Durational> voiceOne = measureOne.getVoice(1);
 		assertEquals(8, voiceOne.size());
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceOne.get(0));
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voiceOne.get(1));
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voiceOne.get(2));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceOne.get(0));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voiceOne.get(1));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voiceOne.get(2));
 		assertEquals(Rest.getRest(Durations.EIGHT), voiceOne.get(3));
-		final Chord cMajor = Chord.of(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT),
-				Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT),
-				Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT));
+		final Chord cMajor = Chord.of(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT),
+				Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT),
+				Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT));
 		assertEquals(cMajor, voiceOne.get(4));
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT_TRIPLET), voiceOne.get(5));
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT_TRIPLET), voiceOne.get(6));
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT_TRIPLET), voiceOne.get(7));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT_TRIPLET), voiceOne.get(5));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT_TRIPLET), voiceOne.get(6));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT_TRIPLET), voiceOne.get(7));
 
 		// Verify data of measure two
 		final Measure measureTwo = staff.getMeasures().get(1);
@@ -148,14 +148,14 @@ public class MusicXmlReaderDomTest {
 		// Verify notes of measure two
 		voiceOne = measureTwo.getVoice(1);
 		assertEquals(2, voiceOne.size());
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.HALF), voiceOne.get(0));
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.HALF), voiceOne.get(1));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.HALF), voiceOne.get(0));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.HALF), voiceOne.get(1));
 
 		final List<Durational> voiceTwo = measureTwo.getVoice(2);
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(0));
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(1));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(0));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(1));
 		assertEquals(Rest.getRest(Durations.QUARTER), voiceTwo.get(2));
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(3));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(3));
 	}
 
 	@Test
@@ -183,8 +183,8 @@ public class MusicXmlReaderDomTest {
 		// Verify contents of measure one of staff one
 		assertEquals(1, staffOneMeasureOne.getVoiceCount());
 		final List<Durational> voiceMOne = staffOneMeasureOne.getVoice(1);
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.HALF), voiceMOne.get(0));
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER), voiceMOne.get(1));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.HALF), voiceMOne.get(0));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER), voiceMOne.get(1));
 
 		// Verify data of measure two of staff one
 		final Measure staffOneMeasureTwo = staffOne.getMeasures().get(1);
@@ -199,7 +199,7 @@ public class MusicXmlReaderDomTest {
 		assertEquals(1, staffOneMeasureTwo.getVoiceCount());
 		final List<Durational> voiceM2 = staffOneMeasureTwo.getVoice(1);
 		assertEquals(Rest.getRest(Durations.QUARTER), voiceM2.get(0));
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.HALF), voiceM2.get(1));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.HALF), voiceM2.get(1));
 
 		final SingleStaffPart partTwo = (SingleStaffPart) score.getParts().get(1);
 		final Staff staffTwo = partTwo.getStaff();
@@ -218,7 +218,7 @@ public class MusicXmlReaderDomTest {
 		// Verify contents of measure one of staff two
 		assertEquals(1, staffTwoMeasureOne.getVoiceCount());
 		final List<Durational> voiceMOneS2 = staffTwoMeasureOne.getVoice(1);
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 3), Durations.HALF.addDot()), voiceMOneS2.get(0));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 3), Durations.HALF.addDot()), voiceMOneS2.get(0));
 
 		// Verify data of measure two of staff two
 		final Measure staffTwoMeasureTwo = staffTwo.getMeasures().get(1);
@@ -232,7 +232,7 @@ public class MusicXmlReaderDomTest {
 		// Verify contents of measure two of staff two
 		assertEquals(1, staffTwoMeasureTwo.getVoiceCount());
 		final List<Durational> voiceM2S2 = staffTwoMeasureTwo.getVoice(1);
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 3), Durations.HALF.addDot()), voiceM2S2.get(0));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 3), Durations.HALF.addDot()), voiceM2S2.get(0));
 	}
 
 	@Test
@@ -363,7 +363,7 @@ public class MusicXmlReaderDomTest {
 		assertEquals(2, multiStaff.getStaffCount());
 
 		int measureCount = 0;
-		final Note expectedNote = Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.WHOLE);
+		final Note expectedNote = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.WHOLE);
 
 		for (Measure measure : multiStaff) {
 			assertTrue(measure.isSingleVoice());

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -58,7 +58,7 @@ public class MonophonicPatternTest {
 		}
 
 		final List<Durational> chordList = new ArrayList<>();
-		chordList.add(Chord.getChord(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT),
+		chordList.add(Chord.of(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT),
 				Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT)));
 
 		try {

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -32,7 +32,7 @@ public class MonophonicPatternTest {
 		final List<Durational> notes = new ArrayList<>();
 		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT));
 		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHT));
-		notes.add(Rest.getRest(Durations.QUARTER));
+		notes.add(Rest.of(Durations.QUARTER));
 		notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
 		notes.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
 
@@ -77,7 +77,7 @@ public class MonophonicPatternTest {
 		assertEquals(pattern1, pattern2);
 
 		final List<Durational> modifiedNotes = new ArrayList<>(this.referenceNotes);
-		modifiedNotes.add(Rest.getRest(Durations.QUARTER));
+		modifiedNotes.add(Rest.of(Durations.QUARTER));
 
 		assertFalse(pattern1.equals(new MonophonicPattern(modifiedNotes)));
 	}
@@ -89,13 +89,13 @@ public class MonophonicPatternTest {
 		final List<Durational> notes = new ArrayList<>();
 		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
 		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
-		notes.add(Rest.getRest(Durations.QUARTER));
+		notes.add(Rest.of(Durations.QUARTER));
 		notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
 		notes.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.WHOLE));
 
 		assertTrue(pattern1.equalsInPitch(new MonophonicPattern(notes)));
 
-		notes.add(Rest.getRest(Durations.QUARTER));
+		notes.add(Rest.of(Durations.QUARTER));
 
 		assertTrue("Adding rest to end of pattern should not make pattern inequal in pitches",
 				pattern1.equalsInPitch(new MonophonicPattern(notes)));
@@ -112,7 +112,7 @@ public class MonophonicPatternTest {
 		final List<Durational> notes = new ArrayList<>();
 		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
 		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
-		notes.add(Rest.getRest(Durations.QUARTER));
+		notes.add(Rest.of(Durations.QUARTER));
 		notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
 		notes.add(Note.of(Pitch.of(Pitch.Base.A, 1, 3), Durations.WHOLE));
 

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -30,11 +30,11 @@ public class MonophonicPatternTest {
 
 	public MonophonicPatternTest() {
 		final List<Durational> notes = new ArrayList<>();
-		notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT));
-		notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT));
+		notes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT));
+		notes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT));
 		notes.add(Rest.getRest(Durations.QUARTER));
-		notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER));
-		notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.B, -1, 3), Durations.QUARTER));
+		notes.add(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER));
+		notes.add(Note.of(Pitch.getPitch(Pitch.Base.B, -1, 3), Durations.QUARTER));
 
 		this.referenceNotes = Collections.unmodifiableList(notes);
 	}
@@ -58,8 +58,8 @@ public class MonophonicPatternTest {
 		}
 
 		final List<Durational> chordList = new ArrayList<>();
-		chordList.add(Chord.of(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT),
-				Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT)));
+		chordList.add(Chord.of(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT),
+				Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT)));
 
 		try {
 			new MonophonicPattern(chordList);
@@ -87,11 +87,11 @@ public class MonophonicPatternTest {
 		final MonophonicPattern pattern1 = new MonophonicPattern(this.referenceNotes);
 
 		final List<Durational> notes = new ArrayList<>();
-		notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
+		notes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		notes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
 		notes.add(Rest.getRest(Durations.QUARTER));
-		notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER));
-		notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.B, -1, 3), Durations.WHOLE));
+		notes.add(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER));
+		notes.add(Note.of(Pitch.getPitch(Pitch.Base.B, -1, 3), Durations.WHOLE));
 
 		assertTrue(pattern1.equalsInPitch(new MonophonicPattern(notes)));
 
@@ -100,7 +100,7 @@ public class MonophonicPatternTest {
 		assertTrue("Adding rest to end of pattern should not make pattern inequal in pitches",
 				pattern1.equalsInPitch(new MonophonicPattern(notes)));
 
-		notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.E, -1, 3), Durations.WHOLE));
+		notes.add(Note.of(Pitch.getPitch(Pitch.Base.E, -1, 3), Durations.WHOLE));
 
 		assertFalse(pattern1.equalsInPitch(new MonophonicPattern(notes)));
 	}
@@ -110,11 +110,11 @@ public class MonophonicPatternTest {
 		final MonophonicPattern pattern1 = new MonophonicPattern(this.referenceNotes);
 
 		final List<Durational> notes = new ArrayList<>();
-		notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
+		notes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		notes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
 		notes.add(Rest.getRest(Durations.QUARTER));
-		notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER));
-		notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.A, 1, 3), Durations.WHOLE));
+		notes.add(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER));
+		notes.add(Note.of(Pitch.getPitch(Pitch.Base.A, 1, 3), Durations.WHOLE));
 
 		assertTrue(pattern1.equalsEnharmonicallyInPitch(new MonophonicPattern(notes)));
 	}

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -30,11 +30,11 @@ public class MonophonicPatternTest {
 
 	public MonophonicPatternTest() {
 		final List<Durational> notes = new ArrayList<>();
-		notes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT));
-		notes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT));
+		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT));
+		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHT));
 		notes.add(Rest.getRest(Durations.QUARTER));
-		notes.add(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER));
-		notes.add(Note.of(Pitch.getPitch(Pitch.Base.B, -1, 3), Durations.QUARTER));
+		notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
+		notes.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
 
 		this.referenceNotes = Collections.unmodifiableList(notes);
 	}
@@ -58,8 +58,8 @@ public class MonophonicPatternTest {
 		}
 
 		final List<Durational> chordList = new ArrayList<>();
-		chordList.add(Chord.of(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT),
-				Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT)));
+		chordList.add(Chord.of(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT),
+				Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT)));
 
 		try {
 			new MonophonicPattern(chordList);
@@ -87,11 +87,11 @@ public class MonophonicPatternTest {
 		final MonophonicPattern pattern1 = new MonophonicPattern(this.referenceNotes);
 
 		final List<Durational> notes = new ArrayList<>();
-		notes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		notes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
+		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
 		notes.add(Rest.getRest(Durations.QUARTER));
-		notes.add(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER));
-		notes.add(Note.of(Pitch.getPitch(Pitch.Base.B, -1, 3), Durations.WHOLE));
+		notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
+		notes.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.WHOLE));
 
 		assertTrue(pattern1.equalsInPitch(new MonophonicPattern(notes)));
 
@@ -100,7 +100,7 @@ public class MonophonicPatternTest {
 		assertTrue("Adding rest to end of pattern should not make pattern inequal in pitches",
 				pattern1.equalsInPitch(new MonophonicPattern(notes)));
 
-		notes.add(Note.of(Pitch.getPitch(Pitch.Base.E, -1, 3), Durations.WHOLE));
+		notes.add(Note.of(Pitch.of(Pitch.Base.E, -1, 3), Durations.WHOLE));
 
 		assertFalse(pattern1.equalsInPitch(new MonophonicPattern(notes)));
 	}
@@ -110,11 +110,11 @@ public class MonophonicPatternTest {
 		final MonophonicPattern pattern1 = new MonophonicPattern(this.referenceNotes);
 
 		final List<Durational> notes = new ArrayList<>();
-		notes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		notes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
+		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
 		notes.add(Rest.getRest(Durations.QUARTER));
-		notes.add(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER));
-		notes.add(Note.of(Pitch.getPitch(Pitch.Base.A, 1, 3), Durations.WHOLE));
+		notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
+		notes.add(Note.of(Pitch.of(Pitch.Base.A, 1, 3), Durations.WHOLE));
 
 		assertTrue(pattern1.equalsEnharmonicallyInPitch(new MonophonicPattern(notes)));
 	}

--- a/src/test/java/org/wmn4j/notation/TestHelper.java
+++ b/src/test/java/org/wmn4j/notation/TestHelper.java
@@ -26,10 +26,10 @@ public class TestHelper {
 
 	public static final String TESTFILE_PATH = "src/test/resources/";
 
-	private static final NoteBuilder C4 = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.HALF);
-	private static final NoteBuilder E4 = new NoteBuilder(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.HALF);
-	private static final NoteBuilder G4 = new NoteBuilder(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.HALF);
-	private static final NoteBuilder C4Quarter = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+	private static final NoteBuilder C4 = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.HALF);
+	private static final NoteBuilder E4 = new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.HALF);
+	private static final NoteBuilder G4 = new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF);
+	private static final NoteBuilder C4Quarter = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
 
 	public static MeasureBuilder getTestMeasureBuilder(int number) {
 		final MeasureBuilder builder = new MeasureBuilder(number);

--- a/src/test/java/org/wmn4j/notation/builders/ChordBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/ChordBuilderTest.java
@@ -35,9 +35,9 @@ public class ChordBuilderTest {
 
 		final Chord chord = builder.build();
 		assertEquals(3, chord.getNoteCount());
-		assertTrue(chord.contains(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.getNote(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER)));
 	}
 
 	@Test
@@ -49,9 +49,9 @@ public class ChordBuilderTest {
 
 		final Chord chord = builder.build();
 		assertEquals(3, chord.getNoteCount());
-		assertTrue(chord.contains(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.getNote(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER)));
 	}
 
 	@Test
@@ -63,7 +63,7 @@ public class ChordBuilderTest {
 
 		final Chord chord = builder.build();
 		assertEquals(1, chord.getNoteCount());
-		assertTrue(chord.contains(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
 	}
 
 	@Test
@@ -77,10 +77,10 @@ public class ChordBuilderTest {
 
 		final Chord chord = builder.build();
 		assertEquals(4, chord.getNoteCount());
-		assertTrue(chord.contains(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.getNote(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.getNote(Pitch.getPitch(Pitch.Base.B, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.B, 0, 4), Durations.QUARTER)));
 	}
 
 	@Test
@@ -112,7 +112,7 @@ public class ChordBuilderTest {
 
 		final Chord chord = chordBuilder.build();
 		assertEquals(2, chord.getNoteCount());
-		assertTrue(chord.contains(Note.getNote(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER)));
 	}
 }

--- a/src/test/java/org/wmn4j/notation/builders/ChordBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/ChordBuilderTest.java
@@ -17,9 +17,9 @@ public class ChordBuilderTest {
 	}
 
 	private List<NoteBuilder> getCMajorAsNoteBuilders() {
-		final NoteBuilder first = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		final NoteBuilder second = new NoteBuilder(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER);
-		final NoteBuilder third = new NoteBuilder(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER);
+		final NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER);
+		final NoteBuilder third = new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER);
 
 		final List<NoteBuilder> cMajor = new ArrayList<>();
 		cMajor.add(first);
@@ -35,9 +35,9 @@ public class ChordBuilderTest {
 
 		final Chord chord = builder.build();
 		assertEquals(3, chord.getNoteCount());
-		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER)));
 	}
 
 	@Test
@@ -45,25 +45,25 @@ public class ChordBuilderTest {
 		final List<NoteBuilder> cMajor = getCMajorAsNoteBuilders();
 
 		final ChordBuilder builder = new ChordBuilder(cMajor);
-		cMajor.get(0).setPitch(Pitch.getPitch(Pitch.Base.B, 0, 4));
+		cMajor.get(0).setPitch(Pitch.of(Pitch.Base.B, 0, 4));
 
 		final Chord chord = builder.build();
 		assertEquals(3, chord.getNoteCount());
-		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER)));
 	}
 
 	@Test
 	public void testConstructorWithSingleNoteBuilderCopiesNoteBuilder() {
-		final NoteBuilder note = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final NoteBuilder note = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
 		final ChordBuilder builder = new ChordBuilder(note);
 
-		note.setPitch(Pitch.getPitch(Pitch.Base.D, 0, 4));
+		note.setPitch(Pitch.of(Pitch.Base.D, 0, 4));
 
 		final Chord chord = builder.build();
 		assertEquals(1, chord.getNoteCount());
-		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER)));
 	}
 
 	@Test
@@ -71,16 +71,16 @@ public class ChordBuilderTest {
 		final List<NoteBuilder> cMajor = getCMajorAsNoteBuilders();
 		final ChordBuilder builder = new ChordBuilder(cMajor);
 
-		final NoteBuilder note = new NoteBuilder(Pitch.getPitch(Pitch.Base.B, 0, 4), Durations.QUARTER);
+		final NoteBuilder note = new NoteBuilder(Pitch.of(Pitch.Base.B, 0, 4), Durations.QUARTER);
 		builder.add(note);
-		note.setPitch(Pitch.getPitch(Pitch.Base.A, 0, 4));
+		note.setPitch(Pitch.of(Pitch.Base.A, 0, 4));
 
 		final Chord chord = builder.build();
 		assertEquals(4, chord.getNoteCount());
-		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.B, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.B, 0, 4), Durations.QUARTER)));
 	}
 
 	@Test
@@ -108,11 +108,11 @@ public class ChordBuilderTest {
 	@Test
 	public void testRemoveIf() {
 		final ChordBuilder chordBuilder = new ChordBuilder(getCMajorAsNoteBuilders());
-		chordBuilder.removeIf((NoteBuilder nb) -> nb.getPitch().equals(Pitch.getPitch(Pitch.Base.C, 0, 4)));
+		chordBuilder.removeIf((NoteBuilder nb) -> nb.getPitch().equals(Pitch.of(Pitch.Base.C, 0, 4)));
 
 		final Chord chord = chordBuilder.build();
 		assertEquals(2, chord.getNoteCount());
-		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER)));
 	}
 }

--- a/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
@@ -64,7 +64,7 @@ public class MeasureBuilderTest {
 
 	@Test
 	public void testBuildMeasureWithGivenAttributes() {
-		final MeasureAttributes measureAttr = MeasureAttributes.getMeasureAttr(TimeSignatures.SIX_EIGHT,
+		final MeasureAttributes measureAttr = MeasureAttributes.of(TimeSignatures.SIX_EIGHT,
 				KeySignatures.DFLATMAJ_BFLATMIN, Barline.DOUBLE, Clefs.F);
 		final MeasureBuilder builder = new MeasureBuilder(1, measureAttr);
 
@@ -91,7 +91,7 @@ public class MeasureBuilderTest {
 
 	@Test
 	public void testSetParametersUsedOverMeasureAttributes() {
-		final MeasureAttributes measureAttr = MeasureAttributes.getMeasureAttr(TimeSignatures.THREE_EIGHT,
+		final MeasureAttributes measureAttr = MeasureAttributes.of(TimeSignatures.THREE_EIGHT,
 				KeySignatures.AMAJ_FSHARPMIN, Barline.REPEAT_RIGHT, Clefs.ALTO);
 		final MeasureBuilder builder = new MeasureBuilder(1, measureAttr);
 

--- a/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
@@ -133,9 +133,9 @@ public class MeasureBuilderTest {
 		final Measure measure = builder.build();
 		assertEquals(2, measure.getVoiceCount());
 		assertTrue(measure.getVoice(1).size() == 1);
-		assertTrue(measure.getVoice(1).contains(Rest.getRest(Durations.EIGHT)));
+		assertTrue(measure.getVoice(1).contains(Rest.of(Durations.EIGHT)));
 		assertTrue(measure.getVoice(3).size() == 1);
-		assertTrue(measure.getVoice(3).contains(Rest.getRest(Durations.EIGHT)));
+		assertTrue(measure.getVoice(3).contains(Rest.of(Durations.EIGHT)));
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
@@ -43,9 +43,9 @@ public class MeasureBuilderTest {
 
 		builder.addVoice();
 		assertEquals(1, builder.getNumberOfVoices());
-		builder.addToVoice(0, new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT))
-		.addToVoice(0, new NoteBuilder(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT))
-		.addToVoice(0, new NoteBuilder(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT));
+		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT))
+		.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT))
+		.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHT));
 
 		final Measure measure = builder.build();
 		assertTrue(measure != null);
@@ -57,9 +57,9 @@ public class MeasureBuilderTest {
 
 		assertEquals(1, measure.getVoiceCount());
 		final List<Durational> voice = measure.getVoice(0);
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voice.get(0));
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT), voice.get(1));
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT), voice.get(2));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT), voice.get(0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT), voice.get(1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHT), voice.get(2));
 	}
 
 	@Test
@@ -70,9 +70,9 @@ public class MeasureBuilderTest {
 
 		builder.addVoice();
 		assertEquals(1, builder.getNumberOfVoices());
-		builder.addToVoice(0, new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT))
-		.addToVoice(0, new NoteBuilder(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT))
-		.addToVoice(0, new NoteBuilder(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT));
+		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT))
+		.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT))
+		.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHT));
 
 		final Measure measure = builder.build();
 		assertTrue(measure != null);
@@ -84,9 +84,9 @@ public class MeasureBuilderTest {
 
 		assertEquals(1, measure.getVoiceCount());
 		final List<Durational> voice = measure.getVoice(0);
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voice.get(0));
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT), voice.get(1));
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT), voice.get(2));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT), voice.get(0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT), voice.get(1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHT), voice.get(2));
 	}
 
 	@Test
@@ -100,9 +100,9 @@ public class MeasureBuilderTest {
 
 		builder.addVoice();
 		assertEquals(1, builder.getNumberOfVoices());
-		builder.addToVoice(0, new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT))
-		.addToVoice(0, new NoteBuilder(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT))
-		.addToVoice(0, new NoteBuilder(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT));
+		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT))
+		.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT))
+		.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHT));
 
 		final Measure measure = builder.build();
 		assertTrue(measure != null);
@@ -114,9 +114,9 @@ public class MeasureBuilderTest {
 
 		assertEquals(1, measure.getVoiceCount());
 		final List<Durational> voice = measure.getVoice(0);
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voice.get(0));
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT), voice.get(1));
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT), voice.get(2));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT), voice.get(0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT), voice.get(1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHT), voice.get(2));
 	}
 
 	@Test
@@ -143,7 +143,7 @@ public class MeasureBuilderTest {
 		MeasureBuilder builder = new MeasureBuilder(1);
 		builder.addToVoice(0, new RestBuilder(Durations.QUARTER));
 		assertFalse("Voice 0 is full for 4/4 measure after adding one quarter rest", builder.isVoiceFull(0));
-		final NoteBuilder c = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 2), Durations.QUARTER);
+		final NoteBuilder c = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.QUARTER);
 		builder.addToVoice(0, c);
 		assertFalse("Voice 0 is full for 4/4 measure after adding two quarters", builder.isVoiceFull(0));
 		builder.addToVoice(0, c);
@@ -169,7 +169,7 @@ public class MeasureBuilderTest {
 		MeasureBuilder builder = new MeasureBuilder(1);
 		builder.addToVoice(0, new RestBuilder(Durations.QUARTER));
 		assertFalse("builder for 4/4 is full after adding one quarter rest", builder.isFull());
-		final NoteBuilder c = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 2), Durations.QUARTER);
+		final NoteBuilder c = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.QUARTER);
 		builder.addToVoice(0, c);
 		assertFalse("builder for 4/4 is full only after adding two quarters", builder.isFull());
 		builder.addToVoice(0, c);
@@ -192,8 +192,8 @@ public class MeasureBuilderTest {
 	@Test
 	public void testBuildingMeasureWithTiedNotes() {
 		final MeasureBuilder builder = new MeasureBuilder(1);
-		final NoteBuilder first = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 2), Durations.HALF);
-		final NoteBuilder second = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 2), Durations.HALF);
+		final NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.HALF);
+		final NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.HALF);
 
 		first.addTieToFollowing(second);
 		builder.addToVoice(1, first).addToVoice(1, second);

--- a/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
@@ -57,9 +57,9 @@ public class MeasureBuilderTest {
 
 		assertEquals(1, measure.getVoiceCount());
 		final List<Durational> voice = measure.getVoice(0);
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voice.get(0));
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT), voice.get(1));
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT), voice.get(2));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voice.get(0));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT), voice.get(1));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT), voice.get(2));
 	}
 
 	@Test
@@ -84,9 +84,9 @@ public class MeasureBuilderTest {
 
 		assertEquals(1, measure.getVoiceCount());
 		final List<Durational> voice = measure.getVoice(0);
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voice.get(0));
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT), voice.get(1));
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT), voice.get(2));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voice.get(0));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT), voice.get(1));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT), voice.get(2));
 	}
 
 	@Test
@@ -114,9 +114,9 @@ public class MeasureBuilderTest {
 
 		assertEquals(1, measure.getVoiceCount());
 		final List<Durational> voice = measure.getVoice(0);
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voice.get(0));
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT), voice.get(1));
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT), voice.get(2));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT), voice.get(0));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT), voice.get(1));
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.EIGHT), voice.get(2));
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/notation/builders/NoteBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/NoteBuilderTest.java
@@ -26,26 +26,26 @@ public class NoteBuilderTest {
 
 	@Test
 	public void testBuildingBasicNote() {
-		final NoteBuilder builder = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final NoteBuilder builder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
 		final Note note = builder.build();
 		assertFalse(note.hasArticulations());
 		assertFalse(note.hasMultiNoteArticulations());
 		assertFalse(note.isTied());
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER), note);
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), note);
 	}
 
 	@Test
 	public void testBuildingNoteWithAllAttributes() {
-		final NoteBuilder builder = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final NoteBuilder builder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
 		builder.addArticulation(Articulation.STACCATO);
 		builder.addMultiNoteArticulation(new MultiNoteArticulation(MultiNoteArticulation.Type.SLUR));
 
-		final Note tiedNote = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final Note tiedNote = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
 		final ScorePosition position = new ScorePosition(1, 1, 1, 1);
 
 		builder.setTiedTo(tiedNote);
 
-		final Note expected = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER,
+		final Note expected = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER,
 				EnumSet.of(Articulation.STACCATO));
 
 		final Note note = builder.build();
@@ -58,9 +58,9 @@ public class NoteBuilderTest {
 
 	@Test
 	public void testBuildingTiedNotes() {
-		final NoteBuilder first = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		final NoteBuilder second = new NoteBuilder(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.QUARTER);
-		final NoteBuilder third = new NoteBuilder(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER);
+		final NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER);
+		final NoteBuilder third = new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER);
 
 		first.addTieToFollowing(second);
 		second.addTieToFollowing(third);
@@ -69,40 +69,40 @@ public class NoteBuilderTest {
 		final Note secondNote = second.build();
 		final Note thirdNote = third.build();
 
-		assertEquals(Pitch.getPitch(Pitch.Base.C, 0, 4), firstNote.getPitch());
+		assertEquals(Pitch.of(Pitch.Base.C, 0, 4), firstNote.getPitch());
 		assertTrue(firstNote.isTiedToFollowing());
 		assertFalse(firstNote.isTiedFromPrevious());
-		assertEquals(Pitch.getPitch(Pitch.Base.D, 0, 4), firstNote.getFollowingTiedNote().get().getPitch());
+		assertEquals(Pitch.of(Pitch.Base.D, 0, 4), firstNote.getFollowingTiedNote().get().getPitch());
 
-		assertEquals(Pitch.getPitch(Pitch.Base.D, 0, 4), secondNote.getPitch());
+		assertEquals(Pitch.of(Pitch.Base.D, 0, 4), secondNote.getPitch());
 		assertTrue(secondNote.isTiedToFollowing());
 		assertTrue(secondNote.isTiedFromPrevious());
-		assertEquals(Pitch.getPitch(Pitch.Base.E, 0, 4), secondNote.getFollowingTiedNote().get().getPitch());
+		assertEquals(Pitch.of(Pitch.Base.E, 0, 4), secondNote.getFollowingTiedNote().get().getPitch());
 
-		assertEquals(Pitch.getPitch(Pitch.Base.E, 0, 4), thirdNote.getPitch());
+		assertEquals(Pitch.of(Pitch.Base.E, 0, 4), thirdNote.getPitch());
 		assertFalse(thirdNote.isTiedToFollowing());
 		assertTrue(thirdNote.isTiedFromPrevious());
 	}
 
 	@Test
 	public void testCopyConstructor() {
-		final NoteBuilder builder = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final NoteBuilder builder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
 		final NoteBuilder copy = new NoteBuilder(builder);
 		assertNotSame(builder, copy);
 
 		assertEquals(Durations.QUARTER, copy.getDuration());
-		assertEquals(Pitch.getPitch(Pitch.Base.C, 0, 4), copy.getPitch());
+		assertEquals(Pitch.of(Pitch.Base.C, 0, 4), copy.getPitch());
 
 		builder.setDuration(Durations.HALF);
 		assertEquals(Durations.QUARTER, copy.getDuration());
 
-		builder.setPitch(Pitch.getPitch(Pitch.Base.D, 0, 4));
-		assertEquals(Pitch.getPitch(Pitch.Base.C, 0, 4), copy.getPitch());
+		builder.setPitch(Pitch.of(Pitch.Base.D, 0, 4));
+		assertEquals(Pitch.of(Pitch.Base.C, 0, 4), copy.getPitch());
 	}
 
 	@Test
 	public void testCopyConstructorArticulations() {
-		final NoteBuilder builder = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final NoteBuilder builder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
 		builder.addArticulation(Articulation.STACCATO);
 
 		final NoteBuilder copy = new NoteBuilder(builder);
@@ -114,7 +114,7 @@ public class NoteBuilderTest {
 
 	@Test
 	public void testCopyConstructorMultiNoteArticulations() {
-		final NoteBuilder builder = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final NoteBuilder builder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
 		final MultiNoteArticulation glissando = new MultiNoteArticulation(MultiNoteArticulation.Type.GLISSANDO);
 		builder.addMultiNoteArticulation(glissando);
 
@@ -127,8 +127,8 @@ public class NoteBuilderTest {
 
 	@Test
 	public void testCopyConstructorsFollowingTiedIsCopiedAsWell() {
-		final NoteBuilder builder = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		final NoteBuilder following = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.HALF);
+		final NoteBuilder builder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final NoteBuilder following = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.HALF);
 		builder.addTieToFollowing(following);
 
 		final NoteBuilder copy = new NoteBuilder(builder);

--- a/src/test/java/org/wmn4j/notation/builders/NoteBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/NoteBuilderTest.java
@@ -31,7 +31,7 @@ public class NoteBuilderTest {
 		assertFalse(note.hasArticulations());
 		assertFalse(note.hasMultiNoteArticulations());
 		assertFalse(note.isTied());
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER), note);
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER), note);
 	}
 
 	@Test
@@ -40,12 +40,12 @@ public class NoteBuilderTest {
 		builder.addArticulation(Articulation.STACCATO);
 		builder.addMultiNoteArticulation(new MultiNoteArticulation(MultiNoteArticulation.Type.SLUR));
 
-		final Note tiedNote = Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final Note tiedNote = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
 		final ScorePosition position = new ScorePosition(1, 1, 1, 1);
 
 		builder.setTiedTo(tiedNote);
 
-		final Note expected = Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER,
+		final Note expected = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER,
 				EnumSet.of(Articulation.STACCATO));
 
 		final Note note = builder.build();

--- a/src/test/java/org/wmn4j/notation/builders/PartBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/PartBuilderTest.java
@@ -69,7 +69,7 @@ public class PartBuilderTest {
 		noteVoices.get(1).add(new RestBuilder(Durations.QUARTER));
 
 		this.measureContents = Collections.unmodifiableMap(noteVoices);
-		this.measureAttr = MeasureAttributes.getMeasureAttr(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
+		this.measureAttr = MeasureAttributes.of(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
 				Barline.SINGLE, Clefs.G);
 	}
 

--- a/src/test/java/org/wmn4j/notation/builders/PartBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/PartBuilderTest.java
@@ -46,10 +46,10 @@ public class PartBuilderTest {
 
 	KeySignature keySig = KeySignatures.CMAJ_AMIN;
 
-	NoteBuilder C4 = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.HALF);
-	NoteBuilder E4 = new NoteBuilder(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.HALF);
-	NoteBuilder G4 = new NoteBuilder(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.HALF);
-	NoteBuilder C4Quarter = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+	NoteBuilder C4 = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.HALF);
+	NoteBuilder E4 = new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.HALF);
+	NoteBuilder G4 = new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF);
+	NoteBuilder C4Quarter = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
 
 	public PartBuilderTest() {
 		final Map<Integer, List<DurationalBuilder>> noteVoice = new HashMap<>();
@@ -142,11 +142,11 @@ public class PartBuilderTest {
 	public void testBuildPartWithTieBetweenMeasures() {
 
 		final MeasureBuilder firstMeasureBuilder = new MeasureBuilder(1);
-		final NoteBuilder firstNoteBuilder = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.WHOLE);
+		final NoteBuilder firstNoteBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.WHOLE);
 		firstMeasureBuilder.addToVoice(1, firstNoteBuilder);
 
 		final MeasureBuilder secondMeasureBuilder = new MeasureBuilder(2);
-		final NoteBuilder secondNoteBuilder = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.WHOLE);
+		final NoteBuilder secondNoteBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.WHOLE);
 		firstNoteBuilder.addTieToFollowing(secondNoteBuilder);
 		secondMeasureBuilder.addToVoice(1, secondNoteBuilder);
 

--- a/src/test/java/org/wmn4j/notation/elements/ChordTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/ChordTest.java
@@ -36,29 +36,29 @@ public class ChordTest {
 
 	public ChordTest() {
 		this.cMajorNotes = new ArrayList<>();
-		this.cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		this.cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER));
-		this.cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER));
+		this.cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		this.cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER));
+		this.cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER));
 		this.cMajor = Chord.of(this.cMajorNotes);
 
 		final List<Note> dMajorNotes = new ArrayList<>();
-		dMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 3), Durations.QUARTER));
-		dMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.F, 1, 3), Durations.QUARTER));
-		dMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.QUARTER));
+		dMajorNotes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 3), Durations.QUARTER));
+		dMajorNotes.add(Note.of(Pitch.of(Pitch.Base.F, 1, 3), Durations.QUARTER));
+		dMajorNotes.add(Note.of(Pitch.of(Pitch.Base.A, 0, 3), Durations.QUARTER));
 		this.dMajor = Chord.of(dMajorNotes);
 
 		final List<Note> fMinorNotes = new ArrayList<>();
-		fMinorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.F, 0, 4), Durations.QUARTER));
-		fMinorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.A, -1, 4), Durations.QUARTER));
-		fMinorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER));
+		fMinorNotes.add(Note.of(Pitch.of(Pitch.Base.F, 0, 4), Durations.QUARTER));
+		fMinorNotes.add(Note.of(Pitch.of(Pitch.Base.A, -1, 4), Durations.QUARTER));
+		fMinorNotes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER));
 		this.fMinor = Chord.of(fMinorNotes);
 
 		final ArrayList<Note> DminorMaj9Notes = new ArrayList<>();
-		DminorMaj9Notes.add(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.EIGHT));
-		DminorMaj9Notes.add(Note.of(Pitch.getPitch(Pitch.Base.F, 0, 4), Durations.EIGHT));
-		DminorMaj9Notes.add(Note.of(Pitch.getPitch(Pitch.Base.A, 0, 4), Durations.EIGHT));
-		DminorMaj9Notes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 1, 5), Durations.EIGHT));
-		DminorMaj9Notes.add(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 5), Durations.EIGHT));
+		DminorMaj9Notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHT));
+		DminorMaj9Notes.add(Note.of(Pitch.of(Pitch.Base.F, 0, 4), Durations.EIGHT));
+		DminorMaj9Notes.add(Note.of(Pitch.of(Pitch.Base.A, 0, 4), Durations.EIGHT));
+		DminorMaj9Notes.add(Note.of(Pitch.of(Pitch.Base.C, 1, 5), Durations.EIGHT));
+		DminorMaj9Notes.add(Note.of(Pitch.of(Pitch.Base.E, 0, 5), Durations.EIGHT));
 		this.dMinorMaj9 = Chord.of(DminorMaj9Notes);
 	}
 
@@ -71,7 +71,7 @@ public class ChordTest {
 
 		// Test that modifying the list of notes used to create the chord does not
 		// modify the chord.
-		notes.add(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.EIGHT));
+		notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHT));
 		assertEquals(3, cMaj.getNoteCount());
 		assertEquals(this.cMajor, cMaj);
 	}
@@ -87,8 +87,8 @@ public class ChordTest {
 
 	@Test
 	public void testVarargsFactory() {
-		final Note C4 = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT);
-		final Note E4 = Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT);
+		final Note C4 = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT);
+		final Note E4 = Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT);
 		final Chord dyad = Chord.of(C4, E4);
 		assertEquals(2, dyad.getNoteCount());
 		assertTrue(dyad.contains(E4));
@@ -103,8 +103,8 @@ public class ChordTest {
 		}
 
 		try {
-			final Note a = Note.of(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.EIGHT);
-			final Note b = Note.of(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.QUARTER);
+			final Note a = Note.of(Pitch.of(Pitch.Base.A, 0, 3), Durations.EIGHT);
+			final Note b = Note.of(Pitch.of(Pitch.Base.A, 0, 3), Durations.QUARTER);
 			final ArrayList<Note> notes = new ArrayList<>();
 			notes.add(a);
 			notes.add(b);
@@ -118,20 +118,20 @@ public class ChordTest {
 
 	@Test
 	public void testContainsPitch() {
-		assertTrue(this.cMajor.contains(Pitch.getPitch(Pitch.Base.C, 0, 4)));
-		assertFalse(this.cMajor.contains(Pitch.getPitch(Pitch.Base.C, 1, 4)));
+		assertTrue(this.cMajor.contains(Pitch.of(Pitch.Base.C, 0, 4)));
+		assertFalse(this.cMajor.contains(Pitch.of(Pitch.Base.C, 1, 4)));
 	}
 
 	@Test
 	public void testContainstNote() {
-		assertTrue(this.cMajor.contains(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
-		assertFalse(this.cMajor.contains(Note.of(Pitch.getPitch(Pitch.Base.C, -1, 4), Durations.QUARTER)));
+		assertTrue(this.cMajor.contains(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+		assertFalse(this.cMajor.contains(Note.of(Pitch.of(Pitch.Base.C, -1, 4), Durations.QUARTER)));
 		final HashSet<Articulation> articulations = new HashSet<>();
 		articulations.add(Articulation.STACCATO);
-		final Note staccatoC5 = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER, articulations);
+		final Note staccatoC5 = Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER, articulations);
 		final Chord staccatoC = this.cMajor.add(staccatoC5);
 		assertTrue(staccatoC.contains(staccatoC5));
-		assertFalse(staccatoC.contains(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER)));
+		assertFalse(staccatoC.contains(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER)));
 		assertFalse(this.cMajor.contains(staccatoC5));
 	}
 
@@ -143,24 +143,24 @@ public class ChordTest {
 
 	@Test
 	public void testGetNote() {
-		assertTrue(this.cMajor.getNote(1).equals(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER)));
-		assertTrue(this.dMajor.getNote(2).equals(Note.of(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.QUARTER)));
+		assertTrue(this.cMajor.getNote(1).equals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER)));
+		assertTrue(this.dMajor.getNote(2).equals(Note.of(Pitch.of(Pitch.Base.A, 0, 3), Durations.QUARTER)));
 	}
 
 	@Test
 	public void testGetLowestNote() {
 		assertTrue(this.cMajor.getLowestNote()
-				.equals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+				.equals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER)));
 		assertTrue(this.fMinor.getLowestNote()
-				.equals(Note.of(Pitch.getPitch(Pitch.Base.F, 0, 4), Durations.QUARTER)));
+				.equals(Note.of(Pitch.of(Pitch.Base.F, 0, 4), Durations.QUARTER)));
 	}
 
 	@Test
 	public void testGetHighestNote() {
 		assertTrue(this.cMajor.getHighestNote()
-				.equals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER)));
+				.equals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER)));
 		assertTrue(this.fMinor.getHighestNote()
-				.equals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER)));
+				.equals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER)));
 	}
 
 	@Test
@@ -172,9 +172,9 @@ public class ChordTest {
 	@Test
 	public void testEquals() {
 		final ArrayList<Note> cMajorNotes = new ArrayList<>();
-		cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER));
-		cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER));
 		final Chord cMaj = Chord.of(cMajorNotes);
 		assertTrue(this.cMajor.equals(cMaj));
 		assertTrue(cMaj.equals(this.cMajor));
@@ -190,13 +190,13 @@ public class ChordTest {
 
 	@Test
 	public void testAddNote() {
-		final Chord cMaj = this.cMajor.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER));
+		final Chord cMaj = this.cMajor.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER));
 		assertFalse(this.cMajor.equals(cMaj));
 		assertEquals(4, cMaj.getNoteCount());
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER), cMaj.getHighestNote());
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER), cMaj.getHighestNote());
 
 		try {
-			final Chord illegalCMaj = this.cMajor.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT));
+			final Chord illegalCMaj = this.cMajor.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHT));
 			fail("Failed to throw expected exception");
 		} catch (final IllegalArgumentException e) {
 			assertTrue(e instanceof IllegalArgumentException);
@@ -205,26 +205,26 @@ public class ChordTest {
 
 	@Test
 	public void testRemoveNote() {
-		final Chord D_FSharp = this.dMajor.remove(Note.of(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.QUARTER));
+		final Chord D_FSharp = this.dMajor.remove(Note.of(Pitch.of(Pitch.Base.A, 0, 3), Durations.QUARTER));
 		assertFalse(this.dMajor.equals(D_FSharp));
 		assertEquals(2, D_FSharp.getNoteCount());
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.F, 1, 3), Durations.QUARTER), D_FSharp.getHighestNote());
+		assertEquals(Note.of(Pitch.of(Pitch.Base.F, 1, 3), Durations.QUARTER), D_FSharp.getHighestNote());
 	}
 
 	@Test
 	public void testRemovePitch() {
-		final Chord D_FSharp = this.dMajor.remove(Pitch.getPitch(Pitch.Base.A, 0, 3));
+		final Chord D_FSharp = this.dMajor.remove(Pitch.of(Pitch.Base.A, 0, 3));
 		assertFalse(this.dMajor.equals(D_FSharp));
 		assertEquals(2, D_FSharp.getNoteCount());
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.F, 1, 3), Durations.QUARTER), D_FSharp.getHighestNote());
+		assertEquals(Note.of(Pitch.of(Pitch.Base.F, 1, 3), Durations.QUARTER), D_FSharp.getHighestNote());
 	}
 
 	@Test
 	public void testIteration() {
 		final ArrayList<Note> cMajorNotes = new ArrayList<>();
-		cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER));
-		cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER));
 
 		int noteCount = 0;
 		for (Note note : this.cMajor) {

--- a/src/test/java/org/wmn4j/notation/elements/ChordTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/ChordTest.java
@@ -36,29 +36,29 @@ public class ChordTest {
 
 	public ChordTest() {
 		this.cMajorNotes = new ArrayList<>();
-		this.cMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		this.cMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER));
-		this.cMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER));
+		this.cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		this.cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER));
+		this.cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER));
 		this.cMajor = Chord.of(this.cMajorNotes);
 
 		final List<Note> dMajorNotes = new ArrayList<>();
-		dMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.D, 0, 3), Durations.QUARTER));
-		dMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.F, 1, 3), Durations.QUARTER));
-		dMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.QUARTER));
+		dMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 3), Durations.QUARTER));
+		dMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.F, 1, 3), Durations.QUARTER));
+		dMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.QUARTER));
 		this.dMajor = Chord.of(dMajorNotes);
 
 		final List<Note> fMinorNotes = new ArrayList<>();
-		fMinorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.F, 0, 4), Durations.QUARTER));
-		fMinorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.A, -1, 4), Durations.QUARTER));
-		fMinorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER));
+		fMinorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.F, 0, 4), Durations.QUARTER));
+		fMinorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.A, -1, 4), Durations.QUARTER));
+		fMinorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER));
 		this.fMinor = Chord.of(fMinorNotes);
 
 		final ArrayList<Note> DminorMaj9Notes = new ArrayList<>();
-		DminorMaj9Notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.EIGHT));
-		DminorMaj9Notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.F, 0, 4), Durations.EIGHT));
-		DminorMaj9Notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.A, 0, 4), Durations.EIGHT));
-		DminorMaj9Notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 1, 5), Durations.EIGHT));
-		DminorMaj9Notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 5), Durations.EIGHT));
+		DminorMaj9Notes.add(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.EIGHT));
+		DminorMaj9Notes.add(Note.of(Pitch.getPitch(Pitch.Base.F, 0, 4), Durations.EIGHT));
+		DminorMaj9Notes.add(Note.of(Pitch.getPitch(Pitch.Base.A, 0, 4), Durations.EIGHT));
+		DminorMaj9Notes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 1, 5), Durations.EIGHT));
+		DminorMaj9Notes.add(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 5), Durations.EIGHT));
 		this.dMinorMaj9 = Chord.of(DminorMaj9Notes);
 	}
 
@@ -71,7 +71,7 @@ public class ChordTest {
 
 		// Test that modifying the list of notes used to create the chord does not
 		// modify the chord.
-		notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.EIGHT));
+		notes.add(Note.of(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.EIGHT));
 		assertEquals(3, cMaj.getNoteCount());
 		assertEquals(this.cMajor, cMaj);
 	}
@@ -87,8 +87,8 @@ public class ChordTest {
 
 	@Test
 	public void testVarargsFactory() {
-		final Note C4 = Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT);
-		final Note E4 = Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT);
+		final Note C4 = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT);
+		final Note E4 = Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT);
 		final Chord dyad = Chord.of(C4, E4);
 		assertEquals(2, dyad.getNoteCount());
 		assertTrue(dyad.contains(E4));
@@ -103,8 +103,8 @@ public class ChordTest {
 		}
 
 		try {
-			final Note a = Note.getNote(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.EIGHT);
-			final Note b = Note.getNote(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.QUARTER);
+			final Note a = Note.of(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.EIGHT);
+			final Note b = Note.of(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.QUARTER);
 			final ArrayList<Note> notes = new ArrayList<>();
 			notes.add(a);
 			notes.add(b);
@@ -124,14 +124,14 @@ public class ChordTest {
 
 	@Test
 	public void testContainstNote() {
-		assertTrue(this.cMajor.contains(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
-		assertFalse(this.cMajor.contains(Note.getNote(Pitch.getPitch(Pitch.Base.C, -1, 4), Durations.QUARTER)));
+		assertTrue(this.cMajor.contains(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+		assertFalse(this.cMajor.contains(Note.of(Pitch.getPitch(Pitch.Base.C, -1, 4), Durations.QUARTER)));
 		final HashSet<Articulation> articulations = new HashSet<>();
 		articulations.add(Articulation.STACCATO);
-		final Note staccatoC5 = Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER, articulations);
+		final Note staccatoC5 = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER, articulations);
 		final Chord staccatoC = this.cMajor.add(staccatoC5);
 		assertTrue(staccatoC.contains(staccatoC5));
-		assertFalse(staccatoC.contains(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER)));
+		assertFalse(staccatoC.contains(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER)));
 		assertFalse(this.cMajor.contains(staccatoC5));
 	}
 
@@ -143,24 +143,24 @@ public class ChordTest {
 
 	@Test
 	public void testGetNote() {
-		assertTrue(this.cMajor.getNote(1).equals(Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER)));
-		assertTrue(this.dMajor.getNote(2).equals(Note.getNote(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.QUARTER)));
+		assertTrue(this.cMajor.getNote(1).equals(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER)));
+		assertTrue(this.dMajor.getNote(2).equals(Note.of(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.QUARTER)));
 	}
 
 	@Test
 	public void testGetLowestNote() {
 		assertTrue(this.cMajor.getLowestNote()
-				.equals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+				.equals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
 		assertTrue(this.fMinor.getLowestNote()
-				.equals(Note.getNote(Pitch.getPitch(Pitch.Base.F, 0, 4), Durations.QUARTER)));
+				.equals(Note.of(Pitch.getPitch(Pitch.Base.F, 0, 4), Durations.QUARTER)));
 	}
 
 	@Test
 	public void testGetHighestNote() {
 		assertTrue(this.cMajor.getHighestNote()
-				.equals(Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER)));
+				.equals(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER)));
 		assertTrue(this.fMinor.getHighestNote()
-				.equals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER)));
+				.equals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER)));
 	}
 
 	@Test
@@ -172,9 +172,9 @@ public class ChordTest {
 	@Test
 	public void testEquals() {
 		final ArrayList<Note> cMajorNotes = new ArrayList<>();
-		cMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		cMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER));
-		cMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER));
 		final Chord cMaj = Chord.of(cMajorNotes);
 		assertTrue(this.cMajor.equals(cMaj));
 		assertTrue(cMaj.equals(this.cMajor));
@@ -190,13 +190,13 @@ public class ChordTest {
 
 	@Test
 	public void testAddNote() {
-		final Chord cMaj = this.cMajor.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER));
+		final Chord cMaj = this.cMajor.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER));
 		assertFalse(this.cMajor.equals(cMaj));
 		assertEquals(4, cMaj.getNoteCount());
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER), cMaj.getHighestNote());
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER), cMaj.getHighestNote());
 
 		try {
-			final Chord illegalCMaj = this.cMajor.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT));
+			final Chord illegalCMaj = this.cMajor.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.EIGHT));
 			fail("Failed to throw expected exception");
 		} catch (final IllegalArgumentException e) {
 			assertTrue(e instanceof IllegalArgumentException);
@@ -205,10 +205,10 @@ public class ChordTest {
 
 	@Test
 	public void testRemoveNote() {
-		final Chord D_FSharp = this.dMajor.remove(Note.getNote(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.QUARTER));
+		final Chord D_FSharp = this.dMajor.remove(Note.of(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.QUARTER));
 		assertFalse(this.dMajor.equals(D_FSharp));
 		assertEquals(2, D_FSharp.getNoteCount());
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.F, 1, 3), Durations.QUARTER), D_FSharp.getHighestNote());
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.F, 1, 3), Durations.QUARTER), D_FSharp.getHighestNote());
 	}
 
 	@Test
@@ -216,15 +216,15 @@ public class ChordTest {
 		final Chord D_FSharp = this.dMajor.remove(Pitch.getPitch(Pitch.Base.A, 0, 3));
 		assertFalse(this.dMajor.equals(D_FSharp));
 		assertEquals(2, D_FSharp.getNoteCount());
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.F, 1, 3), Durations.QUARTER), D_FSharp.getHighestNote());
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.F, 1, 3), Durations.QUARTER), D_FSharp.getHighestNote());
 	}
 
 	@Test
 	public void testIteration() {
 		final ArrayList<Note> cMajorNotes = new ArrayList<>();
-		cMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		cMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER));
-		cMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER));
 
 		int noteCount = 0;
 		for (Note note : this.cMajor) {

--- a/src/test/java/org/wmn4j/notation/elements/ChordTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/ChordTest.java
@@ -39,19 +39,19 @@ public class ChordTest {
 		this.cMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
 		this.cMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER));
 		this.cMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER));
-		this.cMajor = Chord.getChord(this.cMajorNotes);
+		this.cMajor = Chord.of(this.cMajorNotes);
 
 		final List<Note> dMajorNotes = new ArrayList<>();
 		dMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.D, 0, 3), Durations.QUARTER));
 		dMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.F, 1, 3), Durations.QUARTER));
 		dMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.A, 0, 3), Durations.QUARTER));
-		this.dMajor = Chord.getChord(dMajorNotes);
+		this.dMajor = Chord.of(dMajorNotes);
 
 		final List<Note> fMinorNotes = new ArrayList<>();
 		fMinorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.F, 0, 4), Durations.QUARTER));
 		fMinorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.A, -1, 4), Durations.QUARTER));
 		fMinorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 5), Durations.QUARTER));
-		this.fMinor = Chord.getChord(fMinorNotes);
+		this.fMinor = Chord.of(fMinorNotes);
 
 		final ArrayList<Note> DminorMaj9Notes = new ArrayList<>();
 		DminorMaj9Notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.D, 0, 4), Durations.EIGHT));
@@ -59,14 +59,14 @@ public class ChordTest {
 		DminorMaj9Notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.A, 0, 4), Durations.EIGHT));
 		DminorMaj9Notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 1, 5), Durations.EIGHT));
 		DminorMaj9Notes.add(Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 5), Durations.EIGHT));
-		this.dMinorMaj9 = Chord.getChord(DminorMaj9Notes);
+		this.dMinorMaj9 = Chord.of(DminorMaj9Notes);
 	}
 
 	@Test
 	public void testChordImmutable() {
 
 		final List<Note> notes = new ArrayList<>(this.cMajorNotes);
-		final Chord cMaj = Chord.getChord(notes);
+		final Chord cMaj = Chord.of(notes);
 		assertEquals(this.cMajor, cMaj);
 
 		// Test that modifying the list of notes used to create the chord does not
@@ -89,7 +89,7 @@ public class ChordTest {
 	public void testVarargsFactory() {
 		final Note C4 = Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT);
 		final Note E4 = Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.EIGHT);
-		final Chord dyad = Chord.getChord(C4, E4);
+		final Chord dyad = Chord.of(C4, E4);
 		assertEquals(2, dyad.getNoteCount());
 		assertTrue(dyad.contains(E4));
 		assertTrue(dyad.contains(C4));
@@ -108,7 +108,7 @@ public class ChordTest {
 			final ArrayList<Note> notes = new ArrayList<>();
 			notes.add(a);
 			notes.add(b);
-			final Chord c = Chord.getChord(notes);
+			final Chord c = Chord.of(notes);
 			fail("Failed to throw IllegalArgumentException when "
 					+ "creating chord with notes whose durations are not the same");
 		} catch (final IllegalArgumentException e) {
@@ -175,7 +175,7 @@ public class ChordTest {
 		cMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
 		cMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.QUARTER));
 		cMajorNotes.add(Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.QUARTER));
-		final Chord cMaj = Chord.getChord(cMajorNotes);
+		final Chord cMaj = Chord.of(cMajorNotes);
 		assertTrue(this.cMajor.equals(cMaj));
 		assertTrue(cMaj.equals(this.cMajor));
 		assertTrue(this.cMajor.equals(this.cMajor));
@@ -233,7 +233,7 @@ public class ChordTest {
 			assertTrue(cMajorNotes.contains(note));
 		}
 
-		final Chord cMaj = Chord.getChord(cMajorNotes);
+		final Chord cMaj = Chord.of(cMajorNotes);
 		final Iterator<Note> iterator = cMaj.iterator();
 		iterator.next();
 		try {

--- a/src/test/java/org/wmn4j/notation/elements/DurationTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/DurationTest.java
@@ -38,7 +38,7 @@ public class DurationTest {
 
 	@Test
 	public void testGetDurationWithValidParameter() {
-		final Duration duration = Duration.getDuration(1, 4);
+		final Duration duration = Duration.of(1, 4);
 		assertTrue(duration != null);
 		assertTrue(duration.getNumerator() == 1);
 		assertTrue(duration.getDenominator() == 4);
@@ -47,13 +47,13 @@ public class DurationTest {
 	@Test
 	public void testGetDurationWithInvalidParameter() {
 		try {
-			final Duration duration = Duration.getDuration(-1, 2);
+			final Duration duration = Duration.of(-1, 2);
 			fail("No exception was thrown. Expected: IllegalArgumentException");
 		} catch (final Exception e) {
 			assertTrue(e instanceof IllegalArgumentException);
 		}
 		try {
-			final Duration duration = Duration.getDuration(1, 0);
+			final Duration duration = Duration.of(1, 0);
 			fail("No exception was thrown. Expected: IllegalArgumentException");
 		} catch (final Exception e) {
 			assertTrue(e instanceof IllegalArgumentException);
@@ -62,17 +62,17 @@ public class DurationTest {
 
 	@Test
 	public void testEquals() {
-		final Duration quarter = Duration.getDuration(1, 4);
+		final Duration quarter = Duration.of(1, 4);
 		assertTrue(quarter.equals(quarter));
 		assertTrue(quarter.equals(Durations.QUARTER));
-		assertTrue(quarter.equals(Duration.getDuration(1, 4)));
+		assertTrue(quarter.equals(Duration.of(1, 4)));
 
-		final Duration anotherQuarter = Duration.getDuration(2, 8);
+		final Duration anotherQuarter = Duration.of(2, 8);
 		assertTrue(quarter.equals(anotherQuarter));
 		assertTrue(quarter.equals(Durations.QUARTER));
-		assertTrue(quarter.equals(Duration.getDuration(1, 4)));
+		assertTrue(quarter.equals(Duration.of(1, 4)));
 
-		final Duration notQuarter = Duration.getDuration(1, 8);
+		final Duration notQuarter = Duration.of(1, 8);
 		assertFalse(notQuarter.equals(quarter));
 
 		assertFalse(Durations.EIGHT_TRIPLET.equals(Durations.THIRTYSECOND));
@@ -80,20 +80,20 @@ public class DurationTest {
 
 	@Test
 	public void testRationalNumberReduced() {
-		final Duration quarter = Duration.getDuration(3, 12);
+		final Duration quarter = Duration.of(3, 12);
 		assertEquals(1, quarter.getNumerator());
 		assertEquals(4, quarter.getDenominator());
 
-		final Duration quintuplet = Duration.getDuration(5, 100);
+		final Duration quintuplet = Duration.of(5, 100);
 		assertEquals(1, quintuplet.getNumerator());
 		assertEquals(20, quintuplet.getDenominator());
 	}
 
 	@Test
 	public void testToString() {
-		assertEquals("(1/4)", Duration.getDuration(1, 4).toString());
+		assertEquals("(1/4)", Duration.of(1, 4).toString());
 		assertEquals("(1/8)", Durations.EIGHT.toString());
-		assertEquals("(1/16)", Duration.getDuration(1, 16).toString());
+		assertEquals("(1/16)", Duration.of(1, 16).toString());
 	}
 
 	@Test
@@ -108,14 +108,14 @@ public class DurationTest {
 		assertEquals(Durations.EIGHT, Durations.SIXTEENTH.add(Durations.SIXTEENTH));
 		assertEquals(Durations.QUARTER,
 				Durations.EIGHT_TRIPLET.add(Durations.EIGHT_TRIPLET.add(Durations.EIGHT_TRIPLET)));
-		assertEquals(Duration.getDuration(1, 8), Duration.getDuration(3, 32).add(Duration.getDuration(1, 32)));
+		assertEquals(Duration.of(1, 8), Duration.of(3, 32).add(Duration.of(1, 32)));
 	}
 
 	@Test
 	public void testSubtract() {
 		assertEquals(Durations.EIGHT, Durations.QUARTER.subtract(Durations.EIGHT));
 		assertEquals(Durations.QUARTER.addDot(), Durations.HALF.subtract(Durations.EIGHT));
-		assertEquals(Duration.getDuration(2, 12), Durations.QUARTER.subtract(Durations.EIGHT_TRIPLET));
+		assertEquals(Duration.of(2, 12), Durations.QUARTER.subtract(Durations.EIGHT_TRIPLET));
 	}
 
 	@Test
@@ -129,7 +129,7 @@ public class DurationTest {
 	public void testDivideBy() {
 		assertEquals(Durations.EIGHT, Durations.QUARTER.divideBy(2));
 		assertEquals(Durations.QUARTER, Durations.WHOLE.divideBy(4));
-		assertEquals(Duration.getDuration(1, 20), Durations.QUARTER.divideBy(5));
+		assertEquals(Duration.of(1, 20), Durations.QUARTER.divideBy(5));
 	}
 
 	@Test
@@ -155,8 +155,8 @@ public class DurationTest {
 
 	@Test
 	public void testAddDot() {
-		assertEquals(Duration.getDuration(3, 8), Durations.QUARTER.addDot());
-		assertEquals(Duration.getDuration(3, 4), Durations.HALF.addDot());
+		assertEquals(Duration.of(3, 8), Durations.QUARTER.addDot());
+		assertEquals(Duration.of(3, 4), Durations.HALF.addDot());
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/notation/elements/KeySignatureTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/KeySignatureTest.java
@@ -15,9 +15,6 @@ import java.util.List;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.wmn4j.notation.elements.KeySignature;
-import org.wmn4j.notation.elements.KeySignatures;
-import org.wmn4j.notation.elements.Pitch;
 
 /**
  *
@@ -40,7 +37,7 @@ public class KeySignatureTest {
 	public void testGetKeySigExceptions() {
 		try {
 			final List<Pitch.Base> sharps = Arrays.asList(Pitch.Base.C);
-			final KeySignature illegalCustomKeySig = new KeySignature(sharps, sharps);
+			final KeySignature illegalCustomKeySig = KeySignature.of(sharps, sharps);
 			fail("A KeySignature with the same note as sharp and flat was created without exception.");
 		} catch (final Exception e) {
 			assertTrue("Exception was of incorrect type.", e instanceof IllegalArgumentException);
@@ -66,8 +63,8 @@ public class KeySignatureTest {
 		assertTrue(KeySignatures.EMAJ_CSHARPMIN.equals(KeySignatures.EMAJ_CSHARPMIN));
 		assertTrue(KeySignatures.EFLATMAJ_CMIN.equals(KeySignatures.EFLATMAJ_CMIN));
 
-		final KeySignature customSig = new KeySignature(Arrays.asList(Pitch.Base.C), Arrays.asList(Pitch.Base.B));
-		assertTrue(customSig.equals(new KeySignature(Arrays.asList(Pitch.Base.C), Arrays.asList(Pitch.Base.B))));
+		final KeySignature customSig = KeySignature.of(Arrays.asList(Pitch.Base.C), Arrays.asList(Pitch.Base.B));
+		assertTrue(customSig.equals(KeySignature.of(Arrays.asList(Pitch.Base.C), Arrays.asList(Pitch.Base.B))));
 
 		assertFalse(KeySignatures.CMAJ_AMIN.equals(KeySignatures.FMAJ_DMIN));
 	}

--- a/src/test/java/org/wmn4j/notation/elements/MeasureAttributesTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/MeasureAttributesTest.java
@@ -37,7 +37,7 @@ public class MeasureAttributesTest {
 
 	@Test
 	public void testGetMeasureInfo() {
-		final MeasureAttributes attr = MeasureAttributes.getMeasureAttr(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
+		final MeasureAttributes attr = MeasureAttributes.of(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
 				Barline.SINGLE, Barline.SINGLE, Clefs.G);
 
 		assertFalse(attr == null);
@@ -52,7 +52,7 @@ public class MeasureAttributesTest {
 	public void testGetMeasureInfoWithInvalidParameters() {
 
 		try {
-			final MeasureAttributes attr = MeasureAttributes.getMeasureAttr(null, KeySignatures.CMAJ_AMIN, Barline.SINGLE,
+			final MeasureAttributes attr = MeasureAttributes.of(null, KeySignatures.CMAJ_AMIN, Barline.SINGLE,
 					Barline.SINGLE, Clefs.G);
 
 			fail("Did not throw exception with null TimeSignature");
@@ -61,7 +61,7 @@ public class MeasureAttributesTest {
 		}
 
 		try {
-			final MeasureAttributes attr = MeasureAttributes.getMeasureAttr(TimeSignatures.FOUR_FOUR, null, Barline.SINGLE,
+			final MeasureAttributes attr = MeasureAttributes.of(TimeSignatures.FOUR_FOUR, null, Barline.SINGLE,
 					Barline.SINGLE, Clefs.G);
 
 			fail("Did not throw exception with null KeySignature");
@@ -70,7 +70,7 @@ public class MeasureAttributesTest {
 		}
 
 		try {
-			final MeasureAttributes attr = MeasureAttributes.getMeasureAttr(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
+			final MeasureAttributes attr = MeasureAttributes.of(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
 					null, Barline.SINGLE, Clefs.G);
 
 			fail("Did not throw exception with null right barline");
@@ -79,7 +79,7 @@ public class MeasureAttributesTest {
 		}
 
 		try {
-			final MeasureAttributes attr = MeasureAttributes.getMeasureAttr(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
+			final MeasureAttributes attr = MeasureAttributes.of(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
 					Barline.SINGLE, Barline.SINGLE, null);
 
 			fail("Did not throw exception with null Clef");
@@ -90,13 +90,13 @@ public class MeasureAttributesTest {
 
 	@Test
 	public void testEquals() {
-		final MeasureAttributes attr = MeasureAttributes.getMeasureAttr(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
+		final MeasureAttributes attr = MeasureAttributes.of(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
 				Barline.SINGLE, Barline.SINGLE, Clefs.G);
 
-		final MeasureAttributes other = MeasureAttributes.getMeasureAttr(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
+		final MeasureAttributes other = MeasureAttributes.of(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
 				Barline.SINGLE, Barline.SINGLE, Clefs.G);
 
-		final MeasureAttributes different = MeasureAttributes.getMeasureAttr(TimeSignatures.FOUR_FOUR,
+		final MeasureAttributes different = MeasureAttributes.of(TimeSignatures.FOUR_FOUR,
 				KeySignatures.CMAJ_AMIN, Barline.SINGLE, Barline.DOUBLE, Clefs.G);
 
 		assertTrue(attr.equals(attr));

--- a/src/test/java/org/wmn4j/notation/elements/MeasureTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/MeasureTest.java
@@ -27,10 +27,10 @@ public class MeasureTest {
 
 	KeySignature keySig = KeySignatures.CMAJ_AMIN;
 
-	Note C4 = Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.HALF);
-	Note E4 = Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.HALF);
-	Note G4 = Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.HALF);
-	Note C4Quarter = Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+	Note C4 = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.HALF);
+	Note E4 = Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.HALF);
+	Note G4 = Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.HALF);
+	Note C4Quarter = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
 
 	public MeasureTest() {
 		final List<Durational> voiceContents = new ArrayList<>();
@@ -83,8 +83,8 @@ public class MeasureTest {
 	@Test
 	public void testGetVoice() {
 		final Measure m = Measure.of(1, multipleNoteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
-		assertTrue(m.getVoice(1).contains(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.HALF)));
-		assertTrue(m.getVoice(0).contains(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+		assertTrue(m.getVoice(1).contains(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.HALF)));
+		assertTrue(m.getVoice(0).contains(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
 
 		final List<Durational> voice = m.getVoice(0);
 		try {

--- a/src/test/java/org/wmn4j/notation/elements/MeasureTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/MeasureTest.java
@@ -27,10 +27,10 @@ public class MeasureTest {
 
 	KeySignature keySig = KeySignatures.CMAJ_AMIN;
 
-	Note C4 = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.HALF);
-	Note E4 = Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.HALF);
-	Note G4 = Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.HALF);
-	Note C4Quarter = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+	Note C4 = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.HALF);
+	Note E4 = Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.HALF);
+	Note G4 = Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF);
+	Note C4Quarter = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
 
 	public MeasureTest() {
 		final List<Durational> voiceContents = new ArrayList<>();
@@ -83,8 +83,8 @@ public class MeasureTest {
 	@Test
 	public void testGetVoice() {
 		final Measure m = Measure.of(1, multipleNoteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
-		assertTrue(m.getVoice(1).contains(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.HALF)));
-		assertTrue(m.getVoice(0).contains(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+		assertTrue(m.getVoice(1).contains(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.HALF)));
+		assertTrue(m.getVoice(0).contains(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER)));
 
 		final List<Durational> voice = m.getVoice(0);
 		try {

--- a/src/test/java/org/wmn4j/notation/elements/MeasureTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/MeasureTest.java
@@ -47,7 +47,7 @@ public class MeasureTest {
 		final List<Durational> voiceContents = new ArrayList<>();
 		voiceContents.add(C4Quarter);
 		voiceContents.add(Rest.getRest(Durations.QUARTER));
-		voiceContents.add(Chord.getChord(C4, E4, G4));
+		voiceContents.add(Chord.of(C4, E4, G4));
 		this.singleNoteVoice.put(0, voiceContents);
 
 		this.multipleNoteVoices = new HashMap<>();

--- a/src/test/java/org/wmn4j/notation/elements/MeasureTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/MeasureTest.java
@@ -35,16 +35,16 @@ public class MeasureTest {
 	public MeasureTest() {
 		final List<Durational> voiceContents = new ArrayList<>();
 		voiceContents.add(C4Quarter);
-		voiceContents.add(Rest.getRest(Durations.QUARTER));
+		voiceContents.add(Rest.of(Durations.QUARTER));
 		voiceContents.add(Chord.of(C4, E4, G4));
 		this.singleNoteVoice.put(0, voiceContents);
 
 		this.multipleNoteVoices = new HashMap<>();
 		this.multipleNoteVoices.put(0, voiceContents);
 		this.multipleNoteVoices.put(1, new ArrayList<>());
-		this.multipleNoteVoices.get(1).add(Rest.getRest(Durations.QUARTER));
+		this.multipleNoteVoices.get(1).add(Rest.of(Durations.QUARTER));
 		this.multipleNoteVoices.get(1).add(C4);
-		this.multipleNoteVoices.get(1).add(Rest.getRest(Durations.QUARTER));
+		this.multipleNoteVoices.get(1).add(Rest.of(Durations.QUARTER));
 	}
 
 	@Test
@@ -88,7 +88,7 @@ public class MeasureTest {
 
 		final List<Durational> voice = m.getVoice(0);
 		try {
-			voice.add(Rest.getRest(Durations.QUARTER));
+			voice.add(Rest.of(Durations.QUARTER));
 			fail("Failed to throw exception for disabled adding");
 		} catch (final Exception e) {
 			/* Do nothing */ }

--- a/src/test/java/org/wmn4j/notation/elements/MeasureTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/MeasureTest.java
@@ -15,17 +15,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
-import org.wmn4j.notation.elements.Chord;
-import org.wmn4j.notation.elements.Clefs;
-import org.wmn4j.notation.elements.Durational;
-import org.wmn4j.notation.elements.Durations;
-import org.wmn4j.notation.elements.KeySignature;
-import org.wmn4j.notation.elements.KeySignatures;
-import org.wmn4j.notation.elements.Measure;
-import org.wmn4j.notation.elements.Note;
-import org.wmn4j.notation.elements.Pitch;
-import org.wmn4j.notation.elements.Rest;
-import org.wmn4j.notation.elements.TimeSignatures;
 
 /**
  *
@@ -62,14 +51,14 @@ public class MeasureTest {
 	public void testCreatingIllegalMeasureThrowsException() {
 		// Test exceptions thrown correctly for illegal arguments
 		try {
-			final Measure m = new Measure(-1, this.multipleNoteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
+			final Measure m = Measure.of(-1, this.multipleNoteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
 			fail("Exception not thrown");
 		} catch (final Exception e) {
 			assertTrue(e instanceof IllegalArgumentException);
 		}
 
 		try {
-			final Measure m = new Measure(1, null, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
+			final Measure m = Measure.of(1, null, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
 			fail("Exception not thrown");
 		} catch (final Exception e) {
 			assertTrue(e instanceof NullPointerException);
@@ -83,7 +72,7 @@ public class MeasureTest {
 		voice.add(C4);
 		voices.put(0, voice);
 
-		final Measure measure = new Measure(1, voices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
+		final Measure measure = Measure.of(1, voices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
 
 		// Test that modifying the original voices list does no affect measure created
 		// using it.
@@ -93,7 +82,7 @@ public class MeasureTest {
 
 	@Test
 	public void testGetVoice() {
-		final Measure m = new Measure(1, multipleNoteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
+		final Measure m = Measure.of(1, multipleNoteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
 		assertTrue(m.getVoice(1).contains(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.HALF)));
 		assertTrue(m.getVoice(0).contains(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
 
@@ -102,18 +91,18 @@ public class MeasureTest {
 			voice.add(Rest.getRest(Durations.QUARTER));
 			fail("Failed to throw exception for disabled adding");
 		} catch (final Exception e) {
-		/* Do nothing */ }
+			/* Do nothing */ }
 	}
 
 	@Test
 	public void testGetNumber() {
-		assertEquals(1, new Measure(1, singleNoteVoice, TimeSignatures.FOUR_FOUR, keySig, Clefs.G).getNumber());
-		assertEquals(512, new Measure(512, singleNoteVoice, TimeSignatures.FOUR_FOUR, keySig, Clefs.G).getNumber());
+		assertEquals(1, Measure.of(1, singleNoteVoice, TimeSignatures.FOUR_FOUR, keySig, Clefs.G).getNumber());
+		assertEquals(512, Measure.of(512, singleNoteVoice, TimeSignatures.FOUR_FOUR, keySig, Clefs.G).getNumber());
 	}
 
 	@Test
 	public void testIteratorWithSingleVoiceMeasure() {
-		final Measure singleVoiceMeasure = new Measure(1, singleNoteVoice, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
+		final Measure singleVoiceMeasure = Measure.of(1, singleNoteVoice, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
 		final int noteCount = 0;
 
 		final List<Durational> expected = singleNoteVoice.get(0);
@@ -132,7 +121,7 @@ public class MeasureTest {
 
 	@Test
 	public void testIteratorWithMultiVoiceMeasure() {
-		final Measure multiVoiceMeasure = new Measure(1, multipleNoteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
+		final Measure multiVoiceMeasure = Measure.of(1, multipleNoteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
 		final int noteCount = 0;
 
 		final List<Durational> expected = new ArrayList<>();
@@ -154,7 +143,7 @@ public class MeasureTest {
 
 	@Test
 	public void testIteratorRemoveDisabled() {
-		final Measure m = new Measure(1, multipleNoteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
+		final Measure m = Measure.of(1, multipleNoteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
 
 		try {
 			final Iterator<Durational> iter = m.iterator();
@@ -170,7 +159,7 @@ public class MeasureTest {
 	public void testIteratorWithEmptyMeasure() {
 		final Map<Integer, List<Durational>> voices = new HashMap<>();
 		voices.put(0, new ArrayList<>());
-		final Measure emptyMeasure = new Measure(1, voices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
+		final Measure emptyMeasure = Measure.of(1, voices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
 
 		int noteElemCount = 0;
 
@@ -189,7 +178,7 @@ public class MeasureTest {
 		noteVoices.put(1, noteList);
 		noteVoices.put(3, noteList);
 
-		final Measure measure = new Measure(1, noteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
+		final Measure measure = Measure.of(1, noteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
 
 		final List<Durational> expected = new ArrayList<>(noteList);
 		for (Durational d : noteList) {

--- a/src/test/java/org/wmn4j/notation/elements/MultiStaffPartTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/MultiStaffPartTest.java
@@ -16,9 +16,6 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.wmn4j.notation.TestHelper;
-import org.wmn4j.notation.elements.Measure;
-import org.wmn4j.notation.elements.MultiStaffPart;
-import org.wmn4j.notation.elements.Staff;
 
 /**
  *
@@ -42,7 +39,7 @@ public class MultiStaffPartTest {
 	@Test
 	public void testImmutability() {
 		final Map<Integer, Staff> testStavesCopy = new HashMap<>(this.testStaves);
-		final MultiStaffPart part = new MultiStaffPart("Test staff", testStavesCopy);
+		final MultiStaffPart part = MultiStaffPart.of("Test staff", testStavesCopy);
 
 		final List<Measure> testMeasures = new ArrayList<>();
 		testMeasures.add(TestHelper.getTestMeasure(1));
@@ -54,7 +51,7 @@ public class MultiStaffPartTest {
 
 	@Test
 	public void testIterator() {
-		final MultiStaffPart part = new MultiStaffPart("Test staff", this.testStaves);
+		final MultiStaffPart part = MultiStaffPart.of("Test staff", this.testStaves);
 
 		final int expectedCount = 10;
 		int count = 0;
@@ -92,7 +89,7 @@ public class MultiStaffPartTest {
 		staves.put(1, new Staff(measures));
 		staves.put(2, new Staff(measures));
 
-		final MultiStaffPart part = new MultiStaffPart("Test Staff", staves);
+		final MultiStaffPart part = MultiStaffPart.of("Test Staff", staves);
 
 		final int expectedCount = 10;
 		int count = 0;
@@ -121,13 +118,13 @@ public class MultiStaffPartTest {
 
 	@Test
 	public void testIteratorImmutability() {
-		final MultiStaffPart part = new MultiStaffPart("Test staff", this.testStaves);
+		final MultiStaffPart part = MultiStaffPart.of("Test staff", this.testStaves);
 		final Iterator<Measure> iterator = part.iterator();
 		iterator.next();
 		try {
 			iterator.remove();
 			fail("Did not throw exception when calling remove on iterator");
 		} catch (final Exception e) {
-		/* Do nothing */ }
+			/* Do nothing */ }
 	}
 }

--- a/src/test/java/org/wmn4j/notation/elements/MultiStaffPartTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/MultiStaffPartTest.java
@@ -32,8 +32,8 @@ public class MultiStaffPartTest {
 			measures.add(TestHelper.getTestMeasure(i));
 		}
 
-		this.testStaves.put(1, new Staff(measures));
-		this.testStaves.put(2, new Staff(measures));
+		this.testStaves.put(1, Staff.of(measures));
+		this.testStaves.put(2, Staff.of(measures));
 	}
 
 	@Test
@@ -43,7 +43,7 @@ public class MultiStaffPartTest {
 
 		final List<Measure> testMeasures = new ArrayList<>();
 		testMeasures.add(TestHelper.getTestMeasure(1));
-		testStavesCopy.put(1, new Staff(testMeasures));
+		testStavesCopy.put(1, Staff.of(testMeasures));
 
 		assertTrue("Modifying map that was used to create MultiStaffPart changed the MultiStaffPart.",
 				part.getStaff(1).getMeasure(1) == this.testStaves.get(1).getMeasure(1));
@@ -86,8 +86,8 @@ public class MultiStaffPartTest {
 			measures.add(TestHelper.getTestMeasure(i));
 		}
 
-		staves.put(1, new Staff(measures));
-		staves.put(2, new Staff(measures));
+		staves.put(1, Staff.of(measures));
+		staves.put(2, Staff.of(measures));
 
 		final MultiStaffPart part = MultiStaffPart.of("Test Staff", staves);
 

--- a/src/test/java/org/wmn4j/notation/elements/NoteTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/NoteTest.java
@@ -46,7 +46,7 @@ public class NoteTest {
 		final Note A1Copy = Note.of(Pitch.Base.A, 0, 1, Durations.QUARTER);
 		final Note B1 = Note.of(Pitch.Base.B, 0, 1, Durations.QUARTER);
 		final Note Asharp1 = Note.of(Pitch.Base.A, 1, 1, Durations.QUARTER);
-		final Note C4 = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final Note C4 = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
 
 		assertTrue(A1.equals(A1));
 		assertTrue(A1.equals(A1Copy));
@@ -54,9 +54,9 @@ public class NoteTest {
 		assertFalse(A1.equals(A1differentDur));
 		assertFalse(A1.equals(B1));
 		assertFalse(A1.equals(Asharp1));
-		assertTrue(C4.equals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+		assertTrue(C4.equals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER)));
 
-		final Pitch pitch = Pitch.getPitch(Pitch.Base.C, 0, 1);
+		final Pitch pitch = Pitch.of(Pitch.Base.C, 0, 1);
 		final HashSet<Articulation> articulations = new HashSet<>();
 		articulations.add(Articulation.STACCATO);
 		final Note note1 = Note.of(pitch, Durations.EIGHT, articulations);
@@ -97,7 +97,7 @@ public class NoteTest {
 
 	@Test
 	public void testHasArticulation() {
-		final Pitch pitch = Pitch.getPitch(Pitch.Base.C, 0, 1);
+		final Pitch pitch = Pitch.of(Pitch.Base.C, 0, 1);
 		final Set<Articulation> articulations = new HashSet<>();
 		articulations.add(Articulation.STACCATO);
 		assertTrue(Note.of(pitch, Durations.EIGHT, articulations).hasArticulation(Articulation.STACCATO));
@@ -106,7 +106,7 @@ public class NoteTest {
 
 	@Test
 	public void testHasArticulations() {
-		final Pitch pitch = Pitch.getPitch(Pitch.Base.C, 0, 1);
+		final Pitch pitch = Pitch.of(Pitch.Base.C, 0, 1);
 		final HashSet<Articulation> articulations = new HashSet<>();
 		articulations.add(Articulation.STACCATO);
 		assertTrue(Note.of(pitch, Durations.EIGHT, articulations).hasArticulations());
@@ -115,7 +115,7 @@ public class NoteTest {
 
 	@Test
 	public void testGetArticulations() {
-		final Pitch pitch = Pitch.getPitch(Pitch.Base.C, 0, 1);
+		final Pitch pitch = Pitch.of(Pitch.Base.C, 0, 1);
 		assertTrue(Note.of(pitch, Durations.EIGHT).getArticulations().isEmpty());
 
 		final Set<Articulation> articulations = new HashSet<>();
@@ -138,8 +138,8 @@ public class NoteTest {
 
 	@Test
 	public void testTies() {
-		final NoteBuilder firstBuilder = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		final NoteBuilder secondBuilder = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT);
+		final NoteBuilder firstBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final NoteBuilder secondBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT);
 		firstBuilder.addTieToFollowing(secondBuilder);
 
 		final Note secondNote = secondBuilder.build();
@@ -156,11 +156,11 @@ public class NoteTest {
 
 	@Test
 	public void testTiedDuration() {
-		final Note untied = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final Note untied = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
 		assertEquals(Durations.QUARTER, untied.getTiedDuration());
 
-		final NoteBuilder firstBuilder = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		final NoteBuilder secondBuilder = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT);
+		final NoteBuilder firstBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final NoteBuilder secondBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT);
 		firstBuilder.addTieToFollowing(secondBuilder);
 
 		Note firstNote = firstBuilder.build();
@@ -172,7 +172,7 @@ public class NoteTest {
 		firstBuilder.clearCache();
 		secondBuilder.clearCache();
 
-		final NoteBuilder thirdBuilder = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.EIGHT);
+		final NoteBuilder thirdBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT);
 		secondBuilder.addTieToFollowing(thirdBuilder);
 
 		firstNote = firstBuilder.build();

--- a/src/test/java/org/wmn4j/notation/elements/NoteTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/NoteTest.java
@@ -41,12 +41,12 @@ public class NoteTest {
 
 	@Test
 	public void testEquals() {
-		final Note A1 = Note.getNote(Pitch.Base.A, 0, 1, Durations.QUARTER);
-		final Note A1differentDur = Note.getNote(Pitch.Base.A, 0, 1, Durations.EIGHT);
-		final Note A1Copy = Note.getNote(Pitch.Base.A, 0, 1, Durations.QUARTER);
-		final Note B1 = Note.getNote(Pitch.Base.B, 0, 1, Durations.QUARTER);
-		final Note Asharp1 = Note.getNote(Pitch.Base.A, 1, 1, Durations.QUARTER);
-		final Note C4 = Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final Note A1 = Note.of(Pitch.Base.A, 0, 1, Durations.QUARTER);
+		final Note A1differentDur = Note.of(Pitch.Base.A, 0, 1, Durations.EIGHT);
+		final Note A1Copy = Note.of(Pitch.Base.A, 0, 1, Durations.QUARTER);
+		final Note B1 = Note.of(Pitch.Base.B, 0, 1, Durations.QUARTER);
+		final Note Asharp1 = Note.of(Pitch.Base.A, 1, 1, Durations.QUARTER);
+		final Note C4 = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
 
 		assertTrue(A1.equals(A1));
 		assertTrue(A1.equals(A1Copy));
@@ -54,17 +54,17 @@ public class NoteTest {
 		assertFalse(A1.equals(A1differentDur));
 		assertFalse(A1.equals(B1));
 		assertFalse(A1.equals(Asharp1));
-		assertTrue(C4.equals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+		assertTrue(C4.equals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER)));
 
 		final Pitch pitch = Pitch.getPitch(Pitch.Base.C, 0, 1);
 		final HashSet<Articulation> articulations = new HashSet<>();
 		articulations.add(Articulation.STACCATO);
-		final Note note1 = Note.getNote(pitch, Durations.EIGHT, articulations);
+		final Note note1 = Note.of(pitch, Durations.EIGHT, articulations);
 		articulations.add(Articulation.TENUTO);
-		final Note note2 = Note.getNote(pitch, Durations.EIGHT, articulations);
-		final Note note3 = Note.getNote(pitch, Durations.EIGHT, articulations);
+		final Note note2 = Note.of(pitch, Durations.EIGHT, articulations);
+		final Note note3 = Note.of(pitch, Durations.EIGHT, articulations);
 
-		assertFalse(note1.equals(Note.getNote(pitch, Durations.EIGHT)));
+		assertFalse(note1.equals(Note.of(pitch, Durations.EIGHT)));
 		assertFalse(note1.equals(note2));
 		assertTrue(note2.equals(note2));
 		assertTrue(note2.equals(note3));
@@ -74,21 +74,21 @@ public class NoteTest {
 	public void testCreatingInvalidNote() {
 
 		try {
-			final Note note = Note.getNote(Pitch.Base.C, 5, 1, Durations.QUARTER);
+			final Note note = Note.of(Pitch.Base.C, 5, 1, Durations.QUARTER);
 			fail("No exception was thrown. Expected: IllegalArgumentException");
 		} catch (final Exception e) {
 			assertTrue(e instanceof IllegalArgumentException);
 		}
 
 		try {
-			final Note note = Note.getNote(Pitch.Base.C, 0, 11, Durations.QUARTER);
+			final Note note = Note.of(Pitch.Base.C, 0, 11, Durations.QUARTER);
 			fail("No exception was thrown. Expected: IllegalArgumentException");
 		} catch (final Exception e) {
 			assertTrue(e instanceof IllegalArgumentException);
 		}
 
 		try {
-			final Note note = Note.getNote(Pitch.Base.C, 0, 1, null);
+			final Note note = Note.of(Pitch.Base.C, 0, 1, null);
 			fail("No exception was thrown. Expected: IllegalArgumentException");
 		} catch (final Exception e) {
 			assertTrue(e instanceof NullPointerException);
@@ -100,8 +100,8 @@ public class NoteTest {
 		final Pitch pitch = Pitch.getPitch(Pitch.Base.C, 0, 1);
 		final Set<Articulation> articulations = new HashSet<>();
 		articulations.add(Articulation.STACCATO);
-		assertTrue(Note.getNote(pitch, Durations.EIGHT, articulations).hasArticulation(Articulation.STACCATO));
-		assertFalse(Note.getNote(pitch, Durations.EIGHT).hasArticulation(Articulation.STACCATO));
+		assertTrue(Note.of(pitch, Durations.EIGHT, articulations).hasArticulation(Articulation.STACCATO));
+		assertFalse(Note.of(pitch, Durations.EIGHT).hasArticulation(Articulation.STACCATO));
 	}
 
 	@Test
@@ -109,19 +109,19 @@ public class NoteTest {
 		final Pitch pitch = Pitch.getPitch(Pitch.Base.C, 0, 1);
 		final HashSet<Articulation> articulations = new HashSet<>();
 		articulations.add(Articulation.STACCATO);
-		assertTrue(Note.getNote(pitch, Durations.EIGHT, articulations).hasArticulations());
-		assertFalse(Note.getNote(pitch, Durations.EIGHT).hasArticulations());
+		assertTrue(Note.of(pitch, Durations.EIGHT, articulations).hasArticulations());
+		assertFalse(Note.of(pitch, Durations.EIGHT).hasArticulations());
 	}
 
 	@Test
 	public void testGetArticulations() {
 		final Pitch pitch = Pitch.getPitch(Pitch.Base.C, 0, 1);
-		assertTrue(Note.getNote(pitch, Durations.EIGHT).getArticulations().isEmpty());
+		assertTrue(Note.of(pitch, Durations.EIGHT).getArticulations().isEmpty());
 
 		final Set<Articulation> articulations = new HashSet<>();
 		articulations.add(Articulation.STACCATO);
 		articulations.add(Articulation.TENUTO);
-		final Note note = Note.getNote(pitch, Durations.EIGHT, articulations);
+		final Note note = Note.of(pitch, Durations.EIGHT, articulations);
 
 		final Set<Articulation> artic = note.getArticulations();
 		assertEquals(2, artic.size());
@@ -156,7 +156,7 @@ public class NoteTest {
 
 	@Test
 	public void testTiedDuration() {
-		final Note untied = Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final Note untied = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
 		assertEquals(Durations.QUARTER, untied.getTiedDuration());
 
 		final NoteBuilder firstBuilder = new NoteBuilder(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);

--- a/src/test/java/org/wmn4j/notation/elements/PitchTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/PitchTest.java
@@ -33,71 +33,71 @@ public class PitchTest {
 
 	@Test
 	public void testToInt() {
-		assertEquals(12, Pitch.getPitch(Pitch.Base.C, 0, 0).toInt());
-		assertEquals(60, Pitch.getPitch(Pitch.Base.C, 0, 4).toInt());
-		assertEquals(66, Pitch.getPitch(Pitch.Base.F, 1, 4).toInt());
-		assertEquals(51, Pitch.getPitch(Pitch.Base.E, -1, 3).toInt());
+		assertEquals(12, Pitch.of(Pitch.Base.C, 0, 0).toInt());
+		assertEquals(60, Pitch.of(Pitch.Base.C, 0, 4).toInt());
+		assertEquals(66, Pitch.of(Pitch.Base.F, 1, 4).toInt());
+		assertEquals(51, Pitch.of(Pitch.Base.E, -1, 3).toInt());
 	}
 
 	@Test
 	public void testGetPitchClass() {
-		assertEquals(PitchClass.C, Pitch.getPitch(Pitch.Base.C, 0, 5).getPitchClass());
-		assertEquals(PitchClass.GSHARP_AFLAT, Pitch.getPitch(Pitch.Base.A, -1, 3).getPitchClass());
-		assertEquals(PitchClass.B, Pitch.getPitch(Pitch.Base.B, 0, 2).getPitchClass());
+		assertEquals(PitchClass.C, Pitch.of(Pitch.Base.C, 0, 5).getPitchClass());
+		assertEquals(PitchClass.GSHARP_AFLAT, Pitch.of(Pitch.Base.A, -1, 3).getPitchClass());
+		assertEquals(PitchClass.B, Pitch.of(Pitch.Base.B, 0, 2).getPitchClass());
 	}
 
 	@Test
 	public void testGetPCNumber() {
-		assertEquals(0, Pitch.getPitch(Pitch.Base.C, 0, 5).getPitchClassNumber());
-		assertEquals(8, Pitch.getPitch(Pitch.Base.A, -1, 3).getPitchClassNumber());
-		assertEquals(11, Pitch.getPitch(Pitch.Base.B, 0, 2).getPitchClassNumber());
+		assertEquals(0, Pitch.of(Pitch.Base.C, 0, 5).getPitchClassNumber());
+		assertEquals(8, Pitch.of(Pitch.Base.A, -1, 3).getPitchClassNumber());
+		assertEquals(11, Pitch.of(Pitch.Base.B, 0, 2).getPitchClassNumber());
 	}
 
 	@Test
 	public void testToString() {
-		assertEquals("F0", Pitch.getPitch(Pitch.Base.F, 0, 0).toString());
-		assertEquals("Eb2", Pitch.getPitch(Pitch.Base.E, -1, 2).toString());
-		assertEquals("G#3", Pitch.getPitch(Pitch.Base.G, 1, 3).toString());
-		assertEquals("Abb2", Pitch.getPitch(Pitch.Base.A, -2, 2).toString());
-		assertEquals("D##6", Pitch.getPitch(Pitch.Base.D, 2, 6).toString());
+		assertEquals("F0", Pitch.of(Pitch.Base.F, 0, 0).toString());
+		assertEquals("Eb2", Pitch.of(Pitch.Base.E, -1, 2).toString());
+		assertEquals("G#3", Pitch.of(Pitch.Base.G, 1, 3).toString());
+		assertEquals("Abb2", Pitch.of(Pitch.Base.A, -2, 2).toString());
+		assertEquals("D##6", Pitch.of(Pitch.Base.D, 2, 6).toString());
 	}
 
 	@Test
 	public void testEquals() {
-		assertTrue(Pitch.getPitch(Pitch.Base.C, 0, 2).equals(Pitch.getPitch(Pitch.Base.C, 0, 2)));
-		assertTrue(Pitch.getPitch(Pitch.Base.C, 1, 3).equals(Pitch.getPitch(Pitch.Base.C, 1, 3)));
-		assertTrue(Pitch.getPitch(Pitch.Base.C, -1, 2).equals(Pitch.getPitch(Pitch.Base.C, -1, 2)));
+		assertTrue(Pitch.of(Pitch.Base.C, 0, 2).equals(Pitch.of(Pitch.Base.C, 0, 2)));
+		assertTrue(Pitch.of(Pitch.Base.C, 1, 3).equals(Pitch.of(Pitch.Base.C, 1, 3)));
+		assertTrue(Pitch.of(Pitch.Base.C, -1, 2).equals(Pitch.of(Pitch.Base.C, -1, 2)));
 
-		assertFalse(Pitch.getPitch(Pitch.Base.C, 0, 2).equals(Pitch.getPitch(Pitch.Base.D, 0, 2)));
-		assertFalse(Pitch.getPitch(Pitch.Base.C, 0, 2).equals(Pitch.getPitch(Pitch.Base.C, 1, 2)));
-		assertFalse(Pitch.getPitch(Pitch.Base.C, -1, 3).equals(Pitch.getPitch(Pitch.Base.D, -1, 2)));
+		assertFalse(Pitch.of(Pitch.Base.C, 0, 2).equals(Pitch.of(Pitch.Base.D, 0, 2)));
+		assertFalse(Pitch.of(Pitch.Base.C, 0, 2).equals(Pitch.of(Pitch.Base.C, 1, 2)));
+		assertFalse(Pitch.of(Pitch.Base.C, -1, 3).equals(Pitch.of(Pitch.Base.D, -1, 2)));
 	}
 
 	@Test
 	public void testEqualsEnharmonically() {
-		assertTrue(Pitch.getPitch(Pitch.Base.C, 1, 2).equalsEnharmonically(Pitch.getPitch(Pitch.Base.C, 1, 2)));
-		assertTrue(Pitch.getPitch(Pitch.Base.C, 1, 2).equalsEnharmonically(Pitch.getPitch(Pitch.Base.D, -1, 2)));
-		assertFalse(Pitch.getPitch(Pitch.Base.C, 1, 2).equalsEnharmonically(Pitch.getPitch(Pitch.Base.D, -1, 3)));
+		assertTrue(Pitch.of(Pitch.Base.C, 1, 2).equalsEnharmonically(Pitch.of(Pitch.Base.C, 1, 2)));
+		assertTrue(Pitch.of(Pitch.Base.C, 1, 2).equalsEnharmonically(Pitch.of(Pitch.Base.D, -1, 2)));
+		assertFalse(Pitch.of(Pitch.Base.C, 1, 2).equalsEnharmonically(Pitch.of(Pitch.Base.D, -1, 3)));
 	}
 
 	@Test
 	public void testHigherThan() {
-		assertTrue(Pitch.getPitch(Pitch.Base.C, 0, 3).isHigherThan(Pitch.getPitch(Pitch.Base.C, 0, 2)));
-		assertFalse(Pitch.getPitch(Pitch.Base.C, 0, 1).isHigherThan(Pitch.getPitch(Pitch.Base.C, 0, 1)));
-		assertFalse(Pitch.getPitch(Pitch.Base.C, 0, 2).isHigherThan(Pitch.getPitch(Pitch.Base.C, 0, 3)));
+		assertTrue(Pitch.of(Pitch.Base.C, 0, 3).isHigherThan(Pitch.of(Pitch.Base.C, 0, 2)));
+		assertFalse(Pitch.of(Pitch.Base.C, 0, 1).isHigherThan(Pitch.of(Pitch.Base.C, 0, 1)));
+		assertFalse(Pitch.of(Pitch.Base.C, 0, 2).isHigherThan(Pitch.of(Pitch.Base.C, 0, 3)));
 	}
 
 	@Test
 	public void testLowerThan() {
-		assertTrue(Pitch.getPitch(Pitch.Base.C, 0, 2).isLowerThan(Pitch.getPitch(Pitch.Base.C, 1, 2)));
-		assertFalse(Pitch.getPitch(Pitch.Base.E, 1, 4).isLowerThan(Pitch.getPitch(Pitch.Base.D, 0, 4)));
-		assertFalse(Pitch.getPitch(Pitch.Base.C, 0, 4).isLowerThan(Pitch.getPitch(Pitch.Base.C, 0, 3)));
+		assertTrue(Pitch.of(Pitch.Base.C, 0, 2).isLowerThan(Pitch.of(Pitch.Base.C, 1, 2)));
+		assertFalse(Pitch.of(Pitch.Base.E, 1, 4).isLowerThan(Pitch.of(Pitch.Base.D, 0, 4)));
+		assertFalse(Pitch.of(Pitch.Base.C, 0, 4).isLowerThan(Pitch.of(Pitch.Base.C, 0, 3)));
 	}
 
 	@Test
 	public void testCompareTo() {
-		assertTrue(0 == Pitch.getPitch(Pitch.Base.C, 0, 2).compareTo(Pitch.getPitch(Pitch.Base.C, 0, 2)));
-		assertTrue(0 > Pitch.getPitch(Pitch.Base.C, -1, 2).compareTo(Pitch.getPitch(Pitch.Base.C, 0, 2)));
-		assertTrue(0 < Pitch.getPitch(Pitch.Base.E, 0, 3).compareTo(Pitch.getPitch(Pitch.Base.D, 1, 3)));
+		assertTrue(0 == Pitch.of(Pitch.Base.C, 0, 2).compareTo(Pitch.of(Pitch.Base.C, 0, 2)));
+		assertTrue(0 > Pitch.of(Pitch.Base.C, -1, 2).compareTo(Pitch.of(Pitch.Base.C, 0, 2)));
+		assertTrue(0 < Pitch.of(Pitch.Base.E, 0, 3).compareTo(Pitch.of(Pitch.Base.D, 1, 3)));
 	}
 }

--- a/src/test/java/org/wmn4j/notation/elements/RestTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/RestTest.java
@@ -33,23 +33,23 @@ public class RestTest {
 
 	@Test
 	public void testGetDuration() {
-		assertTrue(Rest.getRest(Durations.EIGHT).getDuration().equals(Durations.EIGHT));
-		assertFalse(Rest.getRest(Durations.QUARTER).getDuration().equals(Durations.EIGHT));
+		assertTrue(Rest.of(Durations.EIGHT).getDuration().equals(Durations.EIGHT));
+		assertFalse(Rest.of(Durations.QUARTER).getDuration().equals(Durations.EIGHT));
 	}
 
 	@Test
 	public void testToString() {
-		assertEquals("R(1/4)", Rest.getRest(Durations.QUARTER).toString());
-		assertEquals("R(1/12)", Rest.getRest(Durations.EIGHT_TRIPLET).toString());
+		assertEquals("R(1/4)", Rest.of(Durations.QUARTER).toString());
+		assertEquals("R(1/12)", Rest.of(Durations.EIGHT_TRIPLET).toString());
 	}
 
 	@Test
 	public void testEquals() {
-		final Rest quarter = Rest.getRest(Durations.QUARTER);
-		final Rest half = Rest.getRest(Durations.HALF);
+		final Rest quarter = Rest.of(Durations.QUARTER);
+		final Rest half = Rest.of(Durations.HALF);
 
-		assertTrue(quarter.equals(Rest.getRest(Durations.QUARTER)));
-		assertTrue(Rest.getRest(Durations.QUARTER).equals(quarter));
+		assertTrue(quarter.equals(Rest.of(Durations.QUARTER)));
+		assertTrue(Rest.of(Durations.QUARTER).equals(quarter));
 		assertFalse(quarter.equals(half));
 	}
 }

--- a/src/test/java/org/wmn4j/notation/elements/ScoreTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/ScoreTest.java
@@ -129,11 +129,11 @@ public class ScoreTest {
 		}
 
 		// Test first note.
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER),
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER),
 				score.getAtPosition(new ScorePosition(0, 1, 1, 1, 0)));
 
 		// Test last note.
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 3), Durations.WHOLE),
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 3), Durations.WHOLE),
 				score.getAtPosition(new ScorePosition(1, 2, 3, 2, 0)));
 	}
 
@@ -159,6 +159,6 @@ public class ScoreTest {
 		// Get the middle note (E) from the chord in the score.
 		final ScorePosition position = new ScorePosition(0, 1, 1, 1, 1, 1);
 		final Note noteInChord = (Note) score.getAtPosition(position);
-		assertEquals(Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.HALF), noteInChord);
+		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.HALF), noteInChord);
 	}
 }

--- a/src/test/java/org/wmn4j/notation/elements/ScoreTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/ScoreTest.java
@@ -129,11 +129,11 @@ public class ScoreTest {
 		}
 
 		// Test first note.
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER),
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER),
 				score.getAtPosition(new ScorePosition(0, 1, 1, 1, 0)));
 
 		// Test last note.
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 3), Durations.WHOLE),
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 3), Durations.WHOLE),
 				score.getAtPosition(new ScorePosition(1, 2, 3, 2, 0)));
 	}
 
@@ -159,6 +159,6 @@ public class ScoreTest {
 		// Get the middle note (E) from the chord in the score.
 		final ScorePosition position = new ScorePosition(0, 1, 1, 1, 1, 1);
 		final Note noteInChord = (Note) score.getAtPosition(position);
-		assertEquals(Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.HALF), noteInChord);
+		assertEquals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.HALF), noteInChord);
 	}
 }

--- a/src/test/java/org/wmn4j/notation/elements/ScoreTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/ScoreTest.java
@@ -18,12 +18,6 @@ import java.util.NoSuchElementException;
 import org.junit.Test;
 import org.wmn4j.notation.TestHelper;
 import org.wmn4j.notation.builders.PartBuilder;
-import org.wmn4j.notation.elements.Durational;
-import org.wmn4j.notation.elements.Durations;
-import org.wmn4j.notation.elements.Note;
-import org.wmn4j.notation.elements.Part;
-import org.wmn4j.notation.elements.Pitch;
-import org.wmn4j.notation.elements.Score;
 import org.wmn4j.notation.iterators.PartWiseScoreIterator;
 import org.wmn4j.notation.iterators.ScoreIterator;
 import org.wmn4j.notation.iterators.ScorePosition;
@@ -64,7 +58,7 @@ public class ScoreTest {
 
 	@Test
 	public void testGetAttribute() {
-		final Score score = new Score(getTestAttributes(), getTestParts(5, 5));
+		final Score score = Score.of(getTestAttributes(), getTestParts(5, 5));
 		assertEquals(SCORE_NAME, score.getAttribute(Score.Attribute.NAME));
 		assertEquals(COMPOSER_NAME, score.getAttribute(Score.Attribute.COMPOSER));
 		assertEquals("", score.getAttribute(Score.Attribute.ARRANGER));
@@ -75,7 +69,7 @@ public class ScoreTest {
 		final Map<Score.Attribute, String> attributes = getTestAttributes();
 		final List<Part> parts = getTestParts(5, 5);
 
-		final Score score = new Score(attributes, parts);
+		final Score score = Score.of(attributes, parts);
 		assertEquals("Number of parts was incorrect before trying to modify.", 5, score.getPartCount());
 		parts.add(parts.get(0));
 		assertEquals("Adding part to the list used for creating score changed score.", 5, score.getPartCount());
@@ -88,7 +82,7 @@ public class ScoreTest {
 		try {
 			scoreParts.add(parts.get(0));
 		} catch (final Exception e) {
-		/* Do nothing */ }
+			/* Do nothing */ }
 		assertEquals("Number of parts changed in score", 5, score.getPartCount());
 	}
 
@@ -96,7 +90,7 @@ public class ScoreTest {
 	public void testIterator() {
 		final int partCount = 10;
 		final int measureCount = 10;
-		final Score score = new Score(getTestAttributes(), getTestParts(partCount, measureCount));
+		final Score score = Score.of(getTestAttributes(), getTestParts(partCount, measureCount));
 
 		int parts = 0;
 

--- a/src/test/java/org/wmn4j/notation/elements/SingleStaffPartTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/SingleStaffPartTest.java
@@ -17,19 +17,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
-import org.wmn4j.notation.elements.Chord;
-import org.wmn4j.notation.elements.Clefs;
-import org.wmn4j.notation.elements.Durational;
-import org.wmn4j.notation.elements.Durations;
-import org.wmn4j.notation.elements.KeySignature;
-import org.wmn4j.notation.elements.KeySignatures;
-import org.wmn4j.notation.elements.Measure;
-import org.wmn4j.notation.elements.Note;
-import org.wmn4j.notation.elements.Pitch;
-import org.wmn4j.notation.elements.Rest;
-import org.wmn4j.notation.elements.SingleStaffPart;
-import org.wmn4j.notation.elements.Staff;
-import org.wmn4j.notation.elements.TimeSignatures;
 
 /**
  *
@@ -63,7 +50,7 @@ public class SingleStaffPartTest {
 
 		final List<Measure> measureList = new ArrayList<>();
 		for (int i = 1; i <= this.measureCount; ++i) {
-			measureList.add(new Measure(i, noteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G));
+			measureList.add(Measure.of(i, noteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G));
 		}
 
 		this.measures = Collections.unmodifiableList(measureList);
@@ -128,7 +115,7 @@ public class SingleStaffPartTest {
 			iter.remove();
 			fail("Removing through iterator did not cause exception");
 		} catch (final Exception e) {
-		/* Ignore */ }
+			/* Ignore */ }
 
 		assertEquals(this.measureCount, part.getStaff().getMeasures().size());
 	}

--- a/src/test/java/org/wmn4j/notation/elements/SingleStaffPartTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/SingleStaffPartTest.java
@@ -29,10 +29,10 @@ public class SingleStaffPartTest {
 
 	KeySignature keySig = KeySignatures.CMAJ_AMIN;
 
-	Note C4 = Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.HALF);
-	Note E4 = Note.getNote(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.HALF);
-	Note G4 = Note.getNote(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.HALF);
-	Note C4Quarter = Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+	Note C4 = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.HALF);
+	Note E4 = Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.HALF);
+	Note G4 = Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.HALF);
+	Note C4Quarter = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
 
 	public SingleStaffPartTest() {
 		final Map<Integer, List<Durational>> noteVoice = new HashMap<>();

--- a/src/test/java/org/wmn4j/notation/elements/SingleStaffPartTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/SingleStaffPartTest.java
@@ -38,15 +38,15 @@ public class SingleStaffPartTest {
 		final Map<Integer, List<Durational>> noteVoice = new HashMap<>();
 		noteVoice.put(0, new ArrayList<>());
 		noteVoice.get(0).add(C4Quarter);
-		noteVoice.get(0).add(Rest.getRest(Durations.QUARTER));
+		noteVoice.get(0).add(Rest.of(Durations.QUARTER));
 		noteVoice.get(0).add(Chord.of(C4, E4, G4));
 
 		final Map<Integer, List<Durational>> noteVoices = new HashMap<>();
 		noteVoices.put(0, noteVoice.get(0));
 		noteVoices.put(1, new ArrayList<>());
-		noteVoices.get(1).add(Rest.getRest(Durations.QUARTER));
+		noteVoices.get(1).add(Rest.of(Durations.QUARTER));
 		noteVoices.get(1).add(C4);
-		noteVoices.get(1).add(Rest.getRest(Durations.QUARTER));
+		noteVoices.get(1).add(Rest.of(Durations.QUARTER));
 
 		final List<Measure> measureList = new ArrayList<>();
 		for (int i = 1; i <= this.measureCount; ++i) {

--- a/src/test/java/org/wmn4j/notation/elements/SingleStaffPartTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/SingleStaffPartTest.java
@@ -29,10 +29,10 @@ public class SingleStaffPartTest {
 
 	KeySignature keySig = KeySignatures.CMAJ_AMIN;
 
-	Note C4 = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.HALF);
-	Note E4 = Note.of(Pitch.getPitch(Pitch.Base.E, 0, 4), Durations.HALF);
-	Note G4 = Note.of(Pitch.getPitch(Pitch.Base.G, 0, 4), Durations.HALF);
-	Note C4Quarter = Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER);
+	Note C4 = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.HALF);
+	Note E4 = Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.HALF);
+	Note G4 = Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF);
+	Note C4Quarter = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
 
 	public SingleStaffPartTest() {
 		final Map<Integer, List<Durational>> noteVoice = new HashMap<>();

--- a/src/test/java/org/wmn4j/notation/elements/SingleStaffPartTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/SingleStaffPartTest.java
@@ -59,7 +59,7 @@ public class SingleStaffPartTest {
 	@Test
 	public void testImmutability() {
 		final List<Measure> measuresCopy = new ArrayList<>(this.measures);
-		final SingleStaffPart part = new SingleStaffPart("Test part", measuresCopy);
+		final SingleStaffPart part = SingleStaffPart.of("Test part", measuresCopy);
 		measuresCopy.set(0, null);
 		assertTrue("Modifying list used to create part modified part also.",
 				part.getStaff().getMeasures().get(0) != null);
@@ -67,33 +67,33 @@ public class SingleStaffPartTest {
 
 	@Test
 	public void testGetName() {
-		final SingleStaffPart part = new SingleStaffPart("Test part", this.measures);
+		final SingleStaffPart part = SingleStaffPart.of("Test part", this.measures);
 		assertEquals("Test part", part.getName());
 	}
 
 	@Test
 	public void testIsMultiStaff() {
-		final SingleStaffPart part = new SingleStaffPart("Test part", this.measures);
+		final SingleStaffPart part = SingleStaffPart.of("Test part", this.measures);
 		assertFalse(part.isMultiStaff());
 	}
 
 	@Test
 	public void testGetStaff() {
-		final SingleStaffPart part = new SingleStaffPart("Test part", this.measures);
+		final SingleStaffPart part = SingleStaffPart.of("Test part", this.measures);
 		final Staff staff = part.getStaff();
 		assertEquals(5, staff.getMeasures().size());
 	}
 
 	@Test
 	public void getMeasure() {
-		final SingleStaffPart part = new SingleStaffPart("Test part", this.measures);
+		final SingleStaffPart part = SingleStaffPart.of("Test part", this.measures);
 		final Measure m = part.getMeasure(1);
 		assertTrue(m == this.measures.get(0));
 	}
 
 	@Test
 	public void testIterator() {
-		final SingleStaffPart part = new SingleStaffPart("Test part", this.measures);
+		final SingleStaffPart part = SingleStaffPart.of("Test part", this.measures);
 		int measCount = 0;
 		int measureNumber = 1;
 		for (Measure m : part) {
@@ -107,7 +107,7 @@ public class SingleStaffPartTest {
 
 	@Test
 	public void testIteratorImmutability() {
-		final SingleStaffPart part = new SingleStaffPart("Test part", this.measures);
+		final SingleStaffPart part = SingleStaffPart.of("Test part", this.measures);
 		final Iterator<Measure> iter = part.iterator();
 		iter.next();
 

--- a/src/test/java/org/wmn4j/notation/elements/SingleStaffPartTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/SingleStaffPartTest.java
@@ -52,7 +52,7 @@ public class SingleStaffPartTest {
 		noteVoice.put(0, new ArrayList<>());
 		noteVoice.get(0).add(C4Quarter);
 		noteVoice.get(0).add(Rest.getRest(Durations.QUARTER));
-		noteVoice.get(0).add(Chord.getChord(C4, E4, G4));
+		noteVoice.get(0).add(Chord.of(C4, E4, G4));
 
 		final Map<Integer, List<Durational>> noteVoices = new HashMap<>();
 		noteVoices.put(0, noteVoice.get(0));

--- a/src/test/java/org/wmn4j/notation/elements/StaffTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/StaffTest.java
@@ -16,17 +16,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
-import org.wmn4j.notation.elements.Clefs;
-import org.wmn4j.notation.elements.Durational;
-import org.wmn4j.notation.elements.Durations;
-import org.wmn4j.notation.elements.KeySignatures;
-import org.wmn4j.notation.elements.Measure;
-import org.wmn4j.notation.elements.Note;
-import org.wmn4j.notation.elements.Pitch;
-import org.wmn4j.notation.elements.Rest;
-import org.wmn4j.notation.elements.Staff;
-import org.wmn4j.notation.elements.TimeSignature;
-import org.wmn4j.notation.elements.TimeSignatures;
 
 /**
  *
@@ -46,8 +35,8 @@ public class StaffTest {
 		notes.get(0).add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
 		notes.get(0).add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
 		notes.get(0).add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		measures.add(new Measure(1, notes, timeSig, KeySignatures.CMAJ_AMIN, Clefs.G));
-		measures.add(new Measure(2, notes, timeSig, KeySignatures.CMAJ_AMIN, Clefs.G));
+		measures.add(Measure.of(1, notes, timeSig, KeySignatures.CMAJ_AMIN, Clefs.G));
+		measures.add(Measure.of(2, notes, timeSig, KeySignatures.CMAJ_AMIN, Clefs.G));
 		return measures;
 	}
 
@@ -72,7 +61,7 @@ public class StaffTest {
 		voice.add(Rest.getRest(Durations.WHOLE));
 		final Map<Integer, List<Durational>> notes = new HashMap<>();
 		notes.put(1, voice);
-		origMeasures.add(new Measure(3, notes, TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN, Clefs.G));
+		origMeasures.add(Measure.of(3, notes, TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN, Clefs.G));
 		assertEquals(sizeBeforeAddition, staff.getMeasures().size());
 	}
 
@@ -127,7 +116,7 @@ public class StaffTest {
 		voice.add(Rest.getRest(Durations.WHOLE));
 		final Map<Integer, List<Durational>> notes = new HashMap<>();
 		notes.put(1, voice);
-		measures.add(new Measure(0, notes, TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN, Clefs.G));
+		measures.add(Measure.of(0, notes, TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN, Clefs.G));
 		measures.addAll(getTestMeasures());
 
 		final Staff staff = new Staff(measures);

--- a/src/test/java/org/wmn4j/notation/elements/StaffTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/StaffTest.java
@@ -31,10 +31,10 @@ public class StaffTest {
 		final TimeSignature timeSig = TimeSignature.getTimeSignature(4, 4);
 		final Map<Integer, List<Durational>> notes = new HashMap<>();
 		notes.put(0, new ArrayList<>());
-		notes.get(0).add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		notes.get(0).add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		notes.get(0).add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		notes.get(0).add(Note.getNote(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		notes.get(0).add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		notes.get(0).add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		notes.get(0).add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		notes.get(0).add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
 		measures.add(Measure.of(1, notes, timeSig, KeySignatures.CMAJ_AMIN, Clefs.G));
 		measures.add(Measure.of(2, notes, timeSig, KeySignatures.CMAJ_AMIN, Clefs.G));
 		return measures;

--- a/src/test/java/org/wmn4j/notation/elements/StaffTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/StaffTest.java
@@ -58,7 +58,7 @@ public class StaffTest {
 
 		final int sizeBeforeAddition = origMeasures.size();
 		final List<Durational> voice = new ArrayList<>();
-		voice.add(Rest.getRest(Durations.WHOLE));
+		voice.add(Rest.of(Durations.WHOLE));
 		final Map<Integer, List<Durational>> notes = new HashMap<>();
 		notes.put(1, voice);
 		origMeasures.add(Measure.of(3, notes, TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN, Clefs.G));
@@ -113,7 +113,7 @@ public class StaffTest {
 	public void testGetMeasureWithPickup() {
 		final List<Measure> measures = new ArrayList<>();
 		final List<Durational> voice = new ArrayList<>();
-		voice.add(Rest.getRest(Durations.WHOLE));
+		voice.add(Rest.of(Durations.WHOLE));
 		final Map<Integer, List<Durational>> notes = new HashMap<>();
 		notes.put(1, voice);
 		measures.add(Measure.of(0, notes, TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN, Clefs.G));

--- a/src/test/java/org/wmn4j/notation/elements/StaffTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/StaffTest.java
@@ -43,7 +43,7 @@ public class StaffTest {
 	@Test
 	public void testGetMeasures() {
 		final List<Measure> origMeasures = getTestMeasures();
-		final Staff staff = new Staff(origMeasures);
+		final Staff staff = Staff.of(origMeasures);
 
 		final List<Measure> measures = staff.getMeasures();
 
@@ -68,7 +68,7 @@ public class StaffTest {
 	@Test
 	public void testIterator() {
 		final List<Measure> origMeasures = getTestMeasures();
-		final Staff staff = new Staff(origMeasures);
+		final Staff staff = Staff.of(origMeasures);
 
 		int measureCount = 0;
 		int prevMeasureNum = 0;
@@ -85,7 +85,7 @@ public class StaffTest {
 	@Test
 	public void testIteratorRemoveDisabled() {
 		final List<Measure> origMeasures = getTestMeasures();
-		final Staff staff = new Staff(origMeasures);
+		final Staff staff = Staff.of(origMeasures);
 
 		try {
 			final Iterator<Measure> iter = staff.iterator();
@@ -100,7 +100,7 @@ public class StaffTest {
 	@Test
 	public void testGetMeasure() {
 		final List<Measure> measures = getTestMeasures();
-		final Staff staff = new Staff(measures);
+		final Staff staff = Staff.of(measures);
 
 		assertFalse(staff.hasPickupMeasure());
 
@@ -119,7 +119,7 @@ public class StaffTest {
 		measures.add(Measure.of(0, notes, TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN, Clefs.G));
 		measures.addAll(getTestMeasures());
 
-		final Staff staff = new Staff(measures);
+		final Staff staff = Staff.of(measures);
 		assertTrue(staff.hasPickupMeasure());
 
 		for (int measureNumber = 0; measureNumber < measures.size(); ++measureNumber) {

--- a/src/test/java/org/wmn4j/notation/elements/StaffTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/StaffTest.java
@@ -31,10 +31,10 @@ public class StaffTest {
 		final TimeSignature timeSig = TimeSignature.getTimeSignature(4, 4);
 		final Map<Integer, List<Durational>> notes = new HashMap<>();
 		notes.put(0, new ArrayList<>());
-		notes.get(0).add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		notes.get(0).add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		notes.get(0).add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		notes.get(0).add(Note.of(Pitch.getPitch(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		notes.get(0).add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		notes.get(0).add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		notes.get(0).add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		notes.get(0).add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
 		measures.add(Measure.of(1, notes, timeSig, KeySignatures.CMAJ_AMIN, Clefs.G));
 		measures.add(Measure.of(2, notes, timeSig, KeySignatures.CMAJ_AMIN, Clefs.G));
 		return measures;

--- a/src/test/java/org/wmn4j/notation/elements/StaffTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/StaffTest.java
@@ -28,7 +28,7 @@ public class StaffTest {
 
 	static List<Measure> getTestMeasures() {
 		final List<Measure> measures = new ArrayList<>();
-		final TimeSignature timeSig = TimeSignature.getTimeSignature(4, 4);
+		final TimeSignature timeSig = TimeSignature.of(4, 4);
 		final Map<Integer, List<Durational>> notes = new HashMap<>();
 		notes.put(0, new ArrayList<>());
 		notes.get(0).add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));

--- a/src/test/java/org/wmn4j/notation/elements/TimeSignatureTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/TimeSignatureTest.java
@@ -34,7 +34,7 @@ public class TimeSignatureTest {
 
 	@Test
 	public void testGetTimeSignature() {
-		final TimeSignature timeSig = TimeSignature.getTimeSignature(4, 4);
+		final TimeSignature timeSig = TimeSignature.of(4, 4);
 		assertEquals(4, timeSig.getBeatCount());
 		assertEquals(Durations.QUARTER, timeSig.getBeatDuration());
 	}
@@ -44,15 +44,15 @@ public class TimeSignatureTest {
 		assertEquals(Durations.WHOLE, TimeSignatures.FOUR_FOUR.getTotalDuration());
 		assertEquals(Durations.EIGHT.multiplyBy(6), TimeSignatures.SIX_EIGHT.getTotalDuration());
 		assertEquals(Durations.EIGHT.multiplyBy(13),
-				TimeSignature.getTimeSignature(13, Durations.EIGHT).getTotalDuration());
+				TimeSignature.of(13, Durations.EIGHT).getTotalDuration());
 	}
 
 	@Test
 	public void testEquals() {
-		final TimeSignature timeSigA = TimeSignature.getTimeSignature(4, 4);
-		final TimeSignature timeSigB = TimeSignature.getTimeSignature(4, 4);
-		final TimeSignature timeSigC = TimeSignature.getTimeSignature(3, 4);
-		final TimeSignature timeSigD = TimeSignature.getTimeSignature(4, 8);
+		final TimeSignature timeSigA = TimeSignature.of(4, 4);
+		final TimeSignature timeSigB = TimeSignature.of(4, 4);
+		final TimeSignature timeSigC = TimeSignature.of(3, 4);
+		final TimeSignature timeSigD = TimeSignature.of(4, 8);
 
 		assertTrue(timeSigA.equals(timeSigB));
 		assertFalse(timeSigA.equals(timeSigC));
@@ -61,7 +61,7 @@ public class TimeSignatureTest {
 
 	@Test
 	public void testToString() {
-		final TimeSignature timeSigA = TimeSignature.getTimeSignature(4, 4);
+		final TimeSignature timeSigA = TimeSignature.of(4, 4);
 		assertEquals("Time(4/4)", timeSigA.toString());
 	}
 }

--- a/src/test/java/org/wmn4j/notation/iterators/PartWiseScoreIteratorTest.java
+++ b/src/test/java/org/wmn4j/notation/iterators/PartWiseScoreIteratorTest.java
@@ -65,7 +65,7 @@ public class PartWiseScoreIteratorTest {
 		Durational next = moveIterSteps(1);
 		assertTrue(next instanceof Note);
 		Note n = (Note) next;
-		assertEquals(Pitch.getPitch(Pitch.Base.C, 0, 4), n.getPitch());
+		assertEquals(Pitch.of(Pitch.Base.C, 0, 4), n.getPitch());
 		assertEquals(Durations.QUARTER, n.getDuration());
 
 		// Move to the rest in the first measure of top part.
@@ -82,7 +82,7 @@ public class PartWiseScoreIteratorTest {
 		next = moveIterSteps(5);
 		assertTrue(next instanceof Note);
 		n = (Note) next;
-		assertEquals(Pitch.getPitch(Pitch.Base.C, 0, 4), n.getPitch());
+		assertEquals(Pitch.of(Pitch.Base.C, 0, 4), n.getPitch());
 		assertEquals(Durations.QUARTER, n.getDuration());
 	}
 


### PR DESCRIPTION
* Use the name of for static factory methods consistently because in the majority of cases it works well.
* Use static factory methods throughout the notation elements package for getting instances for consistency's sake.