### PR TITLE
Issue #53: Finish up MeasureBuilder

### DIFF
--- a/src/main/java/org/wmn4j/notation/builders/ChordBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/ChordBuilder.java
@@ -69,6 +69,7 @@ public class ChordBuilder implements DurationalBuilder, Iterable<NoteBuilder> {
 	 *
 	 * @param duration Duration to set
 	 */
+	@Override
 	public void setDuration(Duration duration) {
 		for (NoteBuilder builder : this) {
 			builder.setDuration(duration);

--- a/src/main/java/org/wmn4j/notation/builders/DurationalBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/DurationalBuilder.java
@@ -24,4 +24,11 @@ public interface DurationalBuilder {
 	 * @return the duration set in this builder
 	 */
 	Duration getDuration();
+
+	/**
+	 * Sets the duration of this builder to the given value.
+	 *
+	 * @param duration the duration that is set to this builder
+	 */
+	void setDuration(Duration duration);
 }

--- a/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
@@ -37,6 +37,7 @@ public class MeasureBuilder {
 	private int number;
 	private final Map<Integer, List<DurationalBuilder>> voices;
 	private final MeasureAttributesBuilder attributesBuilder;
+	private final MeasureAttributes initialMeasureAttributes;
 
 	/**
 	 * Create a measure builder with the given attributes.
@@ -47,7 +48,8 @@ public class MeasureBuilder {
 	public MeasureBuilder(int number, MeasureAttributes measureAttributes) {
 		this.voices = new HashMap<>();
 		this.number = number;
-		attributesBuilder = new MeasureAttributesBuilder(measureAttributes);
+		this.attributesBuilder = new MeasureAttributesBuilder(measureAttributes);
+		this.initialMeasureAttributes = measureAttributes;
 	}
 
 	/**
@@ -58,7 +60,8 @@ public class MeasureBuilder {
 	public MeasureBuilder(int number) {
 		this.voices = new HashMap<>();
 		this.number = number;
-		attributesBuilder = new MeasureAttributesBuilder();
+		this.attributesBuilder = new MeasureAttributesBuilder();
+		this.initialMeasureAttributes = null;
 	}
 
 	/**
@@ -346,7 +349,11 @@ public class MeasureBuilder {
 	 * @return a measure with the values set in this builder
 	 */
 	public Measure build() {
-		final MeasureAttributes measureAttributes = attributesBuilder.build();
+		MeasureAttributes measureAttributes = initialMeasureAttributes;
+
+		if (!attributesBuilder.equalsInContent(measureAttributes)) {
+			measureAttributes = attributesBuilder.build();
+		}
 
 		return Measure.of(this.number, this.getBuiltVoices(), measureAttributes);
 	}
@@ -379,6 +386,38 @@ public class MeasureBuilder {
 
 		private MeasureAttributes build() {
 			return MeasureAttributes.of(timeSignature, keySignature, rightBarline, leftBarline, clef, clefChanges);
+		}
+
+		private boolean equalsInContent(MeasureAttributes measureAttributes) {
+			if (measureAttributes == null) {
+				return false;
+			}
+
+			if (!timeSignature.equals(measureAttributes.getTimeSignature())) {
+				return false;
+			}
+
+			if (!keySignature.equals(measureAttributes.getKeySignature())) {
+				return false;
+			}
+
+			if (!clef.equals(measureAttributes.getClef())) {
+				return false;
+			}
+
+			if (!leftBarline.equals(measureAttributes.getLeftBarline())) {
+				return false;
+			}
+
+			if (!rightBarline.equals(measureAttributes.getRightBarline())) {
+				return false;
+			}
+
+			if (!clefChanges.equals(measureAttributes.getClefChanges())) {
+				return false;
+			}
+
+			return true;
 		}
 	}
 }

--- a/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
@@ -25,9 +25,9 @@ import org.wmn4j.notation.elements.TimeSignatures;
 
 /**
  * Class for building {@link Measure} objects. The methods {@link #isFull()
- * isFull} and {@link #isVoiceFull(int) isVoiceFull} should be used for checking
- * if the durations add up to the correct amount to fill up the measure
- * according to the specified time signature.
+ * isFull} and {@link #isFull(int) isVoiceFull} should be used for checking if
+ * the durations add up to the correct amount to fill up the measure according
+ * to the specified time signature.
  *
  * Default values: TimeSignature : 4/4 KeySignature : C-major/a-minor Clef: G
  * Barlines (right and left): Single. No clef changes.
@@ -305,23 +305,27 @@ public class MeasureBuilder {
 	/**
 	 * Returns true if the voice with the given number is full. A voice is
 	 * considered full when the durations in it are enough to fill a measure with
-	 * the time signature set in this builder.
+	 * the time signature set in this builder. The voice may contain more durational
+	 * elements than fit in a measure with the time signature set in this builder.
 	 *
-	 * @param voice index of voice that is checked
+	 * @param voice the number of voice that is checked
 	 * @return true if the durations in the voice add up to fill a measure
 	 */
-	public boolean isVoiceFull(int voice) {
+	public boolean isFull(int voice) {
 		final Duration voiceDuration = this.totalDurationOfVoice(voice);
 		return !voiceDuration.isShorterThan(attributesBuilder.timeSignature.getTotalDuration());
 	}
 
 	/**
-	 * Returns true if any voice in this builder is full.
+	 * Returns true if any voice in this builder is full. A voice is considered full
+	 * when the durations in it are enough to fill a measure with the time signature
+	 * set in this builder. The voice may contain more durational elements than fit
+	 * in a measure with the time signature set in this builder.
 	 *
 	 * @return true if even a single voice is full. False otherwise.
 	 */
 	public boolean isFull() {
-		return voices.keySet().stream().anyMatch(voiceNumber -> isVoiceFull(voiceNumber));
+		return voices.keySet().stream().anyMatch(voiceNumber -> isFull(voiceNumber));
 	}
 
 	private Map<Integer, List<Durational>> buildVoices() {

--- a/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
@@ -321,13 +321,7 @@ public class MeasureBuilder {
 	 * @return true if even a single voice is full. False otherwise.
 	 */
 	public boolean isFull() {
-		for (int voice = 0; voice < this.voices.size(); ++voice) {
-			if (this.isVoiceFull(voice)) {
-				return true;
-			}
-		}
-
-		return false;
+		return voices.keySet().stream().anyMatch(voiceNumber -> isVoiceFull(voiceNumber));
 	}
 
 	private Map<Integer, List<Durational>> buildVoices() {

--- a/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
@@ -328,6 +328,30 @@ public class MeasureBuilder {
 		return voices.keySet().stream().anyMatch(voiceNumber -> isFull(voiceNumber));
 	}
 
+	/**
+	 * Returns true if the total duration of the durational elements in the voice
+	 * with the given number is more than can fit into a measure with the time
+	 * signature set in this builder.
+	 *
+	 * @param voice the number of the voice that is checked
+	 * @return true if the total duration of the durational elements in the voice
+	 *         exceed what can fit in the measure
+	 */
+	public boolean isOverflowing(int voice) {
+		return totalDurationOfVoice(voice).isLongerThan(getTimeSignature().getTotalDuration());
+	}
+
+	/**
+	 * Returns true if any voice in this builder is overflowing. A voice is
+	 * overflowing if the total duration of the durational elements in the voice is
+	 * more than can fit into a measure with the time signature set in this builder.
+	 *
+	 * @return true if any voice in this builder is overflowing
+	 */
+	public boolean isOverflowing() {
+		return voices.keySet().stream().anyMatch(voiceNumber -> isOverflowing(voiceNumber));
+	}
+
 	private Map<Integer, List<Durational>> buildVoices() {
 
 		final Map<Integer, List<Durational>> builtVoices = new HashMap<>();

--- a/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
@@ -346,12 +346,9 @@ public class MeasureBuilder {
 	 * @return a measure with the values set in this builder
 	 */
 	public Measure build() {
-		final MeasureAttributes measureAttr = MeasureAttributes.of(attributesBuilder.timeSignature,
-				attributesBuilder.keySignature,
-				attributesBuilder.rightBarline, attributesBuilder.leftBarline, attributesBuilder.clef,
-				attributesBuilder.clefChanges);
+		final MeasureAttributes measureAttributes = attributesBuilder.build();
 
-		return Measure.of(this.number, this.getBuiltVoices(), measureAttr);
+		return Measure.of(this.number, this.getBuiltVoices(), measureAttributes);
 	}
 
 	private final class MeasureAttributesBuilder {
@@ -378,6 +375,10 @@ public class MeasureBuilder {
 			this.leftBarline = measureAttributes.getLeftBarline();
 			this.rightBarline = measureAttributes.getRightBarline();
 			this.clefChanges = new HashMap<>(measureAttributes.getClefChanges());
+		}
+
+		private MeasureAttributes build() {
+			return MeasureAttributes.of(timeSignature, keySignature, rightBarline, leftBarline, clef, clefChanges);
 		}
 	}
 }

--- a/src/main/java/org/wmn4j/notation/builders/NoteBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/NoteBuilder.java
@@ -95,6 +95,7 @@ public class NoteBuilder implements DurationalBuilder {
 	 *
 	 * @param duration The duration to be set in this builder
 	 */
+	@Override
 	public void setDuration(Duration duration) {
 		this.duration = duration;
 	}

--- a/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
@@ -95,7 +95,7 @@ public class PartBuilder {
 	}
 
 	private List<Measure> getBuiltMeasures(List<MeasureBuilder> builders) {
-		return builders.stream().map(MeasureBuilder::build).collect(Collectors.toList());
+		return builders.stream().map(measureBuilder -> measureBuilder.build(false, false)).collect(Collectors.toList());
 	}
 
 	/**

--- a/src/main/java/org/wmn4j/notation/builders/RestBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/RestBuilder.java
@@ -29,6 +29,7 @@ public final class RestBuilder implements DurationalBuilder {
 	 *
 	 * @param duration the duration that is set to this builder
 	 */
+	@Override
 	public void setDuration(Duration duration) {
 		this.duration = Objects.requireNonNull(duration);
 	}

--- a/src/main/java/org/wmn4j/notation/elements/Measure.java
+++ b/src/main/java/org/wmn4j/notation/elements/Measure.java
@@ -77,6 +77,10 @@ public final class Measure implements Iterable<Durational> {
 	 * @param measureAttr the attributes of the measure.
 	 */
 	private Measure(int number, Map<Integer, List<Durational>> noteVoices, MeasureAttributes measureAttr) {
+		if (number < 0) {
+			throw new IllegalArgumentException("Measure number cannot be negative");
+		}
+
 		this.number = number;
 		final SortedMap<Integer, List<Durational>> voicesCopy = new TreeMap<>();
 

--- a/src/main/java/org/wmn4j/notation/elements/MeasureAttributes.java
+++ b/src/main/java/org/wmn4j/notation/elements/MeasureAttributes.java
@@ -178,6 +178,10 @@ public final class MeasureAttributes {
 			return false;
 		}
 
+		if (!this.clefChanges.equals(other.clefChanges)) {
+			return false;
+		}
+
 		return true;
 	}
 

--- a/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
@@ -222,4 +222,32 @@ public class MeasureBuilderTest {
 		assertEquals(eightDurationNote, measure.get(1, 1));
 		assertEquals(Rest.of(Durations.EIGHT), measure.get(1, 2));
 	}
+
+	@Test
+	public void testIsVoiceOverflowing() {
+		final MeasureBuilder builder = new MeasureBuilder(1);
+		builder.setTimeSignature(TimeSignatures.TWO_FOUR);
+		NoteBuilder withHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.HALF);
+		NoteBuilder withDottedHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.HALF.addDot());
+		builder.addToVoice(0, withHalfDuration);
+		builder.addToVoice(1, withDottedHalfDuration);
+
+		assertFalse(builder.isOverflowing(0));
+		assertTrue(builder.isOverflowing(1));
+	}
+
+	@Test
+	public void testIsOverflowing() {
+		final MeasureBuilder builder = new MeasureBuilder(1);
+		builder.setTimeSignature(TimeSignatures.TWO_FOUR);
+		NoteBuilder withHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.HALF);
+		NoteBuilder withDottedHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.HALF.addDot());
+		builder.addToVoice(0, withHalfDuration);
+
+		assertFalse(builder.isOverflowing());
+
+		builder.addToVoice(1, withDottedHalfDuration);
+
+		assertTrue(builder.isOverflowing());
+	}
 }

--- a/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
@@ -301,4 +301,30 @@ public class MeasureBuilderTest {
 		assertFalse(builder.isOverflowing());
 		builder.build();
 	}
+
+	@Test
+	public void testBuildingWithoutPaddingAndTrimming() {
+		final MeasureBuilder builder = new MeasureBuilder(1);
+		builder.setTimeSignature(TimeSignatures.TWO_FOUR);
+
+		NoteBuilder tooLongBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.WHOLE);
+		NoteBuilder tooShortBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.QUARTER);
+
+		builder.addToVoice(0, tooLongBuilder);
+		builder.addToVoice(1, tooShortBuilder);
+
+		final Note expectedVoice0Note = tooLongBuilder.build();
+		final Note expectedVoice1Note = tooShortBuilder.build();
+
+		assertTrue(builder.isOverflowing(0));
+		assertTrue(!builder.isFull(1));
+
+		final Measure incompleteMeasure = builder.build(false, false);
+
+		assertEquals(1, incompleteMeasure.getVoice(0).size());
+		assertEquals(expectedVoice0Note, incompleteMeasure.get(0, 0));
+
+		assertEquals(1, incompleteMeasure.getVoice(1).size());
+		assertEquals(expectedVoice1Note, incompleteMeasure.get(1, 0));
+	}
 }

--- a/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
@@ -11,9 +11,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 
 import org.junit.Test;
-import org.wmn4j.notation.builders.MeasureBuilder;
-import org.wmn4j.notation.builders.NoteBuilder;
-import org.wmn4j.notation.builders.RestBuilder;
 import org.wmn4j.notation.elements.Barline;
 import org.wmn4j.notation.elements.Clefs;
 import org.wmn4j.notation.elements.Durational;
@@ -26,10 +23,6 @@ import org.wmn4j.notation.elements.Pitch;
 import org.wmn4j.notation.elements.Rest;
 import org.wmn4j.notation.elements.TimeSignatures;
 
-/**
- *
- * @author Otso Björklund
- */
 public class MeasureBuilderTest {
 
 	public MeasureBuilderTest() {
@@ -44,8 +37,8 @@ public class MeasureBuilderTest {
 		builder.addVoice();
 		assertEquals(1, builder.getNumberOfVoices());
 		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT))
-		.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT))
-		.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHT));
+				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT))
+				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHT));
 
 		final Measure measure = builder.build();
 		assertTrue(measure != null);
