### PR TITLE
Issue #40: Specify more detailed exceptions for file reading and parsing

### DIFF
--- a/src/main/java/org/wmn4j/io/ParsingFailureException.java
+++ b/src/main/java/org/wmn4j/io/ParsingFailureException.java
@@ -1,0 +1,17 @@
+package org.wmn4j.io;
+
+/**
+ * Exception for cases in which parsing a file fails. For example, this may be thrown when attempting to read an invalid
+ * MusicXML file.
+ */
+public final class ParsingFailureException extends Exception {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param message a message that indicates why the parsing failed
+	 */
+	public ParsingFailureException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/org/wmn4j/io/ScoreReader.java
+++ b/src/main/java/org/wmn4j/io/ScoreReader.java
@@ -19,16 +19,18 @@ public interface ScoreReader {
 	 *
 	 * @param filePath the path of the music notation file from which to read the contents of the score
 	 * @return a score with the contents of the music notation file at the given path
-	 * @throws IOException if the file is not found or the file is not valid
+	 * @throws IOException             if the file is not found or reading the file fails
+	 * @throws ParsingFailureException if the file cannot be parsed
 	 */
-	Score readScore(Path filePath) throws IOException;
+	Score readScore(Path filePath) throws IOException, ParsingFailureException;
 
 	/**
 	 * Returns a score builder with the contents of the music notation file at the given path.
 	 *
 	 * @param filePath the path of the music notation file from which to read the contents of the score builder
 	 * @return a score builder with the contents of the music notation file at the given path
-	 * @throws IOException if the file is not found or the file is not valid
+	 * @throws IOException             if the file is not found or reading the file fails
+	 * @throws ParsingFailureException if the file cannot be parsed
 	 */
-	ScoreBuilder scoreBuilderFromFile(Path filePath) throws IOException;
+	ScoreBuilder scoreBuilderFromFile(Path filePath) throws IOException, ParsingFailureException;
 }

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
@@ -104,8 +104,12 @@ class MusicXmlReaderDom implements MusicXmlReader {
 		final ScoreBuilder scoreBuilder = new ScoreBuilder();
 		final File musicXmlFile = filePath.toFile();
 
+		if (!musicXmlFile.exists()) {
+			throw new IOException(filePath.toString() + " does not exist");
+		}
+
 		if (this.validateInput && !isMusicXmlFileValid(musicXmlFile)) {
-			throw new ParsingFailureException("File " + filePath.toString() + " is not a valid MusicXML file");
+			throw new ParsingFailureException(filePath.toString() + " is not a valid MusicXML file");
 		}
 
 		try {

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
@@ -9,6 +9,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.wmn4j.io.ParsingFailureException;
 import org.wmn4j.notation.builders.ChordBuilder;
 import org.wmn4j.notation.builders.MeasureBuilder;
 import org.wmn4j.notation.builders.NoteBuilder;
@@ -94,17 +95,17 @@ class MusicXmlReaderDom implements MusicXmlReader {
 	}
 
 	@Override
-	public Score readScore(Path filePath) throws IOException {
+	public Score readScore(Path filePath) throws IOException, ParsingFailureException {
 		return scoreBuilderFromFile(filePath).build();
 	}
 
 	@Override
-	public ScoreBuilder scoreBuilderFromFile(Path filePath) throws IOException {
+	public ScoreBuilder scoreBuilderFromFile(Path filePath) throws IOException, ParsingFailureException {
 		final ScoreBuilder scoreBuilder = new ScoreBuilder();
 		final File musicXmlFile = filePath.toFile();
 
 		if (this.validateInput && !isMusicXmlFileValid(musicXmlFile)) {
-			throw new IOException("File at " + filePath.toString() + " is not a valid MusicXML file");
+			throw new ParsingFailureException("File " + filePath.toString() + " is not a valid MusicXML file");
 		}
 
 		try {
@@ -114,10 +115,10 @@ class MusicXmlReaderDom implements MusicXmlReader {
 				final Document musicXmlDoc = docBuilder.parse(musicXmlFile);
 				readScoreToBuilder(scoreBuilder, musicXmlDoc);
 			} catch (final SAXException ex) {
-				throw new IOException("Parsing failed with exception " + ex.toString());
+				throw new ParsingFailureException("Parsing failed: " + ex.getMessage());
 			}
 		} catch (final ParserConfigurationException e) {
-			throw new IOException("Parser configuration failed");
+			throw new ParsingFailureException("Parser configuration failed: " + e.getMessage());
 		}
 
 		return scoreBuilder;

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
@@ -4,18 +4,8 @@
  */
 package org.wmn4j.io.musicxml;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Map;
-
 import org.junit.Test;
+import org.wmn4j.io.ParsingFailureException;
 import org.wmn4j.notation.TestHelper;
 import org.wmn4j.notation.elements.Articulation;
 import org.wmn4j.notation.elements.Barline;
@@ -38,6 +28,16 @@ import org.wmn4j.notation.elements.Staff;
 import org.wmn4j.notation.elements.TimeSignature;
 import org.wmn4j.notation.elements.TimeSignatures;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class MusicXmlReaderDomTest {
 
@@ -57,7 +57,7 @@ public class MusicXmlReaderDomTest {
 
 		try {
 			score = reader.readScore(path);
-		} catch (final IOException e) {
+		} catch (final IOException | ParsingFailureException e) {
 			fail("Parsing failed with exception " + e);
 		}
 
@@ -449,10 +449,13 @@ public class MusicXmlReaderDomTest {
 	public void testReadingIncorrectXmlFile() {
 		final MusicXmlReader reader = new MusicXmlReaderDom(true);
 		try {
-			final Score score = reader.readScore(Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + "singleCinvalid.xml"));
+			final Score score = reader
+					.readScore(Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + "singleCinvalid.xml"));
 			fail("No exception was thrown when trying to read incorrectly formatted XML file");
-		} catch (final IOException e) {
-
+		} catch (IOException ioException) {
+			fail("Reading the score failed due to IOException when a parsing failure was expected");
+		} catch (ParsingFailureException e) {
+			// Pass the test, this exception is expected.
 		}
 
 	}
@@ -463,7 +466,7 @@ public class MusicXmlReaderDomTest {
 		try {
 			reader.readScore(Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + "singleC.xml"));
 		} catch (Exception e) {
-			fail("Exception was thrown while validating valid MusicXml file");
+			fail("Exception " + e + " was thrown while validating valid MusicXml file");
 		}
 
 	}

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
@@ -471,4 +471,16 @@ public class MusicXmlReaderDomTest {
 
 	}
 
+	@Test
+	public void testReadingFileThatDoesNotExist() {
+		final MusicXmlReader reader = new MusicXmlReaderDom(true);
+		try {
+			reader.readScore(Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH
+					+ "aFileThatDoesNotAndShouldNotExistInTestFiles.xml"));
+		} catch (ParsingFailureException parsingFailure) {
+			fail("Reading the score failed due to parsing failure when an io expection was expected");
+		} catch (IOException ioException) {
+			// Pass the test, this exception is expected.
+		}
+	}
 }

--- a/src/test/java/org/wmn4j/notation/TestHelper.java
+++ b/src/test/java/org/wmn4j/notation/TestHelper.java
@@ -1,12 +1,7 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.wmn4j.io.musicxml.MusicXmlReader;
 import org.wmn4j.notation.builders.ChordBuilder;
@@ -18,10 +13,9 @@ import org.wmn4j.notation.elements.Measure;
 import org.wmn4j.notation.elements.Pitch;
 import org.wmn4j.notation.elements.Score;
 
-/**
- *
- * @author Otso Björklund
- */
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 public class TestHelper {
 
 	public static final String TESTFILE_PATH = "src/test/resources/";

--- a/src/test/java/org/wmn4j/notation/TestHelper.java
+++ b/src/test/java/org/wmn4j/notation/TestHelper.java
@@ -54,7 +54,7 @@ public class TestHelper {
 
 		try {
 			score = reader.readScore(path);
-		} catch (final IOException e) {
+		} catch (final Exception e) {
 			System.out.println("Failed to read score from " + path.toString() + " with exception: " + e);
 		}
 


### PR DESCRIPTION
Implements issue #40 

Add exception type for parsing failures and throw that when parsing fails.
Throw IOException when IO fails.