### PR TITLE
Issue #78: Ensure each staff of a MultiStaffPart has same number of measures

### DIFF
--- a/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/MeasureBuilder.java
@@ -3,14 +3,6 @@
  */
 package org.wmn4j.notation.builders;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.wmn4j.notation.elements.Barline;
 import org.wmn4j.notation.elements.Clef;
 import org.wmn4j.notation.elements.Clefs;
@@ -23,12 +15,20 @@ import org.wmn4j.notation.elements.MeasureAttributes;
 import org.wmn4j.notation.elements.TimeSignature;
 import org.wmn4j.notation.elements.TimeSignatures;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
  * Class for building {@link Measure} objects. The methods {@link #isFull()
  * isFull} and {@link #isFull(int) isVoiceFull} should be used for checking if
  * the durations add up to the correct amount to fill up the measure according
  * to the specified time signature.
- *
+ * <p>
  * Default values: TimeSignature : 4/4 KeySignature : C-major/a-minor Clef: G
  * Barlines (right and left): Single. No clef changes.
  */
@@ -38,6 +38,16 @@ public class MeasureBuilder {
 	private final Map<Integer, List<DurationalBuilder>> voices;
 	private final MeasureAttributesBuilder attributesBuilder;
 	private final MeasureAttributes initialMeasureAttributes;
+
+	/**
+	 * Returns a measure builder with the measure number and attributes of the given measure builder.
+	 *
+	 * @param builder the builder whose attributes are set to this builder
+	 * @return a measure builder with the attributes of the given measure builder
+	 */
+	public static MeasureBuilder withAttributesOf(MeasureBuilder builder) {
+		return new MeasureBuilder(builder.number, builder.getAttributes());
+	}
 
 	/**
 	 * Create a measure builder with the given attributes.
@@ -189,7 +199,7 @@ public class MeasureBuilder {
 	 * values of the clef changes measured from the beginning of the measure.
 	 *
 	 * @return clef changes currently set for this builder. Durations are offsets
-	 *         from the beginning of the measure.
+	 * from the beginning of the measure.
 	 */
 	public Map<Duration, Clef> getClefChanges() {
 		return attributesBuilder.clefChanges;
@@ -335,7 +345,7 @@ public class MeasureBuilder {
 	 *
 	 * @param voice the number of the voice that is checked
 	 * @return true if the total duration of the durational elements in the voice
-	 *         exceed what can fit in the measure
+	 * exceed what can fit in the measure
 	 */
 	public boolean isOverflowing(int voice) {
 		return totalDurationOfVoice(voice).isLongerThan(getTimeSignature().getTotalDuration());
@@ -422,6 +432,14 @@ public class MeasureBuilder {
 		return builtVoices;
 	}
 
+	private MeasureAttributes getAttributes() {
+		if (attributesBuilder.equalsInContent(initialMeasureAttributes)) {
+			return initialMeasureAttributes;
+		}
+
+		return attributesBuilder.build();
+	}
+
 	/**
 	 * Returns a {@link Measure} with the values set in this builder. Voices that do
 	 * not contain enough durational notation elements are padded with rests at the
@@ -446,17 +464,11 @@ public class MeasureBuilder {
 	 * @return a measure with the values set in this builder
 	 */
 	public Measure build(boolean padWithRests, boolean trim) {
-		MeasureAttributes measureAttributes = initialMeasureAttributes;
-
-		if (!attributesBuilder.equalsInContent(measureAttributes)) {
-			measureAttributes = attributesBuilder.build();
-		}
-
 		if (trim) {
 			this.trim();
 		}
 
-		return Measure.of(this.number, this.buildVoices(padWithRests), measureAttributes);
+		return Measure.of(this.number, this.buildVoices(padWithRests), getAttributes());
 	}
 
 	private final class MeasureAttributesBuilder {

--- a/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
@@ -3,18 +3,20 @@
  */
 package org.wmn4j.notation.builders;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
 import org.wmn4j.notation.elements.Measure;
 import org.wmn4j.notation.elements.MultiStaffPart;
 import org.wmn4j.notation.elements.Part;
 import org.wmn4j.notation.elements.SingleStaffPart;
 import org.wmn4j.notation.elements.Staff;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Builder for building {@link Part} objects.
@@ -108,12 +110,30 @@ public class PartBuilder {
 			return SingleStaffPart.of(this.partAttributes,
 					getBuiltMeasures(this.staveContents.get(SINGLE_STAFF_NUMBER)));
 		} else {
+			padShorterStavesWithRestMeasures();
 			final Map<Integer, Staff> staves = new HashMap<>();
 			for (int staffNumber : this.staveContents.keySet()) {
 				staves.put(staffNumber, Staff.of(getBuiltMeasures(this.staveContents.get(staffNumber))));
 			}
 
 			return MultiStaffPart.of(this.partAttributes, staves);
+		}
+	}
+
+	private void padShorterStavesWithRestMeasures() {
+		Optional<List<MeasureBuilder>> longestStaffOpt = staveContents.values().stream()
+				.max(Comparator.comparing(List::size));
+
+		if (longestStaffOpt.isPresent()) {
+			final List<MeasureBuilder> longestStaff = longestStaffOpt.get();
+			final int longestStaffMeasureCount = longestStaff.size();
+
+			for (List<MeasureBuilder> staffContents : staveContents.values()) {
+
+				for (int i = staffContents.size(); i < longestStaffMeasureCount; ++i) {
+					staffContents.add(MeasureBuilder.withAttributesOf(longestStaff.get(i)));
+				}
+			}
 		}
 	}
 }

--- a/src/main/java/org/wmn4j/notation/elements/Measure.java
+++ b/src/main/java/org/wmn4j/notation/elements/Measure.java
@@ -70,6 +70,17 @@ public final class Measure implements Iterable<Durational> {
 	}
 
 	/**
+	 * Returns a full measure rest with the given measure number and attributes.
+	 *
+	 * @param number            number of the measure
+	 * @param measureAttributes the attributes of the measure
+	 * @return a full measure rest with the given measure number and attributes
+	 */
+	public static Measure restMeasureOf(int number, MeasureAttributes measureAttributes) {
+		return new Measure(number, Collections.emptyMap(), measureAttributes);
+	}
+
+	/**
 	 * Constructor.
 	 *
 	 * @param number      number of the measure.
@@ -205,7 +216,7 @@ public final class Measure implements Iterable<Durational> {
 	 * Returns the clef changes in this measure.
 	 *
 	 * @return a map of clef changes in this measure, where the duration key is the
-	 *         offset counted from the beginning of the measure.
+	 * offset counted from the beginning of the measure.
 	 */
 	public Map<Duration, Clef> getClefChanges() {
 		return this.measureAttr.getClefChanges();
@@ -249,6 +260,15 @@ public final class Measure implements Iterable<Durational> {
 		}
 
 		return voice.get(index);
+	}
+
+	/**
+	 * Returns true if this measure is a full measure rest.
+	 *
+	 * @return true if this measure is a full measure rest
+	 */
+	public boolean isFullMeasureRest() {
+		return this.voices.isEmpty();
 	}
 
 	@Override
@@ -313,8 +333,8 @@ public final class Measure implements Iterable<Durational> {
 		 * call of {@link #next() next}.
 		 *
 		 * @return the voice of the {@link Durational} that was returned by the last
-		 *         call of {@link #next() next}. If next has not been called, return
-		 *         value is useless.
+		 * call of {@link #next() next}. If next has not been called, return
+		 * value is useless.
 		 */
 		public int getVoiceOfPrevious() {
 			return this.prevVoiceNumber;
@@ -325,8 +345,8 @@ public final class Measure implements Iterable<Durational> {
 		 * call of {@link #next() next}.
 		 *
 		 * @return the index of the {@link Durational} that was returned by the last
-		 *         call of {@link #next() next}. If next has not been called, return
-		 *         value is useless.
+		 * call of {@link #next() next}. If next has not been called, return
+		 * value is useless.
 		 */
 		public int getIndexOfPrevious() {
 			return this.prevPositionInVoice;

--- a/src/main/java/org/wmn4j/notation/elements/MultiStaffPart.java
+++ b/src/main/java/org/wmn4j/notation/elements/MultiStaffPart.java
@@ -32,6 +32,7 @@ public final class MultiStaffPart implements Part {
 	 */
 	public static MultiStaffPart of(String name, Map<Integer, Staff> staves) {
 		Map<Part.Attribute, String> attributes = new HashMap<>();
+		attributes.put(Attribute.NAME, name);
 		return new MultiStaffPart(attributes, staves);
 	}
 

--- a/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
@@ -4,12 +4,6 @@
  */
 package org.wmn4j.notation.builders;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.util.List;
-
 import org.junit.Test;
 import org.wmn4j.notation.elements.Barline;
 import org.wmn4j.notation.elements.Clefs;
@@ -23,6 +17,12 @@ import org.wmn4j.notation.elements.Note;
 import org.wmn4j.notation.elements.Pitch;
 import org.wmn4j.notation.elements.Rest;
 import org.wmn4j.notation.elements.TimeSignatures;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class MeasureBuilderTest {
 
@@ -326,5 +326,15 @@ public class MeasureBuilderTest {
 
 		assertEquals(1, incompleteMeasure.getVoice(1).size());
 		assertEquals(expectedVoice1Note, incompleteMeasure.get(1, 0));
+	}
+
+	@Test
+	public void testBuildingFullMeasureRest() {
+		final MeasureBuilder builder = new MeasureBuilder(1);
+		builder.setTimeSignature(TimeSignatures.SIX_EIGHT).setKeySignature(KeySignatures.DFLATMAJ_BFLATMIN);
+		builder.setRightBarline(Barline.DOUBLE).setClef(Clefs.F);
+
+		final Measure fullMeasureRest = builder.build();
+		assertTrue(fullMeasureRest.isFullMeasureRest());
 	}
 }

--- a/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/MeasureBuilderTest.java
@@ -337,4 +337,18 @@ public class MeasureBuilderTest {
 		final Measure fullMeasureRest = builder.build();
 		assertTrue(fullMeasureRest.isFullMeasureRest());
 	}
+
+	@Test
+	public void testBuildingWithAttributesOfAnotherBuilder() {
+		final MeasureBuilder builder = new MeasureBuilder(1);
+		builder.setTimeSignature(TimeSignatures.SIX_EIGHT).setKeySignature(KeySignatures.DFLATMAJ_BFLATMIN);
+		builder.setRightBarline(Barline.DOUBLE).setClef(Clefs.F);
+
+		final MeasureBuilder withSameAttributes = MeasureBuilder.withAttributesOf(builder);
+
+		assertEquals(TimeSignatures.SIX_EIGHT, withSameAttributes.getTimeSignature());
+		assertEquals(KeySignatures.DFLATMAJ_BFLATMIN, withSameAttributes.getKeySignature());
+		assertEquals(Barline.DOUBLE, withSameAttributes.getRightBarline());
+		assertEquals(Clefs.F, withSameAttributes.getClef());
+	}
 }

--- a/src/test/java/org/wmn4j/notation/builders/PartBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/PartBuilderTest.java
@@ -9,6 +9,7 @@ import org.wmn4j.notation.elements.Clefs;
 import org.wmn4j.notation.elements.Durations;
 import org.wmn4j.notation.elements.KeySignature;
 import org.wmn4j.notation.elements.KeySignatures;
+import org.wmn4j.notation.elements.Measure;
 import org.wmn4j.notation.elements.MeasureAttributes;
 import org.wmn4j.notation.elements.MultiStaffPart;
 import org.wmn4j.notation.elements.Note;
@@ -148,5 +149,74 @@ public class PartBuilderTest {
 
 		assertEquals(secondNote, firstNote.getFollowingTiedNote().get());
 		assertTrue(secondNote.isTiedFromPrevious());
+	}
+
+	@Test
+	public void testGivenBuilderWithMultipleStavesWhenBuiltPartsHavePadding() {
+		final MeasureBuilder firstMeasureBuilder = new MeasureBuilder(1);
+		final NoteBuilder firstNoteBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.WHOLE);
+		firstMeasureBuilder.addToVoice(1, firstNoteBuilder);
+
+		final MeasureBuilder secondMeasureBuilder = new MeasureBuilder(2);
+		final NoteBuilder secondNoteBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.WHOLE);
+		secondMeasureBuilder.addToVoice(1, secondNoteBuilder);
+
+		final PartBuilder partBuilder = new PartBuilder("Part");
+		partBuilder.addToStaff(1, firstMeasureBuilder).addToStaff(1, secondMeasureBuilder);
+		partBuilder.addToStaff(2, firstMeasureBuilder);
+		final Part part = partBuilder.build();
+
+		final Note firstNote = (Note) part.getMeasure(SingleStaffPart.STAFF_NUMBER, 1).get(1, 0);
+		final Note secondNote = (Note) part.getMeasure(SingleStaffPart.STAFF_NUMBER, 2).get(1, 0);
+
+		assertEquals(firstNoteBuilder.build(), firstNote);
+		assertEquals(secondNoteBuilder.build(), secondNote);
+
+		assertFalse(part.getMeasure(1, 1).isFullMeasureRest());
+		assertFalse(part.getMeasure(1, 2).isFullMeasureRest());
+
+		assertFalse(part.getMeasure(2, 1).isFullMeasureRest());
+		assertTrue(part.getMeasure(2, 2).isFullMeasureRest());
+	}
+
+	@Test
+	public void testGivenBuilderWithMultipleStavesAndTimeSignatureChangesWhenBuiltMeasuresHaveCorrectTimeSignatures() {
+		final MeasureBuilder firstMeasureBuilder = new MeasureBuilder(1);
+		firstMeasureBuilder.setTimeSignature(TimeSignatures.SIX_EIGHT);
+		final MeasureBuilder secondMeasureBuilder = new MeasureBuilder(2);
+		secondMeasureBuilder.setTimeSignature(TimeSignatures.FOUR_FOUR);
+		final MeasureBuilder thirdMeasureBuilder = new MeasureBuilder(3);
+		thirdMeasureBuilder.setTimeSignature(TimeSignatures.THREE_FOUR);
+
+		PartBuilder builder = new PartBuilder("Test part");
+		builder.addToStaff(1, firstMeasureBuilder).addToStaff(1, secondMeasureBuilder)
+				.addToStaff(1, thirdMeasureBuilder);
+		builder.addToStaff(2, firstMeasureBuilder).addToStaff(2, secondMeasureBuilder);
+		builder.addToStaff(3, firstMeasureBuilder);
+
+		Part part = builder.build();
+		final Measure staffOneMeasureOne = part.getMeasure(1, 1);
+		final Measure staffOneMeasureTwo = part.getMeasure(1, 2);
+		final Measure staffOneMeasureThree = part.getMeasure(1, 3);
+
+		assertEquals(TimeSignatures.SIX_EIGHT, staffOneMeasureOne.getTimeSignature());
+		assertEquals(TimeSignatures.FOUR_FOUR, staffOneMeasureTwo.getTimeSignature());
+		assertEquals(TimeSignatures.THREE_FOUR, staffOneMeasureThree.getTimeSignature());
+
+		Measure staffTwoMeasureOne = part.getMeasure(2, 1);
+		Measure staffTwoMeasureTwo = part.getMeasure(2, 2);
+		Measure staffTwoMeasureThree = part.getMeasure(2, 3);
+
+		assertEquals(TimeSignatures.SIX_EIGHT, staffTwoMeasureOne.getTimeSignature());
+		assertEquals(TimeSignatures.FOUR_FOUR, staffTwoMeasureTwo.getTimeSignature());
+		assertEquals(TimeSignatures.THREE_FOUR, staffTwoMeasureThree.getTimeSignature());
+
+		Measure staffThreeMeasureOne = part.getMeasure(3, 1);
+		Measure staffThreeMeasureTwo = part.getMeasure(3, 2);
+		Measure staffThreeMeasureThree = part.getMeasure(3, 3);
+
+		assertEquals(TimeSignatures.SIX_EIGHT, staffThreeMeasureOne.getTimeSignature());
+		assertEquals(TimeSignatures.FOUR_FOUR, staffThreeMeasureTwo.getTimeSignature());
+		assertEquals(TimeSignatures.THREE_FOUR, staffThreeMeasureThree.getTimeSignature());
 	}
 }

--- a/src/test/java/org/wmn4j/notation/builders/PartBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/PartBuilderTest.java
@@ -1,26 +1,9 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.builders;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.junit.Test;
-import org.wmn4j.notation.builders.ChordBuilder;
-import org.wmn4j.notation.builders.DurationalBuilder;
-import org.wmn4j.notation.builders.MeasureBuilder;
-import org.wmn4j.notation.builders.NoteBuilder;
-import org.wmn4j.notation.builders.PartBuilder;
-import org.wmn4j.notation.builders.RestBuilder;
 import org.wmn4j.notation.elements.Barline;
 import org.wmn4j.notation.elements.Clefs;
 import org.wmn4j.notation.elements.Durations;
@@ -35,10 +18,16 @@ import org.wmn4j.notation.elements.SingleStaffPart;
 import org.wmn4j.notation.elements.Staff;
 import org.wmn4j.notation.elements.TimeSignatures;
 
-/**
- *
- * @author Otso Björklund
- */
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class PartBuilderTest {
 
 	private final Map<Integer, List<DurationalBuilder>> measureContents;

--- a/src/test/java/org/wmn4j/notation/elements/MeasureTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/MeasureTest.java
@@ -4,20 +4,21 @@
  */
 package org.wmn4j.notation.elements;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
- *
  * @author Otso Björklund
  */
 public class MeasureTest {
@@ -91,7 +92,8 @@ public class MeasureTest {
 			voice.add(Rest.of(Durations.QUARTER));
 			fail("Failed to throw exception for disabled adding");
 		} catch (final Exception e) {
-			/* Do nothing */ }
+			/* Do nothing */
+		}
 	}
 
 	@Test
@@ -194,5 +196,28 @@ public class MeasureTest {
 
 		assertEquals("Iterator iterated through a number of objects different from size of expected", expected.size(),
 				count);
+	}
+
+	@Test
+	public void testFullMeasureRest() {
+		final List<Durational> noteList = this.singleNoteVoice.get(0);
+		final Map<Integer, List<Durational>> noteVoices = new HashMap<>();
+		noteVoices.put(1, noteList);
+		noteVoices.put(3, noteList);
+
+		final Measure measure = Measure.of(1, noteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
+		assertFalse(measure.isFullMeasureRest());
+
+		final MeasureAttributes attributes = MeasureAttributes
+				.of(TimeSignatures.FOUR_FOUR, keySig, Barline.SINGLE, Clefs.G);
+		final Measure fullMeasureRest = Measure.restMeasureOf(2, attributes);
+		assertTrue(fullMeasureRest.isFullMeasureRest());
+
+		try {
+			fullMeasureRest.get(0, 0);
+			fail("Trying to get a durational from full meausure rest did not throw exception");
+		} catch (NoSuchElementException exception) {
+			/* Do nothing */
+		}
 	}
 }

--- a/src/test/java/org/wmn4j/notation/elements/MultiStaffPartTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/MultiStaffPartTest.java
@@ -4,9 +4,8 @@
  */
 package org.wmn4j.notation.elements;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.Test;
+import org.wmn4j.notation.TestHelper;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -14,11 +13,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
-import org.wmn4j.notation.TestHelper;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
- *
  * @author Otso Björklund
  */
 public class MultiStaffPartTest {
@@ -34,6 +33,15 @@ public class MultiStaffPartTest {
 
 		this.testStaves.put(1, Staff.of(measures));
 		this.testStaves.put(2, Staff.of(measures));
+	}
+
+	@Test
+	public void testPartHasName() {
+		final Map<Integer, Staff> testStavesCopy = new HashMap<>(this.testStaves);
+
+		final String partName = "Test staff";
+		final MultiStaffPart part = MultiStaffPart.of(partName, testStavesCopy);
+		assertEquals(partName, part.getName());
 	}
 
 	@Test
@@ -125,6 +133,7 @@ public class MultiStaffPartTest {
 			iterator.remove();
 			fail("Did not throw exception when calling remove on iterator");
 		} catch (final Exception e) {
-			/* Do nothing */ }
+			/* Do nothing */
+		}
 	}
 }


### PR DESCRIPTION
* Add methods for handling full measure rests.
* Pad shorter staves with full measure rests in part builder when creating multi staff parts.