### PR TITLE
Issue #32: Add support for reading markings from MusicXML

### DIFF
--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
@@ -522,11 +522,13 @@ final class MusicXmlReaderDom implements MusicXmlReader {
 		if (articulationsNode.isPresent()) {
 			for (int i = 0; i < articulationsNode.get().getChildNodes().getLength(); ++i) {
 				final Node articulationNode = articulationsNode.get().getChildNodes().item(i);
-				final Articulation articulation = getArticulation(articulationNode.getNodeName());
-				if (articulation != null) {
-					noteBuilder.addArticulation(articulation);
-				} else {
-					LOG.warn("Articulation of type " + articulationNode.getNodeName() + " not supported");
+				if (articulationNode.getNodeType() == Node.ELEMENT_NODE) {
+					final Articulation articulation = getArticulation(articulationNode.getNodeName());
+					if (articulation != null) {
+						noteBuilder.addArticulation(articulation);
+					} else {
+						LOG.warn("Articulation of type " + articulationNode.getNodeName() + " not supported");
+					}
 				}
 			}
 		}

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
@@ -3,6 +3,9 @@
  */
 package org.wmn4j.io.musicxml;
 
+import java.util.Collections;
+import java.util.Set;
+
 final class MusicXmlTags {
 
 	// Barline tags
@@ -69,6 +72,16 @@ final class MusicXmlTags {
 	static final String ACCENT = "accent";
 	static final String TENUTO = "tenuto";
 	static final String FERMATA = "fermata";
+
+	// Markings
+	static final String SLUR = "slur";
+	static final String GLISSANDO = "glissando";
+	static final String MARKING_NUMBER = "number";
+	static final String MARKING_TYPE = "type";
+	static final String MARKING_TYPE_START = "start";
+	static final String MARKING_TYPE_STOP = "stop";
+
+	static final Set<String> MARKING_NODE_NAMES = Collections.unmodifiableSet(Set.of(SLUR, GLISSANDO));
 
 	// Part tags
 	static final String PART = "part";

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
@@ -736,6 +736,9 @@ class MusicXmlReaderDomTest {
 		assertPickupMeasureReadCorrectly(scoreWithPickup.build());
 	}
 
+	/*
+	 * Expects the contents of "pickup_measure_test.xml".
+	 */
 	private void assertPickupMeasureReadCorrectly(Score score) {
 		assertEquals(1, score.getPartCount());
 		Part part = score.getParts().get(0);
@@ -766,6 +769,9 @@ class MusicXmlReaderDomTest {
 		assertScoreHasExpectedAttributes(scoreWithAttributesBuilder.build());
 	}
 
+	/*
+	 * Expectes the contents of "attribute_reading_test.xml".
+	 */
 	private void assertScoreHasExpectedAttributes(Score score) {
 		assertEquals("Composition title", score.getTitle());
 		assertEquals("Composer name", score.getAttribute(Score.Attribute.COMPOSER));

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
@@ -44,12 +44,12 @@ class MusicXmlReaderDomTest {
 
 	private static final String MUSICXML_FILE_PATH = "musicxml/";
 
-	MusicXmlReader getMusicXmlReader() {
-		return MusicXmlReader.getReader(false);
+	MusicXmlReader getMusicXmlReader(boolean validate) {
+		return new MusicXmlReaderDom(validate);
 	}
 
-	Score readScore(String testFileName) {
-		final MusicXmlReader reader = getMusicXmlReader();
+	Score readScore(String testFileName, boolean validate) {
+		final MusicXmlReader reader = getMusicXmlReader(validate);
 		Score score = null;
 		final Path path = Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + testFileName);
 
@@ -63,8 +63,8 @@ class MusicXmlReaderDomTest {
 		return score;
 	}
 
-	ScoreBuilder readScoreBuilder(String testFileName) {
-		final MusicXmlReader reader = getMusicXmlReader();
+	ScoreBuilder readScoreBuilder(String testFileName, boolean validate) {
+		final MusicXmlReader reader = getMusicXmlReader(validate);
 		ScoreBuilder scoreBuilder = null;
 		final Path path = Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + testFileName);
 
@@ -80,13 +80,13 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testReadScoreWithSingleNote() {
-		final Score score = readScore("singleC.xml");
+		final Score score = readScore("singleC.xml", false);
 		assertSingleNoteScoreReadCorrectly(score);
 	}
 
 	@Test
 	void testReadScoreBuilderWithSingleNote() {
-		final ScoreBuilder scoreBuilder = readScoreBuilder("singleC.xml");
+		final ScoreBuilder scoreBuilder = readScoreBuilder("singleC.xml", false);
 		assertSingleNoteScoreReadCorrectly(scoreBuilder.build());
 	}
 
@@ -119,13 +119,13 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testChordsAndMultipleVoicesReadToScore() {
-		final Score score = readScore("twoMeasures.xml");
+		final Score score = readScore("twoMeasures.xml", false);
 		assertChordsAndMultipleVoicesReadCorrectly(score);
 	}
 
 	@Test
 	void testChordsAndMultipleVoicesReadToScoreBuilder() {
-		final ScoreBuilder scoreBuilder = readScoreBuilder("twoMeasures.xml");
+		final ScoreBuilder scoreBuilder = readScoreBuilder("twoMeasures.xml", false);
 		assertChordsAndMultipleVoicesReadCorrectly(scoreBuilder.build());
 	}
 
@@ -192,13 +192,13 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testReadScoreWithMultipleStaves() {
-		final Score score = readScore("twoStavesAndMeasures.xml");
+		final Score score = readScore("twoStavesAndMeasures.xml", false);
 		assertScoreWithMultipleStavesReadCorrectly(score);
 	}
 
 	@Test
 	void testReadScoreBuilderWithMultipleStaves() {
-		final ScoreBuilder scoreBuilder = readScoreBuilder("twoStavesAndMeasures.xml");
+		final ScoreBuilder scoreBuilder = readScoreBuilder("twoStavesAndMeasures.xml", false);
 		assertScoreWithMultipleStavesReadCorrectly(scoreBuilder.build());
 	}
 
@@ -281,13 +281,13 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testBarlinesReadToScore() {
-		final Score score = readScore("barlines.xml");
+		final Score score = readScore("barlines.xml", false);
 		assertBarlinesReadCorrectly(score);
 	}
 
 	@Test
 	void testBarlinesReadToScoreBuilder() {
-		final ScoreBuilder scoreBuilder = readScoreBuilder("barlines.xml");
+		final ScoreBuilder scoreBuilder = readScoreBuilder("barlines.xml", false);
 		assertBarlinesReadCorrectly(scoreBuilder.build());
 	}
 
@@ -329,13 +329,13 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testClefsReadToScore() {
-		final Score score = readScore("clefs.xml");
+		final Score score = readScore("clefs.xml", false);
 		assertClefsReadCorrectly(score);
 	}
 
 	@Test
 	void testClefsReadToScoreBuilder() {
-		final ScoreBuilder scoreBuilder = readScoreBuilder("clefs.xml");
+		final ScoreBuilder scoreBuilder = readScoreBuilder("clefs.xml", false);
 		assertClefsReadCorrectly(scoreBuilder.build());
 	}
 
@@ -370,13 +370,13 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testMultiStaffClefsReadToScore() {
-		final Score score = readScore("multiStaffClefs.xml");
+		final Score score = readScore("multiStaffClefs.xml", false);
 		assertMultiStaffClefsReadCorrectlyToScore(score);
 	}
 
 	@Test
 	void testMultiStaffClefsReadToScoreBuilder() {
-		final ScoreBuilder scoreBuilder = readScoreBuilder("multiStaffClefs.xml");
+		final ScoreBuilder scoreBuilder = readScoreBuilder("multiStaffClefs.xml", false);
 		assertMultiStaffClefsReadCorrectlyToScore(scoreBuilder.build());
 	}
 
@@ -412,13 +412,13 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testKeySignaturesReadToScore() {
-		final Score score = readScore("keysigs.xml");
+		final Score score = readScore("keysigs.xml", false);
 		assertKeySignaturesReadToScoreCorrectly(score);
 	}
 
 	@Test
 	void testKeySignaturesReadToScoreBuilder() {
-		final ScoreBuilder scoreBuilder = readScoreBuilder("keysigs.xml");
+		final ScoreBuilder scoreBuilder = readScoreBuilder("keysigs.xml", false);
 		assertKeySignaturesReadToScoreCorrectly(scoreBuilder.build());
 	}
 
@@ -435,13 +435,13 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testMultiStaffPartReadToScore() {
-		final Score score = readScore("multistaff.xml");
+		final Score score = readScore("multistaff.xml", false);
 		assertMultiStaffPartReadCorrectly(score);
 	}
 
 	@Test
 	void testMultiStaffPartReadToScoreBuilder() {
-		final ScoreBuilder scoreBuilder = readScoreBuilder("multistaff.xml");
+		final ScoreBuilder scoreBuilder = readScoreBuilder("multistaff.xml", false);
 		assertMultiStaffPartReadCorrectly(scoreBuilder.build());
 	}
 
@@ -485,13 +485,13 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testTimeSignaturesReadToScore() {
-		final Score score = readScore("timesigs.xml");
+		final Score score = readScore("timesigs.xml", false);
 		assertTimeSignaturesReadCorrectly(score);
 	}
 
 	@Test
 	void testTimeSignaturesReadToScoreBuilder() {
-		final ScoreBuilder scoreBuilder = readScoreBuilder("timesigs.xml");
+		final ScoreBuilder scoreBuilder = readScoreBuilder("timesigs.xml", false);
 		assertTimeSignaturesReadCorrectly(scoreBuilder.build());
 	}
 
@@ -509,13 +509,13 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testTimeSignatureChangeReadToScore() {
-		final Score score = readScore("scoreIteratorTesting.xml");
+		final Score score = readScore("scoreIteratorTesting.xml", false);
 		assertTimeSignatureChangeReadCorrectly(score);
 	}
 
 	@Test
 	void testTimeSignatureChangeReadToScoreBuilder() {
-		final ScoreBuilder scoreBuilder = readScoreBuilder("scoreIteratorTesting.xml");
+		final ScoreBuilder scoreBuilder = readScoreBuilder("scoreIteratorTesting.xml", false);
 		assertTimeSignatureChangeReadCorrectly(scoreBuilder.build());
 	}
 
@@ -530,13 +530,13 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testTiedNotesReadToScore() {
-		final Score score = readScore("tieTesting.xml");
+		final Score score = readScore("tieTesting.xml", false);
 		assertTiedNotesReadCorrectly(score);
 	}
 
 	@Test
 	void testTiedNotesReadToScoreBuilder() {
-		final ScoreBuilder scoreBuilder = readScoreBuilder("tieTesting.xml");
+		final ScoreBuilder scoreBuilder = readScoreBuilder("tieTesting.xml", false);
 		assertTiedNotesReadCorrectly(scoreBuilder.build());
 	}
 
@@ -585,13 +585,13 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testReadingScoreWithArticulations() {
-		final Score score = readScore("articulations.xml");
+		final Score score = readScore("articulations.xml", false);
 		assertScoreWithArticulationsReadCorrectly(score);
 	}
 
 	@Test
 	void testReadingScoreBuilderWithArticulations() {
-		final ScoreBuilder scoreBuilder = readScoreBuilder("articulations.xml");
+		final ScoreBuilder scoreBuilder = readScoreBuilder("articulations.xml", false);
 		assertScoreWithArticulationsReadCorrectly(scoreBuilder.build());
 	}
 
@@ -627,7 +627,7 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testReadingIncorrectXmlFileToScore() {
-		final MusicXmlReader reader = new MusicXmlReaderDom(true);
+		final MusicXmlReader reader = getMusicXmlReader(true);
 		try {
 			reader.readScore(Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + "singleCinvalidXml.xml"));
 			fail("No exception was thrown when trying to read incorrectly formatted XML file");
@@ -640,7 +640,7 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testReadingIncorrectXmlFileToScoreBuilder() {
-		final MusicXmlReader reader = new MusicXmlReaderDom(true);
+		final MusicXmlReader reader = getMusicXmlReader(true);
 		try {
 			reader.readScoreBuilder(Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + "singleCinvalidXml.xml"));
 			fail("No exception was thrown when trying to read incorrectly formatted XML file");
@@ -653,7 +653,7 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testReadingIncorrectMusicXmlFileToScore() {
-		final MusicXmlReader reader = new MusicXmlReaderDom(true);
+		final MusicXmlReader reader = getMusicXmlReader(true);
 		try {
 			reader.readScore(Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + "singleCInvalidMusicXml.xml"));
 			fail("No exception was thrown when trying to read XML file that does not comply to MusicXml schema");
@@ -666,7 +666,7 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testReadingIncorrectMusicXmlFileToScoreBuilder() {
-		final MusicXmlReader reader = new MusicXmlReaderDom(true);
+		final MusicXmlReader reader = getMusicXmlReader(true);
 		try {
 			reader.readScoreBuilder(
 					Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + "singleCInvalidMusicXml.xml"));
@@ -680,7 +680,7 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testValidatingCorrectXmlFileWhenReadingToScore() {
-		final MusicXmlReader reader = new MusicXmlReaderDom(true);
+		final MusicXmlReader reader = getMusicXmlReader(true);
 		try {
 			reader.readScore(Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + "singleC.xml"));
 		} catch (Exception e) {
@@ -690,7 +690,7 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testValidatingCorrectXmlFileWhenReadingToScoreBuilder() {
-		final MusicXmlReader reader = new MusicXmlReaderDom(true);
+		final MusicXmlReader reader = getMusicXmlReader(true);
 		try {
 			reader.readScoreBuilder(Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + "singleC.xml"));
 		} catch (Exception e) {
@@ -700,7 +700,7 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testReadingFileThatDoesNotExistToScore() {
-		final MusicXmlReader reader = new MusicXmlReaderDom(true);
+		final MusicXmlReader reader = getMusicXmlReader(true);
 		try {
 			reader.readScore(Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH
 					+ "aFileThatDoesNotAndShouldNotExistInTestFiles.xml"));
@@ -713,7 +713,7 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testReadingFileThatDoesNotExistToScoreBuilder() {
-		final MusicXmlReader reader = new MusicXmlReaderDom(true);
+		final MusicXmlReader reader = getMusicXmlReader(true);
 		try {
 			reader.readScoreBuilder(Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH
 					+ "aFileThatDoesNotAndShouldNotExistInTestFiles.xml"));
@@ -726,27 +726,14 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testReadingScoreWithPickupMeasure() {
-		final MusicXmlReader reader = new MusicXmlReaderDom(true);
-		try {
-			Score scoreWithPickup = reader
-					.readScore(Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + "pickup_measure_test.xml"));
-			assertPickupMeasureReadCorrectly(scoreWithPickup);
-		} catch (Exception exception) {
-			fail("Reading score with pickup measure failed with " + exception);
-		}
+		Score scoreWithPickup = readScore("pickup_measure_test.xml", false);
+		assertPickupMeasureReadCorrectly(scoreWithPickup);
 	}
 
 	@Test
 	void testReadingScoreBuilderWithPickupMeasure() {
-		final MusicXmlReader reader = new MusicXmlReaderDom(true);
-		try {
-			ScoreBuilder scoreWithPickup = reader
-					.readScoreBuilder(
-							Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + "pickup_measure_test.xml"));
-			assertPickupMeasureReadCorrectly(scoreWithPickup.build());
-		} catch (Exception exception) {
-			fail("Reading score with pickup measure failed with " + exception);
-		}
+		ScoreBuilder scoreWithPickup = readScoreBuilder("pickup_measure_test.xml", false);
+		assertPickupMeasureReadCorrectly(scoreWithPickup.build());
 	}
 
 	private void assertPickupMeasureReadCorrectly(Score score) {
@@ -769,27 +756,14 @@ class MusicXmlReaderDomTest {
 
 	@Test
 	void testReadingAttributesIntoScore() {
-		final MusicXmlReader reader = new MusicXmlReaderDom(true);
-		try {
-			Score scoreWithAttributes = reader
-					.readScore(Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + "attribute_reading_test.xml"));
-			assertScoreHasExpectedAttributes(scoreWithAttributes);
-		} catch (Exception exception) {
-			fail("Reading attributes test file failed with " + exception);
-		}
+		Score scoreWithAttributes = readScore("attribute_reading_test.xml", false);
+		assertScoreHasExpectedAttributes(scoreWithAttributes);
 	}
 
 	@Test
 	void testReadingAttributesIntoScoreBuilder() {
-		final MusicXmlReader reader = new MusicXmlReaderDom(true);
-		try {
-			ScoreBuilder scoreWithAttributesBuilder = reader
-					.readScoreBuilder(
-							Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + "attribute_reading_test.xml"));
-			assertScoreHasExpectedAttributes(scoreWithAttributesBuilder.build());
-		} catch (Exception exception) {
-			fail("Reading attributes test file failed with " + exception);
-		}
+		ScoreBuilder scoreWithAttributesBuilder = readScoreBuilder("attribute_reading_test.xml", false);
+		assertScoreHasExpectedAttributes(scoreWithAttributesBuilder.build());
 	}
 
 	private void assertScoreHasExpectedAttributes(Score score) {

--- a/src/test/resources/musicxml/multi_staff_multi_voice_marking_test.xml
+++ b/src/test/resources/musicxml/multi_staff_multi_voice_marking_test.xml
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Multi staff marking test</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore 3.0.0</software>
+      <encoding-date>2019-05-24</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <credit page="1">
+    <credit-words default-x="170.079" default-y="1531.18" justify="right" valign="bottom" font-size="24">Multi staff marking test</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="546.16">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>21.00</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        <staff-layout number="2">
+          <staff-distance>0.00</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="86.27" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <notations>
+          <slur type="start" number="1"/>
+          </notations>
+        </note>
+      <note default-x="200.84" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <notations>
+          <slur type="start" number="2"/>
+          </notations>
+        </note>
+      <note default-x="315.41" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <notations>
+          <slur type="stop" number="1"/>
+          </notations>
+        </note>
+      <note default-x="429.99" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <notations>
+          <slur type="stop" number="2"/>
+          </notations>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <staff>2</staff>
+        </note>
+      <note default-x="200.84" default-y="-120.00">
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <notations>
+          <slur type="start" number="1"/>
+          </notations>
+        </note>
+      <note default-x="315.41" default-y="-115.00">
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <notations>
+          <slur type="stop" number="1"/>
+          </notations>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="2" width="510.33">
+      <note default-x="10.00" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <notations>
+          <slur type="start" number="1"/>
+          </notations>
+        </note>
+      <note default-x="132.43" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <notations>
+          <glissando line-type="wavy" number="1" type="start" default-y="-9.63">gliss.</glissando>
+          </notations>
+        </note>
+      <note default-x="254.87" default-y="-5.00">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <notations>
+          <slur type="stop" number="1"/>
+          <glissando line-type="wavy" number="1" type="stop"/>
+          </notations>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="10.00" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <notations>
+          <slur type="start" number="1"/>
+          <glissando line-type="wavy" number="1" type="start" default-y="-39.63">gliss.</glissando>
+          </notations>
+        </note>
+      <note default-x="132.43" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <notations>
+          <glissando line-type="wavy" number="1" type="stop"/>
+          </notations>
+        </note>
+      <note default-x="254.87" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <notations>
+          <slur type="stop" number="1"/>
+          </notations>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/test/resources/musicxml/single_staff_single_voice_marking_test.xml
+++ b/src/test/resources/musicxml/single_staff_single_voice_marking_test.xml
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Title</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer</creator>
+    <encoding>
+      <software>MuseScore 3.0.0</software>
+      <encoding-date>2019-05-19</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <credit page="1">
+    <credit-words default-x="170.079" default-y="1531.11" justify="right" valign="bottom" font-size="24">Single staff single voice marking test</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="577.34">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>0.00</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>2</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="73.07" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <slur type="start" number="1"/>
+          </notations>
+        </note>
+      <note default-x="139.21" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <beam number="1">continue</beam>
+        <notations>
+          <slur type="stop" number="1"/>
+          </notations>
+        </note>
+      <note default-x="205.35" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <beam number="1">continue</beam>
+        <notations>
+          <glissando line-type="wavy" number="1" type="start" default-y="-39.31"/>
+          </notations>
+        </note>
+      <note default-x="271.49" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <glissando line-type="wavy" number="1" type="stop"/>
+          </notations>
+        </note>
+      <note default-x="337.63" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <slur type="start" number="1"/>
+          </notations>
+        </note>
+      <note default-x="403.77" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <beam number="1">end</beam>
+        </note>
+      <note default-x="469.91" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <slur type="stop" number="1"/>
+          </notations>
+        </note>
+      </measure>
+    <measure number="2" width="500.15">
+      <note default-x="10.00" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <slur type="start" number="1"/>
+          </notations>
+        </note>
+      <note default-x="76.60" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <beam number="1">end</beam>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        </note>
+      <note default-x="209.81" default-y="-5.00">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <notations>
+          <slur type="stop" number="1"/>
+          </notations>
+        </note>
+      <note default-x="276.42" default-y="0.00">
+        <pitch>
+          <step>F</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <slur type="start" number="1"/>
+          <glissando line-type="wavy" number="1" type="start" default-y="0.43"/>
+          </notations>
+        </note>
+      <note default-x="382.99" default-y="5.00">
+        <pitch>
+          <step>G</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <slur type="stop" number="1"/>
+          <glissando line-type="wavy" number="1" type="stop"/>
+          </notations>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>


### PR DESCRIPTION
Adds support for reading markings (slurs, glissando) from MusicXML. 
The implementation only supports markings that occur between notes in the same voice.
Handling of slurs that cross parts and voices is more complex and is to be handled in issue #109 