### PR TITLE
Issue #39: Add common interface for reading files into Score objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out
 .DS_Store
 .gradle
 .idea
+/bin/

--- a/src/main/java/org/wmn4j/io/ScoreReader.java
+++ b/src/main/java/org/wmn4j/io/ScoreReader.java
@@ -1,0 +1,34 @@
+/*
+ * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
+ */
+package org.wmn4j.io;
+
+import org.wmn4j.notation.builders.ScoreBuilder;
+import org.wmn4j.notation.elements.Score;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Represents a reader for music notation files. The only supported file type is MusicXML.
+ */
+public interface ScoreReader {
+
+	/**
+	 * Returns a score with the contents of the music notation file at the given path.
+	 *
+	 * @param filePath the path of the music notation file from which to read the contents of the score
+	 * @return a score with the contents of the music notation file at the given path
+	 * @throws IOException if the file is not found or the file is not valid
+	 */
+	Score readScore(Path filePath) throws IOException;
+
+	/**
+	 * Returns a score builder with the contents of the music notation file at the given path.
+	 *
+	 * @param filePath the path of the music notation file from which to read the contents of the score builder
+	 * @return a score builder with the contents of the music notation file at the given path
+	 * @throws IOException if the file is not found or the file is not valid
+	 */
+	ScoreBuilder scoreBuilderFromFile(Path filePath) throws IOException;
+}

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlReader.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlReader.java
@@ -3,17 +3,15 @@
  */
 package org.wmn4j.io.musicxml;
 
-import org.wmn4j.notation.builders.ScoreBuilder;
-import org.wmn4j.notation.elements.Score;
+import org.wmn4j.io.ScoreReader;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
  * Represents a reader for MusicXML files.
  */
-public interface MusicXmlReader {
+public interface MusicXmlReader extends ScoreReader {
 
 	/**
 	 * The path to the local MusicXML schema.
@@ -31,21 +29,4 @@ public interface MusicXmlReader {
 		return new MusicXmlReaderDom(validate);
 	}
 
-	/**
-	 * Returns a score with the contents of the MusicXML file at the given path.
-	 *
-	 * @param filePath the path of the MusicXML file from which to read the contents of the score
-	 * @return a score with the contents of the MusicXML file at the given path
-	 * @throws IOException if the file is not found or the file is not valid
-	 */
-	Score readScore(Path filePath) throws IOException;
-
-	/**
-	 * Returns a score builder with the contents of the MusicXML file at the given path.
-	 *
-	 * @param filePath the path of the MusicXML file from which to read the contents of the score builder
-	 * @return a score builder with the contents of the MusicXML file at the given path
-	 * @throws IOException if the file is not found or the file is not valid
-	 */
-	ScoreBuilder scoreBuilderFromFile(Path filePath) throws IOException;
 }


### PR DESCRIPTION
A new interface is added for reading music notation files into Score objects. The existing MusicXmlReader interface extends the new interface and overlap is removed from MusicXmlReader. By implementing MusicXmlReader, MusicXmlReaderDom also implements ScoreReader.