### PR TITLE
Deploy javadocs only on OpenJDK builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ deploy:
   keep-history: true
   on:
     branch: master
+    jdk: openjdk11


### PR DESCRIPTION
Currently deployment is run twice for the different JDK versions that wmn4j is built with.
Restrict deployment to only OpenJDK11.