### PR TITLE
Issue #31: Ensure supported articulations are read from MusicXML

### DIFF
--- a/src/main/java/org/wmn4j/notation/elements/Chord.java
+++ b/src/main/java/org/wmn4j/notation/elements/Chord.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Represents a chord. This class should be used for chords where the notes are
@@ -24,7 +25,6 @@ public final class Chord implements Durational, Iterable<Note> {
 	 *
 	 * @param n A non-empty and non-null array of {@link Note} objects
 	 * @return a chord with the given notes
-	 *
 	 * @throws NullPointerException     if notes is null
 	 * @throws IllegalArgumentException if notes is empty or all Note objects in
 	 *                                  notes are not of same duration
@@ -38,7 +38,6 @@ public final class Chord implements Durational, Iterable<Note> {
 	 *
 	 * @param notes A non-empty and non-null Collection of {@link Note} objects
 	 * @return a chord with the given notes
-	 *
 	 * @throws NullPointerException     if notes is null.
 	 * @throws IllegalArgumentException if notes is empty or all Note objects in
 	 *                                  notes are not of same duration.
@@ -50,10 +49,10 @@ public final class Chord implements Durational, Iterable<Note> {
 	/**
 	 * Private constructor. Use static getters for getting an instance.
 	 *
+	 * @param notes the notes that are put in this Chord
 	 * @throws NullPointerException     if notes is null
 	 * @throws IllegalArgumentException if notes is empty or all Note objects in
 	 *                                  notes are not of same duration
-	 * @param notes the notes that are put in this Chord
 	 */
 	private Chord(Collection<Note> notes) {
 
@@ -84,10 +83,10 @@ public final class Chord implements Durational, Iterable<Note> {
 	 * Returns the {@link Note} at the given index counting from lowest pitch in
 	 * this {@link Chord}.
 	 *
-	 * @throws IllegalArgumentException if fromLowest is smaller than 0 or at least
-	 *                                  the number of notes in this Chord
 	 * @param fromLowest index of note, 0 being the lowest note in the chord
 	 * @return the note from index fromLowest
+	 * @throws IllegalArgumentException if fromLowest is smaller than 0 or at least
+	 *                                  the number of notes in this Chord
 	 */
 	public Note getNote(int fromLowest) {
 		if (fromLowest < 0 || fromLowest >= this.notes.size()) {
@@ -192,11 +191,40 @@ public final class Chord implements Durational, Iterable<Note> {
 	}
 
 	/**
+	 * Returns true if this chord has articulations.
+	 *
+	 * @return true if this chord has articulations
+	 */
+	public boolean hasArticulations() {
+		return this.notes.stream().anyMatch(note -> note.hasArticulations());
+	}
+
+	/**
+	 * Returns true if this chord has the given articulation.
+	 *
+	 * @param articulation the articulation whose presence is checked
+	 * @return true if this chord has the given articulation
+	 */
+	public boolean hasArticulation(Articulation articulation) {
+		return this.notes.stream().anyMatch(note -> note.hasArticulation(articulation));
+	}
+
+	/**
+	 * Returns an unmodifiable view of all articulations defined for this chord.
+	 *
+	 * @return the articulations defined for this chord
+	 */
+	public Collection<Articulation> getArticulations() {
+		return this.notes.stream().flatMap(note -> note.getArticulations().stream())
+				.collect(Collectors.toUnmodifiableSet());
+	}
+
+	/**
 	 * Returns true if the given Object is equal to this.
 	 *
 	 * @param o Object against which this is compared for equality.
 	 * @return true if o is an instance of Chord and contains all and no other notes
-	 *         than the ones in this Chord.
+	 * than the ones in this Chord.
 	 */
 	@Override
 	public boolean equals(Object o) {

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
@@ -602,11 +602,30 @@ public class MusicXmlReaderDomTest {
 	 * Expects the contents of the file "articulations.xml"
 	 */
 	private void assertScoreWithArticulationsReadCorrectly(Score score) {
-		final Measure measure = score.getPart(0).getMeasure(0, 1);
-		assertTrue(((Note) measure.get(1, 0)).hasArticulation(Articulation.STACCATO));
-		assertTrue(((Note) measure.get(1, 1)).hasArticulation(Articulation.ACCENT));
-		assertTrue(((Note) measure.get(1, 2)).hasArticulation(Articulation.TENUTO));
-		assertTrue(((Note) measure.get(1, 3)).hasArticulation(Articulation.FERMATA));
+		final Measure measureOne = score.getPart(0).getMeasure(0, 1);
+		assertTrue(((Note) measureOne.get(1, 0)).hasArticulation(Articulation.STACCATO));
+		assertTrue(((Note) measureOne.get(1, 1)).hasArticulation(Articulation.ACCENT));
+		assertTrue(((Note) measureOne.get(1, 2)).hasArticulation(Articulation.TENUTO));
+		assertTrue(((Note) measureOne.get(1, 3)).hasArticulation(Articulation.FERMATA));
+
+		final Measure measureTwo = score.getPart(0).getMeasure(0, 2);
+		Note firstNoteInMeasureTwo = (Note) measureTwo.get(1, 0);
+		assertTrue(firstNoteInMeasureTwo.hasArticulation(Articulation.STACCATO));
+		assertTrue(firstNoteInMeasureTwo.hasArticulation(Articulation.ACCENT));
+		assertTrue(firstNoteInMeasureTwo.hasArticulation(Articulation.TENUTO));
+		assertTrue(firstNoteInMeasureTwo.hasArticulation(Articulation.FERMATA));
+		assertEquals(4, firstNoteInMeasureTwo.getArticulations().size());
+
+		assertTrue(((Chord) measureTwo.get(1, 1)).hasArticulation(Articulation.STACCATO));
+
+		Chord secondChordInMeasureTwo = (Chord) measureTwo.get(1, 2);
+		assertEquals(3, secondChordInMeasureTwo.getArticulations().size());
+		assertTrue((secondChordInMeasureTwo.hasArticulation(Articulation.STACCATO)));
+		assertTrue((secondChordInMeasureTwo.hasArticulation(Articulation.ACCENT)));
+		assertTrue((secondChordInMeasureTwo.hasArticulation(Articulation.FERMATA)));
+		assertFalse((secondChordInMeasureTwo.hasArticulation(Articulation.TENUTO)));
+
+		assertFalse(((Note) measureTwo.get(1, 3)).hasArticulations());
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/notation/elements/ChordTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/ChordTest.java
@@ -6,9 +6,12 @@ package org.wmn4j.notation.elements;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -187,6 +190,53 @@ public class ChordTest {
 		} catch (final IllegalArgumentException e) {
 			// Pass because exception is expected
 		}
+	}
+
+	@Test
+	public void testHasArticulations() {
+		List<Note> cMajorCopy = new ArrayList<>(this.cMajorNotes);
+		Set<Articulation> articulations = EnumSet.of(Articulation.ACCENT);
+		cMajorCopy.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER, articulations));
+		Chord chordWithAccent = Chord.of(cMajorCopy);
+		assertTrue(chordWithAccent.hasArticulations());
+		assertFalse(cMajor.hasArticulations());
+	}
+
+	@Test
+	public void testHasArticulation() {
+		List<Note> cMajorNotesWithAccentAndStaccato = new ArrayList<>();
+		cMajorNotesWithAccentAndStaccato
+				.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER, EnumSet.of(Articulation.ACCENT)));
+		cMajorNotesWithAccentAndStaccato
+				.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER, EnumSet.of(Articulation.STACCATO)));
+		cMajorNotesWithAccentAndStaccato.add(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER));
+		Chord cMajorWithArticulations = Chord.of(cMajorNotesWithAccentAndStaccato);
+
+		assertTrue(cMajorWithArticulations.hasArticulation(Articulation.STACCATO));
+		assertTrue(cMajorWithArticulations.hasArticulation(Articulation.ACCENT));
+		assertFalse(cMajorWithArticulations.hasArticulation(Articulation.TENUTO));
+
+		assertFalse(cMajor.hasArticulation(Articulation.STACCATO));
+		assertFalse(cMajor.hasArticulation(Articulation.ACCENT));
+	}
+
+	@Test
+	public void testGetArticulations() {
+		List<Note> cMajorNotesWithAccentAndStaccato = new ArrayList<>();
+		cMajorNotesWithAccentAndStaccato
+				.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER, EnumSet.of(Articulation.ACCENT)));
+		cMajorNotesWithAccentAndStaccato
+				.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER, EnumSet.of(Articulation.STACCATO)));
+		cMajorNotesWithAccentAndStaccato.add(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER));
+		Chord cMajorWithArticulations = Chord.of(cMajorNotesWithAccentAndStaccato);
+
+		Collection<Articulation> articulations = cMajorWithArticulations.getArticulations();
+		assertEquals(2, articulations.size());
+		assertTrue(articulations.contains(Articulation.STACCATO));
+		assertTrue(articulations.contains(Articulation.ACCENT));
+		assertFalse(articulations.contains(Articulation.TENUTO));
+
+		assertTrue(cMajor.getArticulations().isEmpty());
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/notation/elements/ChordTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/ChordTest.java
@@ -12,16 +12,17 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class ChordTest {
 
-	List<Note> cMajorNotes;
-	Chord cMajor;
-	Chord dMajor;
-	Chord fMinor;
-	Chord dMinorMaj9;
+	private final List<Note> cMajorNotes;
+	private final Chord cMajor;
+	private final Chord dMajor;
+	private final Chord fMinor;
+	private final Chord dMinorMaj9;
 
 	public ChordTest() {
 		this.cMajorNotes = new ArrayList<>();
@@ -88,7 +89,7 @@ public class ChordTest {
 	public void testGetNoteDurationsSameForAllNotes() {
 		final Duration duration = this.dMinorMaj9.getDuration();
 		for (int i = 0; i < this.dMinorMaj9.getNoteCount(); ++i) {
-			assertTrue(duration.equals(this.dMinorMaj9.getNote(i).getDuration()));
+			assertEquals(duration, this.dMinorMaj9.getNote(i).getDuration());
 		}
 
 		try {
@@ -97,7 +98,7 @@ public class ChordTest {
 			final ArrayList<Note> notes = new ArrayList<>();
 			notes.add(a);
 			notes.add(b);
-			final Chord c = Chord.of(notes);
+			Chord.of(notes);
 			fail("Failed to throw IllegalArgumentException when "
 					+ "creating chord with notes whose durations are not the same");
 		} catch (final IllegalArgumentException e) {
@@ -126,30 +127,26 @@ public class ChordTest {
 
 	@Test
 	public void testGetDuration() {
-		assertFalse(this.cMajor.getDuration().equals(Durations.SIXTEENTH));
-		assertTrue(this.dMajor.getDuration().equals(Durations.QUARTER));
+		assertNotEquals(Durations.SIXTEENTH, this.cMajor.getDuration());
+		assertEquals(Durations.QUARTER, this.dMajor.getDuration());
 	}
 
 	@Test
 	public void testGetNote() {
-		assertTrue(this.cMajor.getNote(1).equals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER)));
-		assertTrue(this.dMajor.getNote(2).equals(Note.of(Pitch.of(Pitch.Base.A, 0, 3), Durations.QUARTER)));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER), this.cMajor.getNote(1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.A, 0, 3), Durations.QUARTER), this.dMajor.getNote(2));
 	}
 
 	@Test
 	public void testGetLowestNote() {
-		assertTrue(this.cMajor.getLowestNote()
-				.equals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER)));
-		assertTrue(this.fMinor.getLowestNote()
-				.equals(Note.of(Pitch.of(Pitch.Base.F, 0, 4), Durations.QUARTER)));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), this.cMajor.getLowestNote());
+		assertEquals(Note.of(Pitch.of(Pitch.Base.F, 0, 4), Durations.QUARTER), this.fMinor.getLowestNote());
 	}
 
 	@Test
 	public void testGetHighestNote() {
-		assertTrue(this.cMajor.getHighestNote()
-				.equals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER)));
-		assertTrue(this.fMinor.getHighestNote()
-				.equals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER)));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER), this.cMajor.getHighestNote());
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER), this.fMinor.getHighestNote());
 	}
 
 	@Test
