### PR TITLE
Issue #25: Add reading of score and part attributes to MusicXML reader

### DIFF
--- a/src/main/java/org/wmn4j/io/musicxml/DocHelper.java
+++ b/src/main/java/org/wmn4j/io/musicxml/DocHelper.java
@@ -3,6 +3,7 @@
  */
 package org.wmn4j.io.musicxml;
 
+import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -59,6 +60,27 @@ final class DocHelper {
 		}
 
 		return foundChildren;
+	}
+
+	/**
+	 * Returns the value of the attribute with the given name for the node if the attribute is present.
+	 *
+	 * @param node          the node for which the attribute is returned if it is present.
+	 * @param attributeName the name of the attribute whose value is returned
+	 * @return the value of the attribute with the given name for the node if the attribute is present
+	 */
+	static Optional<String> getAttributeValue(Node node, String attributeName) {
+		NamedNodeMap attributes = node.getAttributes();
+		if (attributes == null) {
+			return Optional.empty();
+		}
+
+		Node attributeNode = attributes.getNamedItem(attributeName);
+		if (attributeNode == null) {
+			return Optional.empty();
+		}
+
+		return Optional.of(attributeNode.getTextContent());
 	}
 
 	private DocHelper() {

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
@@ -74,6 +74,7 @@ final class MusicXmlTags {
 	static final String PART = "part";
 	static final String PART_ID = "id";
 	static final String PART_NAME = "part-name";
+	static final String PART_NAME_ABBREVIATION = "part-abbreviation";
 	static final String PART_LIST = "part-list";
 	static final String PLIST_SCORE_PART = "score-part";
 
@@ -84,8 +85,13 @@ final class MusicXmlTags {
 
 	// Score info tags
 	static final String SCORE_MOVEMENT_TITLE = "movement-title";
+	static final String SCORE_WORK = "work";
+	static final String SCORE_WORK_TITLE = "work-title";
 	static final String SCORE_IDENTIFICATION = "identification";
 	static final String SCORE_IDENTIFICATION_CREATOR = "creator";
+	static final String SCORE_IDENTIFICATION_CREATOR_TYPE = "type";
+	static final String SCORE_IDENTIFICATION_COMPOSER = "composer";
+	static final String SCORE_IDENTIFICATION_ARRANGER = "arranger";
 	static final String SCORE_PARTWISE = "score-partwise";
 
 	private MusicXmlTags() {

--- a/src/main/java/org/wmn4j/notation/elements/Score.java
+++ b/src/main/java/org/wmn4j/notation/elements/Score.java
@@ -28,6 +28,11 @@ public final class Score implements Iterable<Part> {
 		TITLE,
 
 		/**
+		 * The title of the movement.
+		 */
+		MOVEMENT_TITLE,
+
+		/**
 		 * The subtitle of the score.
 		 */
 		SUBTITLE,

--- a/src/main/java/org/wmn4j/notation/elements/Score.java
+++ b/src/main/java/org/wmn4j/notation/elements/Score.java
@@ -40,11 +40,7 @@ public final class Score implements Iterable<Part> {
 		/**
 		 * The arranger.
 		 */
-		ARRANGER,
-		/**
-		 * The year of publication.
-		 */
-		YEAR
+		ARRANGER
 	}
 
 	private final Map<Attribute, String> scoreAttr;

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
@@ -97,7 +97,7 @@ public class MusicXmlReaderDomTest {
 	 * Expects the contents of the file "singleC.xml"
 	 */
 	private void assertSingleNoteScoreReadCorrectly(Score score) {
-		assertEquals("Single C", score.getTitle());
+		assertEquals("Single C", score.getAttribute(Score.Attribute.MOVEMENT_TITLE));
 		assertEquals(1, score.getParts().size());
 
 		final Part part = score.getParts().get(0);
@@ -136,7 +136,7 @@ public class MusicXmlReaderDomTest {
 	 * Expects the contents of the file "twoMeasures.xml"
 	 */
 	private void assertChordsAndMultipleVoicesReadCorrectly(Score score) {
-		assertEquals("Two bar sample", score.getTitle());
+		assertEquals("Two bar sample", score.getAttribute(Score.Attribute.MOVEMENT_TITLE));
 		assertEquals("TestFile Composer", score.getAttribute(Score.Attribute.COMPOSER));
 		assertEquals(1, score.getParts().size());
 
@@ -209,7 +209,7 @@ public class MusicXmlReaderDomTest {
 	 * Expects the contents of the file "twoStavesAndMeasures.xml"
 	 */
 	private void assertScoreWithMultipleStavesReadCorrectly(Score score) {
-		assertEquals("Multistaff test file", score.getTitle());
+		assertEquals("Multistaff test file", score.getAttribute(Score.Attribute.MOVEMENT_TITLE));
 		assertEquals("TestFile Composer", score.getAttribute(Score.Attribute.COMPOSER));
 		assertEquals(2, score.getParts().size());
 
@@ -749,5 +749,47 @@ public class MusicXmlReaderDomTest {
 		Measure pickupMeasure = staff.getMeasure(0);
 		assertTrue(pickupMeasure.isPickUp());
 		assertEquals(0, pickupMeasure.getNumber());
+	}
+
+	@Test
+	public void testReadingAttributesIntoScore() {
+		final MusicXmlReader reader = new MusicXmlReaderDom(true);
+		try {
+			Score scoreWithAttributes = reader
+					.readScore(Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + "attribute_reading_test.xml"));
+			assertScoreHasExpectedAttributes(scoreWithAttributes);
+		} catch (Exception exception) {
+			fail("Reading attributes test file failed with " + exception);
+		}
+	}
+
+	@Test
+	public void testReadingAttributesIntoScoreBuilder() {
+		final MusicXmlReader reader = new MusicXmlReaderDom(true);
+		try {
+			ScoreBuilder scoreWithAttributesBuilder = reader
+					.readScoreBuilder(
+							Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + "attribute_reading_test.xml"));
+			assertScoreHasExpectedAttributes(scoreWithAttributesBuilder.build());
+		} catch (Exception exception) {
+			fail("Reading attributes test file failed with " + exception);
+		}
+	}
+
+	private void assertScoreHasExpectedAttributes(Score score) {
+		assertEquals("Composition title", score.getTitle());
+		assertEquals("Composer name", score.getAttribute(Score.Attribute.COMPOSER));
+		assertEquals("Movement title", score.getAttribute(Score.Attribute.MOVEMENT_TITLE));
+		assertEquals("Arranger name", score.getAttribute(Score.Attribute.ARRANGER));
+
+		List<Part> parts = score.getParts();
+		assertEquals(2, parts.size());
+		Part part1 = parts.get(0);
+		assertEquals("Part name 1", part1.getName());
+		assertEquals("Short part name 1", part1.getAttribute(Part.Attribute.ABBREVIATED_NAME));
+
+		Part part2 = parts.get(1);
+		assertEquals("Part name 2", part2.getName());
+		assertEquals("Short part name 2", part2.getAttribute(Part.Attribute.ABBREVIATED_NAME));
 	}
 }

--- a/src/test/java/org/wmn4j/notation/elements/ScoreTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/ScoreTest.java
@@ -27,6 +27,7 @@ public class ScoreTest {
 	public static final String SCORE_NAME = "TestScore";
 	public static final String SUBTITLE = "Score subtitle";
 	public static final String COMPOSER_NAME = "TestComposer";
+	public static final String MOVEMENT_NAME = "TestMovement";
 	public static final String ARRANGER = "Test Arranger";
 
 	public ScoreTest() {
@@ -35,6 +36,7 @@ public class ScoreTest {
 	public static Map<Score.Attribute, String> getTestAttributes() {
 		final Map<Score.Attribute, String> attributes = new HashMap<>();
 		attributes.put(Score.Attribute.TITLE, SCORE_NAME);
+		attributes.put(Score.Attribute.MOVEMENT_TITLE, MOVEMENT_NAME);
 		attributes.put(Score.Attribute.SUBTITLE, SUBTITLE);
 		attributes.put(Score.Attribute.COMPOSER, COMPOSER_NAME);
 		attributes.put(Score.Attribute.ARRANGER, ARRANGER);
@@ -73,6 +75,7 @@ public class ScoreTest {
 		assertEquals(SUBTITLE, score.getAttribute(Score.Attribute.SUBTITLE));
 		assertEquals(COMPOSER_NAME, score.getAttribute(Score.Attribute.COMPOSER));
 		assertEquals(ARRANGER, score.getAttribute(Score.Attribute.ARRANGER));
+		assertEquals(MOVEMENT_NAME, score.getAttribute(Score.Attribute.MOVEMENT_TITLE));
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/notation/elements/ScoreTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/ScoreTest.java
@@ -73,7 +73,6 @@ public class ScoreTest {
 		assertEquals(SUBTITLE, score.getAttribute(Score.Attribute.SUBTITLE));
 		assertEquals(COMPOSER_NAME, score.getAttribute(Score.Attribute.COMPOSER));
 		assertEquals(ARRANGER, score.getAttribute(Score.Attribute.ARRANGER));
-		assertEquals("", score.getAttribute(Score.Attribute.YEAR));
 	}
 
 	@Test

--- a/src/test/resources/musicxml/attribute_reading_test.xml
+++ b/src/test/resources/musicxml/attribute_reading_test.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Composition title</work-title>
+  </work>
+  <movement-title>Movement title</movement-title>
+  <identification>
+    <creator type="composer">Composer name</creator>
+    <creator type="arranger">Arranger name</creator>
+    <encoding>
+      <software>MuseScore 3.0.0</software>
+      <encoding-date>2019-05-15</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Part name 1</part-name>
+      <part-abbreviation>Short part name 1</part-abbreviation>
+    </score-part>
+    <score-part id="P2">
+      <part-name>Part name 2</part-name>
+      <part-abbreviation>Short part name 2</part-abbreviation>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1" width="1077.16">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+    <part id="P2">
+      <measure number="1" width="1077.16">
+        <attributes>
+          <divisions>1</divisions>
+          <key>
+            <fifths>0</fifths>
+            </key>
+          <time>
+            <beats>4</beats>
+            <beat-type>4</beat-type>
+            </time>
+          <clef>
+            <sign>G</sign>
+            <line>2</line>
+            </clef>
+          </attributes>
+        <note>
+          <rest/>
+          <duration>4</duration>
+          <voice>1</voice>
+          </note>
+        <barline location="right">
+          <bar-style>light-heavy</bar-style>
+          </barline>
+        </measure>
+      </part>
+  </score-partwise>


### PR DESCRIPTION
Implements issue #25 

Adds support for reading
* Score title
* Movement title
* Composer
* Arranger
* Part name
* Abbrebiated part name
from MusicXML.