### PR TITLE
Issue #79: Ensure each part in a Score built with a ScoreBuilder has the same number of measures

### DIFF
--- a/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
@@ -46,6 +46,18 @@ public class PartBuilder {
 	}
 
 	/**
+	 * Returns the number of measures in the longest staff in this builder.
+	 * <p>
+	 * For a single staff part the returned number is the number of measures. For a part with multiple staves
+	 * the returned number is the number of measures in the staff with the largest number of measures.
+	 *
+	 * @return the number of measures in the longest staff in this builder
+	 */
+	public int getMeasureCount() {
+		return staveContents.values().stream().map(staff -> staff.size()).max(Integer::compareTo).orElse(0);
+	}
+
+	/**
 	 * Adds a {@link MeasureBuilder} to this builder. This is used for building
 	 * parts with a single staff.
 	 *

--- a/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -97,6 +98,15 @@ public class PartBuilder {
 	 */
 	public void setAttribute(Part.Attribute attribute, String value) {
 		this.partAttributes.put(attribute, value);
+	}
+
+	/**
+	 * Returns the staff numbers set in this builder.
+	 *
+	 * @return the staff numbers set in this builder
+	 */
+	public Set<Integer> getStaffNumbers() {
+		return staveContents.keySet();
 	}
 
 	/**

--- a/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
@@ -14,6 +14,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -44,6 +45,20 @@ public class PartBuilder {
 	 */
 	public int getStaffCount() {
 		return this.staveContents.size();
+	}
+
+	/**
+	 * Returns the list of builders associated with the given staff number.
+	 *
+	 * @param staffNumber the number of the staff for which to return the measure builders
+	 * @return the list of builders associated with the given staff number
+	 */
+	public List<MeasureBuilder> getStaffContents(int staffNumber) {
+		if (!staveContents.containsKey(staffNumber)) {
+			throw new NoSuchElementException("No staff with the number " + staffNumber);
+		}
+
+		return staveContents.get(staffNumber);
 	}
 
 	/**

--- a/src/main/java/org/wmn4j/notation/builders/ScoreBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/ScoreBuilder.java
@@ -3,13 +3,15 @@
  */
 package org.wmn4j.notation.builders;
 
+import org.wmn4j.notation.elements.Part;
+import org.wmn4j.notation.elements.Score;
+
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.wmn4j.notation.elements.Part;
-import org.wmn4j.notation.elements.Score;
+import java.util.Optional;
 
 /**
  * Class for building {@link Score} objects.
@@ -52,8 +54,38 @@ public class ScoreBuilder {
 	 * @return a score with the contents of this builder
 	 */
 	public Score build() {
+		padPartsWithEmptyMeasures();
 		final List<Part> parts = new ArrayList<>();
 		this.partBuilders.forEach((builder) -> parts.add(builder.build()));
 		return Score.of(this.scoreAttr, parts);
+	}
+
+	private void padPartsWithEmptyMeasures() {
+		Optional<List<MeasureBuilder>> longestStaffInScoreContentsOpt = partBuilders.stream()
+				.flatMap(partBuilder -> partBuilder.getStaffNumbers().stream()
+						.map(staffNumber -> partBuilder.getStaffContents(staffNumber)))
+				.max(Comparator.comparing(List::size));
+
+		if (longestStaffInScoreContentsOpt.isPresent()) {
+
+			List<MeasureBuilder> longestStaffInScoreContents = longestStaffInScoreContentsOpt.get();
+
+			for (PartBuilder partBuilder : partBuilders) {
+
+				Optional<Integer> numberOfLongestStaffInPartOpt = partBuilder.getStaffNumbers().stream()
+						.max(Comparator.comparing(staffNumber -> partBuilder.getStaffContents(staffNumber).size()));
+
+				if (numberOfLongestStaffInPartOpt.isPresent()) {
+					final int numberOfLongestStaffInPart = numberOfLongestStaffInPartOpt.get();
+					final int longestStaffInPartLength = partBuilder.getStaffContents(numberOfLongestStaffInPart)
+							.size();
+
+					for (int i = longestStaffInPartLength; i < longestStaffInScoreContents.size(); ++i) {
+						partBuilder.addToStaff(numberOfLongestStaffInPart,
+								MeasureBuilder.withAttributesOf(longestStaffInScoreContents.get(i)));
+					}
+				}
+			}
+		}
 	}
 }