@@ -188,7 +185,7 @@ public class ChordTest {
 			final Chord illegalCMaj = this.cMajor.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHT));
 			fail("Failed to throw expected exception");
 		} catch (final IllegalArgumentException e) {
-			assertTrue(e instanceof IllegalArgumentException);
+			// Pass because exception is expected
 		}
 	}
 

--- a/src/test/java/org/wmn4j/notation/elements/ChordTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/ChordTest.java
@@ -1,31 +1,20 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.notation.elements;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.Test;
-import org.wmn4j.notation.elements.Articulation;
-import org.wmn4j.notation.elements.Chord;
-import org.wmn4j.notation.elements.Duration;
-import org.wmn4j.notation.elements.Durations;
-import org.wmn4j.notation.elements.Note;
-import org.wmn4j.notation.elements.Pitch;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-/**
- *
- * @author Otso Björklund
- */
 public class ChordTest {
 
 	List<Note> cMajorNotes;

--- a/src/test/resources/musicxml/articulations.xml
+++ b/src/test/resources/musicxml/articulations.xml
@@ -1,183 +1,265 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
-<score-partwise version="3.0">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
   <movement-title>Articulation tests</movement-title>
   <identification>
     <rights>©</rights>
     <encoding>
-      <software>Finale 2014.5 for Mac</software>
-      <software>Dolet Light for Finale 2014.5</software>
-      <encoding-date>2018-05-02</encoding-date>
-      <supports attribute="new-system" element="print" type="yes" value="yes"/>
-      <supports attribute="new-page" element="print" type="yes" value="yes"/>
+      <software>MuseScore 3.0.0</software>
+      <encoding-date>2019-05-18</encoding-date>
       <supports element="accidental" type="yes"/>
       <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
       <supports element="stem" type="yes"/>
-    </encoding>
-  </identification>
+      </encoding>
+    </identification>
   <defaults>
     <scaling>
       <millimeters>7.2319</millimeters>
       <tenths>40</tenths>
-    </scaling>
-    <page-layout>
-      <page-height>1545</page-height>
-      <page-width>1194</page-width>
-      <page-margins type="both">
-        <left-margin>140</left-margin>
-        <right-margin>70</right-margin>
-        <top-margin>70</top-margin>
-        <bottom-margin>70</bottom-margin>
-      </page-margins>
-    </page-layout>
-    <system-layout>
-      <system-margins>
-        <left-margin>0</left-margin>
-        <right-margin>0</right-margin>
-      </system-margins>
-      <system-distance>121</system-distance>
-      <top-system-distance>70</top-system-distance>
-    </system-layout>
-    <appearance>
-      <line-width type="stem">0.7487</line-width>
-      <line-width type="beam">5</line-width>
-      <line-width type="staff">0.7487</line-width>
-      <line-width type="light barline">0.7487</line-width>
-      <line-width type="heavy barline">5</line-width>
-      <line-width type="leger">0.7487</line-width>
-      <line-width type="ending">0.7487</line-width>
-      <line-width type="wedge">0.7487</line-width>
-      <line-width type="enclosure">0.7487</line-width>
-      <line-width type="tuplet bracket">0.7487</line-width>
-      <note-size type="grace">60</note-size>
-      <note-size type="cue">60</note-size>
-      <distance type="hyphen">120</distance>
-      <distance type="beam">8</distance>
-    </appearance>
-    <music-font font-family="Maestro,engraved" font-size="20.5"/>
-    <word-font font-family="Times New Roman" font-size="10.25"/>
-  </defaults>
+      </scaling>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
   <credit page="1">
-    <credit-type>title</credit-type>
-    <credit-words default-x="632" default-y="1475" font-size="24" justify="center" valign="top">Articulation tests</credit-words>
-  </credit>
+    <credit-words default-x="55.3105" default-y="1559.01" justify="left" valign="bottom" font-size="12">Score</credit-words>
+    </credit>
   <credit page="1">
-    <credit-type>rights</credit-type>
-    <credit-words default-x="632" default-y="53" font-size="10" justify="center" valign="bottom">©</credit-words>
-  </credit>
+    <credit-words default-x="580.921" default-y="1586.99" justify="center" valign="top" font-size="24">Articulation tests</credit-words>
+    </credit>
   <credit page="1">
-    <credit-words default-x="140" default-y="1478" font-size="12" valign="top">Score</credit-words>
-  </credit>
+    <credit-words default-x="580.921" default-y="110.621" justify="center" valign="bottom" font-size="8">©</credit-words>
+    </credit>
   <part-list>
     <score-part id="P1">
       <part-name print-object="no">MusicXML Part</part-name>
       <score-instrument id="P1-I1">
         <instrument-name>ARIA Pvoice</instrument-name>
-        <virtual-instrument>
-          <virtual-library>Garritan Instruments for Finale</virtual-library>
-          <virtual-name>005. Keyboards/Steinway Piano</virtual-name>
-        </virtual-instrument>
-      </score-instrument>
-      <midi-device>Bank 1</midi-device>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>
-        <volume>80</volume>
+        <volume>79.5276</volume>
         <pan>0</pan>
-      </midi-instrument>
-    </score-part>
-  </part-list>
-  <!--=========================================================-->
+        </midi-instrument>
+      </score-part>
+    </part-list>
   <part id="P1">
-    <measure number="1" width="913">
+    <measure number="1" width="550.74">
       <print>
         <system-layout>
           <system-margins>
-            <left-margin>70</left-margin>
-            <right-margin>0</right-margin>
-          </system-margins>
-          <top-system-distance>177</top-system-distance>
-        </system-layout>
-        <measure-numbering>system</measure-numbering>
-      </print>
+            <left-margin>0.00</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <top-system-distance>98.00</top-system-distance>
+          </system-layout>
+        </print>
       <attributes>
-        <divisions>2</divisions>
+        <divisions>1</divisions>
         <key>
           <fifths>0</fifths>
-          <mode>major</mode>
-        </key>
+          </key>
         <time>
           <beats>4</beats>
           <beat-type>4</beat-type>
-        </time>
+          </time>
         <clef>
           <sign>G</sign>
           <line>2</line>
-        </clef>
-      </attributes>
-      <sound tempo="120"/>
-      <note default-x="86">
+          </clef>
+        </attributes>
+      <note default-x="73.07" default-y="-50.00">
         <pitch>
           <step>C</step>
           <octave>4</octave>
-        </pitch>
-        <duration>2</duration>
+          </pitch>
+        <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <stem default-y="-14">up</stem>
+        <stem>up</stem>
         <notations>
           <articulations>
-            <staccato default-x="3" default-y="-63" placement="below"/>
-          </articulations>
-        </notations>
-      </note>
-      <note default-x="291">
+            <staccato/>
+            </articulations>
+          </notations>
+        </note>
+      <note default-x="192.09" default-y="-50.00">
         <pitch>
           <step>C</step>
           <octave>4</octave>
-        </pitch>
-        <duration>2</duration>
+          </pitch>
+        <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <stem default-y="-14">up</stem>
+        <stem>up</stem>
         <notations>
           <articulations>
-            <accent default-x="-1" default-y="-70" placement="below"/>
-          </articulations>
-        </notations>
-      </note>
-      <note default-x="495">
+            <accent/>
+            </articulations>
+          </notations>
+        </note>
+      <note default-x="311.11" default-y="-50.00">
         <pitch>
           <step>C</step>
           <octave>4</octave>
-        </pitch>
-        <duration>2</duration>
+          </pitch>
+        <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <stem default-y="-14">up</stem>
+        <stem>up</stem>
         <notations>
           <articulations>
-            <tenuto default-x="1" default-y="-61" placement="below"/>
-          </articulations>
-        </notations>
-      </note>
-      <note default-x="699">
+            <tenuto/>
+            </articulations>
+          </notations>
+        </note>
+      <note default-x="430.13" default-y="-50.00">
         <pitch>
           <step>C</step>
           <octave>4</octave>
-        </pitch>
-        <duration>2</duration>
+          </pitch>
+        <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <stem default-y="-14">up</stem>
+        <stem>up</stem>
         <notations>
-          <fermata default-x="-5" default-y="5" type="upright"/>
-        </notations>
-      </note>
+          <fermata type="upright"/>
+          </notations>
+        </note>
+      </measure>
+    <measure number="2" width="500.48">
+      <note default-x="13.80" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <fermata type="upright"/>
+          <articulations>
+            <staccato/>
+            <tenuto/>
+            <accent/>
+            </articulations>
+          </notations>
+        </note>
+      <note default-x="132.82" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <articulations>
+            <staccato/>
+            </articulations>
+          </notations>
+        </note>
+      <note default-x="132.82" default-y="-40.00">
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="132.82" default-y="-30.00">
+        <chord/>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="132.82" default-y="-15.00">
+        <chord/>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="251.84" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <fermata type="upright"/>
+          <articulations>
+            <staccato/>
+            <accent/>
+            </articulations>
+          </notations>
+        </note>
+      <note default-x="251.84" default-y="-40.00">
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="251.84" default-y="-30.00">
+        <chord/>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="251.84" default-y="-15.00">
+        <chord/>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="370.86" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>
-      </barline>
-    </measure>
-  </part>
-  <!--=========================================================-->
-</score-partwise>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>


### PR DESCRIPTION
Add access to articulations in chords.
Add test cases for reading multiple articulations for a single note from MusicXML.
Add test cases for reading articulations for a chord from MusicXML.