@@ -71,8 +64,8 @@ public class MeasureBuilderTest {
 		builder.addVoice();
 		assertEquals(1, builder.getNumberOfVoices());
 		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT))
-		.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT))
-		.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHT));
+				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT))
+				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHT));
 
 		final Measure measure = builder.build();
 		assertTrue(measure != null);
@@ -101,8 +94,8 @@ public class MeasureBuilderTest {
 		builder.addVoice();
 		assertEquals(1, builder.getNumberOfVoices());
 		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT))
-		.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT))
-		.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHT));
+				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT))
+				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHT));
 
 		final Measure measure = builder.build();
 		assertTrue(measure != null);
@@ -154,8 +147,8 @@ public class MeasureBuilderTest {
 		builder.setTimeSignature(TimeSignatures.SIX_EIGHT).setKeySignature(KeySignatures.CMAJ_AMIN);
 
 		builder.addToVoice(0, new RestBuilder(Durations.QUARTER.addDot()))
-		.addToVoice(0, new RestBuilder(Durations.QUARTER))
-		.addToVoice(1, new RestBuilder(Durations.QUARTER.addDot()));
+				.addToVoice(0, new RestBuilder(Durations.QUARTER))
+				.addToVoice(1, new RestBuilder(Durations.QUARTER.addDot()));
 		builder.addToVoice(0, new RestBuilder(Durations.SIXTEENTH_TRIPLET)).addToVoice(0,
 				new RestBuilder(Durations.SIXTEENTH_TRIPLET));
 		assertFalse("Voice 0 is full when 6/8 measure is lacking one sixteenth triplet", builder.isVoiceFull(0));
@@ -180,8 +173,8 @@ public class MeasureBuilderTest {
 		builder.setTimeSignature(TimeSignatures.SIX_EIGHT);
 
 		builder.addToVoice(0, new RestBuilder(Durations.QUARTER.addDot()))
-		.addToVoice(0, new RestBuilder(Durations.QUARTER))
-		.addToVoice(1, new RestBuilder(Durations.QUARTER.addDot()));
+				.addToVoice(0, new RestBuilder(Durations.QUARTER))
+				.addToVoice(1, new RestBuilder(Durations.QUARTER.addDot()));
 		builder.addToVoice(0, new RestBuilder(Durations.SIXTEENTH_TRIPLET)).addToVoice(0,
 				new RestBuilder(Durations.SIXTEENTH_TRIPLET));
 		assertFalse("builder is full when 6/8 measure is lacking one sixteenth triplet", builder.isFull());

--- a/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
@@ -138,13 +138,13 @@ public class MeasureBuilderTest {
 	public void testIsVoiceFull() {
 		MeasureBuilder builder = new MeasureBuilder(1);
 		builder.addToVoice(0, new RestBuilder(Durations.QUARTER));
-		assertFalse("Voice 0 is full for 4/4 measure after adding one quarter rest", builder.isVoiceFull(0));
+		assertFalse("Voice 0 is full for 4/4 measure after adding one quarter rest", builder.isFull(0));
 		final NoteBuilder c = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.QUARTER);
 		builder.addToVoice(0, c);
-		assertFalse("Voice 0 is full for 4/4 measure after adding two quarters", builder.isVoiceFull(0));
+		assertFalse("Voice 0 is full for 4/4 measure after adding two quarters", builder.isFull(0));
 		builder.addToVoice(0, c);
 		builder.addToVoice(0, c);
-		assertTrue("Voice 0 is not full when 4 quarter durations added to 4/4", builder.isVoiceFull(0));
+		assertTrue("Voice 0 is not full when 4 quarter durations added to 4/4", builder.isFull(0));
 
 		builder = new MeasureBuilder(1);
 		builder.setTimeSignature(TimeSignatures.SIX_EIGHT).setKeySignature(KeySignatures.CMAJ_AMIN);
@@ -154,10 +154,10 @@ public class MeasureBuilderTest {
 				.addToVoice(1, new RestBuilder(Durations.QUARTER.addDot()));
 		builder.addToVoice(0, new RestBuilder(Durations.SIXTEENTH_TRIPLET)).addToVoice(0,
 				new RestBuilder(Durations.SIXTEENTH_TRIPLET));
-		assertFalse("Voice 0 is full when 6/8 measure is lacking one sixteenth triplet", builder.isVoiceFull(0));
+		assertFalse("Voice 0 is full when 6/8 measure is lacking one sixteenth triplet", builder.isFull(0));
 		builder.addToVoice(0, new RestBuilder(Durations.SIXTEENTH_TRIPLET));
-		assertTrue("Voice 0 is not full when 6/8 measure should be full.", builder.isVoiceFull(0));
-		assertFalse("Voice 1 is full for 6/8 measure when it should not be", builder.isVoiceFull(1));
+		assertTrue("Voice 0 is not full when 6/8 measure should be full.", builder.isFull(0));
+		assertFalse("Voice 1 is full for 6/8 measure when it should not be", builder.isFull(1));
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/notation/elements/MeasureAttributesTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/MeasureAttributesTest.java
@@ -1,7 +1,4 @@
-/*
- * Copyright 2018 Otso Björklund.
- * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
- */
+
 package org.wmn4j.notation.elements;
 
 import static org.junit.Assert.assertEquals;
@@ -9,19 +6,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.wmn4j.notation.elements.Barline;
-import org.wmn4j.notation.elements.Clefs;
-import org.wmn4j.notation.elements.KeySignatures;
-import org.wmn4j.notation.elements.MeasureAttributes;
-import org.wmn4j.notation.elements.TimeSignatures;
 
-/**
- *
- * @author Otso Björklund
- */
 public class MeasureAttributesTest {
 
 	public MeasureAttributesTest() {
@@ -90,14 +81,20 @@ public class MeasureAttributesTest {
 
 	@Test
 	public void testEquals() {
+
+		final Map<Duration, Clef> clefChangesA = new HashMap<>();
+		clefChangesA.put(Durations.HALF, Clefs.F);
+		final Map<Duration, Clef> clefChangesB = new HashMap<>();
+		clefChangesB.put(Durations.HALF.addDot(), Clefs.F);
+
 		final MeasureAttributes attr = MeasureAttributes.of(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
-				Barline.SINGLE, Barline.SINGLE, Clefs.G);
+				Barline.SINGLE, Barline.SINGLE, Clefs.G, clefChangesA);
 
 		final MeasureAttributes other = MeasureAttributes.of(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
-				Barline.SINGLE, Barline.SINGLE, Clefs.G);
+				Barline.SINGLE, Barline.SINGLE, Clefs.G, clefChangesA);
 
 		final MeasureAttributes different = MeasureAttributes.of(TimeSignatures.FOUR_FOUR,
-				KeySignatures.CMAJ_AMIN, Barline.SINGLE, Barline.DOUBLE, Clefs.G);
+				KeySignatures.CMAJ_AMIN, Barline.SINGLE, Barline.DOUBLE, Clefs.G, clefChangesB);
 
 		assertTrue(attr.equals(attr));
 		assertTrue(attr.equals(other));


### PR DESCRIPTION
* Pad voices with rests if they don't fill the measure
* Trim excess durations from a measure
* Allow building measures without padding and trimming to allow pickup measures and the rare cases that a score contains a measure that has too many notes (those exist...).