--- a/src/test/java/org/wmn4j/notation/builders/PartBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/PartBuilderTest.java
@@ -105,6 +105,21 @@ public class PartBuilderTest {
 	}
 
 	@Test
+	public void testGetStaffNumbers() {
+		PartBuilder builder = new PartBuilder("Test");
+		assertTrue(builder.getStaffNumbers().isEmpty());
+
+		builder.add(new MeasureBuilder(1));
+		assertEquals(1, builder.getStaffNumbers().size());
+		assertTrue(builder.getStaffNumbers().contains(1));
+
+		builder.addToStaff(2, new MeasureBuilder(1));
+		assertEquals(2, builder.getStaffNumbers().size());
+		assertTrue(builder.getStaffNumbers().contains(1));
+		assertTrue(builder.getStaffNumbers().contains(2));
+	}
+
+	@Test
 	public void testBuildSingleStaffPart() {
 		final int measureCount = 5;
 		final PartBuilder builder = new PartBuilder("");

--- a/src/test/java/org/wmn4j/notation/builders/PartBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/PartBuilderTest.java
@@ -90,6 +90,21 @@ public class PartBuilderTest {
 	}
 
 	@Test
+	public void testGetMeasureCount() {
+		PartBuilder builder = new PartBuilder("Test");
+		assertEquals(0, builder.getMeasureCount());
+
+		builder.addToStaff(1, new MeasureBuilder(1));
+		assertEquals(1, builder.getMeasureCount());
+
+		builder.addToStaff(2, new MeasureBuilder(1));
+		assertEquals(1, builder.getMeasureCount());
+
+		builder.addToStaff(1, new MeasureBuilder(2));
+		assertEquals(2, builder.getMeasureCount());
+	}
+
+	@Test
 	public void testBuildSingleStaffPart() {
 		final int measureCount = 5;
 		final PartBuilder builder = new PartBuilder("");

--- a/src/test/java/org/wmn4j/notation/builders/PartBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/PartBuilderTest.java
@@ -24,10 +24,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class PartBuilderTest {
 
@@ -117,6 +119,30 @@ public class PartBuilderTest {
 		assertEquals(2, builder.getStaffNumbers().size());
 		assertTrue(builder.getStaffNumbers().contains(1));
 		assertTrue(builder.getStaffNumbers().contains(2));
+	}
+
+	@Test
+	public void testGetMeasureBuildersForStaff() {
+		PartBuilder builder = new PartBuilder("Test");
+		assertTrue(builder.getStaffNumbers().isEmpty());
+
+		builder.addToStaff(1, new MeasureBuilder(1));
+		builder.addToStaff(1, new MeasureBuilder(2));
+		builder.addToStaff(2, new MeasureBuilder(1));
+
+		assertEquals(2, builder.getStaffContents(1).size());
+		assertEquals(1, builder.getStaffContents(1).get(0).getNumber());
+		assertEquals(2, builder.getStaffContents(1).get(1).getNumber());
+
+		assertEquals(1, builder.getStaffContents(2).size());
+		assertEquals(1, builder.getStaffContents(2).get(0).getNumber());
+
+		try {
+			builder.getStaffContents(3);
+			fail("Trying to get builder from a voice that is not set in the builder did not throw exception");
+		} catch (NoSuchElementException e) {
+			/* Do nothing */
+		}
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/notation/builders/ScoreBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/ScoreBuilderTest.java
@@ -1,26 +1,19 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.builders;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.wmn4j.notation.TestHelper;
+import org.wmn4j.notation.elements.Score;
+import org.wmn4j.notation.elements.ScoreTest;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
-import org.wmn4j.notation.TestHelper;
-import org.wmn4j.notation.builders.PartBuilder;
-import org.wmn4j.notation.builders.ScoreBuilder;
-import org.wmn4j.notation.elements.Score;
-import org.wmn4j.notation.elements.ScoreTest;
+import static org.junit.Assert.assertEquals;
 
-/**
- *
- * @author Otso Björklund
- */
 public class ScoreBuilderTest {
 
 	public ScoreBuilderTest() {

--- a/src/test/java/org/wmn4j/notation/builders/ScoreBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/ScoreBuilderTest.java
@@ -5,8 +5,10 @@ package org.wmn4j.notation.builders;
 
 import org.junit.Test;
 import org.wmn4j.notation.TestHelper;
+import org.wmn4j.notation.elements.Part;
 import org.wmn4j.notation.elements.Score;
 import org.wmn4j.notation.elements.ScoreTest;
+import org.wmn4j.notation.elements.TimeSignatures;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,5 +55,61 @@ public class ScoreBuilderTest {
 		assertEquals(ScoreTest.COMPOSER_NAME, score.getAttribute(Score.Attribute.COMPOSER));
 
 		assertEquals(5, score.getPartCount());
+	}
+
+	@Test
+	public void testPartsAreOfEqualLengthWhenBuilt() {
+		final List<PartBuilder> partBuilders = getTestPartBuilders(3, 1);
+		PartBuilder first = partBuilders.get(0);
+		first.add(new MeasureBuilder(2));
+
+		MeasureBuilder thirdMeasureBuilder = new MeasureBuilder(3);
+		thirdMeasureBuilder.setTimeSignature(TimeSignatures.THREE_FOUR);
+		first.add(thirdMeasureBuilder);
+
+		MeasureBuilder fourthMeasureBuilder = new MeasureBuilder(4);
+		fourthMeasureBuilder.setTimeSignature(TimeSignatures.FOUR_FOUR);
+		first.add(fourthMeasureBuilder);
+
+		PartBuilder multiStaffPartBuilder = partBuilders.get(1);
+		multiStaffPartBuilder.addToStaff(2, new MeasureBuilder(1));
+
+		ScoreBuilder scoreBuilder = new ScoreBuilder();
+		scoreBuilder.setAttribute(Score.Attribute.NAME, "test score");
+
+		scoreBuilder.addPart(first);
+		scoreBuilder.addPart(multiStaffPartBuilder);
+		scoreBuilder.addPart(partBuilders.get(2));
+
+		Score score = scoreBuilder.build();
+
+		Part firstPart = score.getPart(0);
+		assertEquals(4, firstPart.getMeasureCount());
+		assertEquals(1, firstPart.getStaffCount());
+		assertEquals(TimeSignatures.FOUR_FOUR, firstPart.getMeasure(1, 1).getTimeSignature());
+		assertEquals(TimeSignatures.FOUR_FOUR, firstPart.getMeasure(1, 2).getTimeSignature());
+		assertEquals(TimeSignatures.THREE_FOUR, firstPart.getMeasure(1, 3).getTimeSignature());
+		assertEquals(TimeSignatures.FOUR_FOUR, firstPart.getMeasure(1, 4).getTimeSignature());
+
+		Part secondPart = score.getPart(1);
+		assertEquals(4, secondPart.getMeasureCount());
+		assertEquals(2, secondPart.getStaffCount());
+		assertEquals(TimeSignatures.FOUR_FOUR, secondPart.getMeasure(1, 1).getTimeSignature());
+		assertEquals(TimeSignatures.FOUR_FOUR, secondPart.getMeasure(1, 2).getTimeSignature());
+		assertEquals(TimeSignatures.THREE_FOUR, secondPart.getMeasure(1, 3).getTimeSignature());
+		assertEquals(TimeSignatures.FOUR_FOUR, secondPart.getMeasure(1, 4).getTimeSignature());
+
+		assertEquals(TimeSignatures.FOUR_FOUR, secondPart.getMeasure(2, 1).getTimeSignature());
+		assertEquals(TimeSignatures.FOUR_FOUR, secondPart.getMeasure(2, 2).getTimeSignature());
+		assertEquals(TimeSignatures.THREE_FOUR, secondPart.getMeasure(2, 3).getTimeSignature());
+		assertEquals(TimeSignatures.FOUR_FOUR, secondPart.getMeasure(2, 4).getTimeSignature());
+
+		Part thirdPart = score.getPart(2);
+		assertEquals(4, thirdPart.getMeasureCount());
+		assertEquals(1, thirdPart.getStaffCount());
+		assertEquals(TimeSignatures.FOUR_FOUR, thirdPart.getMeasure(1, 1).getTimeSignature());
+		assertEquals(TimeSignatures.FOUR_FOUR, thirdPart.getMeasure(1, 2).getTimeSignature());
+		assertEquals(TimeSignatures.THREE_FOUR, thirdPart.getMeasure(1, 3).getTimeSignature());
+		assertEquals(TimeSignatures.FOUR_FOUR, thirdPart.getMeasure(1, 4).getTimeSignature());
 	}
 }


### PR DESCRIPTION
Add empty measures to the end of parts that are shorter than the longest part in the score being collected into a score builder. This is intended for ensuring that all parts have the same number of measures in a score that is built using a score builder.