### PR TITLE
Issue #4: Add support for writing basic notation to MusicXML

### DIFF
--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
@@ -18,6 +18,7 @@ final class MusicXmlTags {
 	static final String BARLINE_REPEAT_DIR_FORWARD = "forward";
 	static final String BARLINE_REPEAT_DIR_BACKWARD = "backward";
 	static final String BARLINE_STYLE = "bar-style";
+	static final String BARLINE_STYLE_REGULAR = "regular";
 	static final String BARLINE_STYLE_DASHED = "dashed";
 	static final String BARLINE_STYLE_HEAVY = "heavy";
 	static final String BARLINE_STYLE_HEAVY_LIGHT = "heavy-light";

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
@@ -48,6 +48,8 @@ final class MusicXmlTags {
 	static final String MEAS_ATTR_KEY_FIFTHS = "fifths";
 	static final String MEAS_ATTR_STAVES = "staves";
 	static final String MEAS_ATTR_STAFF_NUMBER = "number";
+	static final String MEASURE_BACKUP = "backup";
+	static final String MEASURE_FORWARD = "forward";
 
 	// Note tags
 	static final String NOTE = "note";

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
@@ -106,6 +106,7 @@ final class MusicXmlTags {
 	static final String SCORE_IDENTIFICATION_COMPOSER = "composer";
 	static final String SCORE_IDENTIFICATION_ARRANGER = "arranger";
 	static final String SCORE_PARTWISE = "score-partwise";
+	static final String MUSICXML_VERSION = "version";
 
 	private MusicXmlTags() {
 	}

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriter.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriter.java
@@ -5,6 +5,8 @@ package org.wmn4j.io.musicxml;
 
 import org.wmn4j.notation.elements.Score;
 
+import java.nio.file.Path;
+
 /**
  * Represents a writer for MusicXML files.
  */
@@ -26,6 +28,6 @@ public interface MusicXmlWriter {
 	 *
 	 * @param path the output path for the MusicXML file
 	 */
-	void writeToFile(String path);
+	void writeToFile(Path path);
 
 }

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
@@ -232,7 +232,8 @@ class MusicXmlWriterDom implements MusicXmlWriter {
 			if (voicesHandled < measure.getVoiceCount()) {
 				measureElement.appendChild(createBackupElement(cumulatedDuration));
 			} else {
-				if (cumulatedDuration.isShorterThan(measure.getTimeSignature().getTotalDuration())) {
+				if (!measure.isPickUp()
+						&& cumulatedDuration.isShorterThan(measure.getTimeSignature().getTotalDuration())) {
 					Duration duration = measure.getTimeSignature().getTotalDuration().subtract(cumulatedDuration);
 					measureElement.appendChild(createForwardElement(duration));
 				}

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
@@ -39,6 +39,7 @@ import java.util.TreeMap;
 class MusicXmlWriterDom implements MusicXmlWriter {
 
 	private Document doc;
+	private final String MUSICXML_VERSION_NUMBER = "3.1";
 	private final Score score;
 	private final SortedMap<String, Part> partIdMap = new TreeMap<>();
 	private final int divisions;
@@ -57,6 +58,7 @@ class MusicXmlWriterDom implements MusicXmlWriter {
 			// root elements
 			this.doc = docBuilder.newDocument();
 			final Element rootElement = this.doc.createElement(MusicXmlTags.SCORE_PARTWISE);
+			rootElement.setAttribute(MusicXmlTags.MUSICXML_VERSION, MUSICXML_VERSION_NUMBER);
 			this.doc.appendChild(rootElement);
 
 			// staff elements
@@ -76,7 +78,7 @@ class MusicXmlWriterDom implements MusicXmlWriter {
 			transformer.setOutputProperty(OutputKeys.METHOD, "xml");
 			final DOMImplementation domImpl = doc.getImplementation();
 			final DocumentType doctype = domImpl.createDocumentType("doctype",
-					"-//Recordare//DTD MusicXML 3.0 Partwise//EN",
+					"-//Recordare//DTD MusicXML " + MUSICXML_VERSION_NUMBER + " Partwise//EN",
 					"http://www.musicxml.org/dtds/partwise.dtd");
 			transformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, doctype.getPublicId());
 			transformer.setOutputProperty(OutputKeys.DOCTYPE_SYSTEM, doctype.getSystemId());

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
@@ -37,6 +37,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.math.BigInteger;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -62,7 +63,7 @@ class MusicXmlWriterDom implements MusicXmlWriter {
 	}
 
 	@Override
-	public void writeToFile(String path) {
+	public void writeToFile(Path path) {
 		try {
 			final DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
 			final DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
@@ -96,7 +97,7 @@ class MusicXmlWriterDom implements MusicXmlWriter {
 			transformer.setOutputProperty(OutputKeys.DOCTYPE_SYSTEM, doctype.getSystemId());
 
 			final DOMSource source = new DOMSource(doc);
-			final StreamResult result = new StreamResult(new File(path));
+			final StreamResult result = new StreamResult(new File(path.toString()));
 
 			transformer.transform(source, result);
 

--- a/src/main/java/org/wmn4j/notation/elements/Clef.java
+++ b/src/main/java/org/wmn4j/notation/elements/Clef.java
@@ -61,6 +61,22 @@ public final class Clef {
 		return new Clef(Objects.requireNonNull(symbol), line);
 	}
 
+	/**
+	 * Returns the symbol of this clef.
+	 * @return the symbol of this clef
+	 */
+	public Symbol getSymbol() {
+		return symbol;
+	}
+
+	/**
+	 * Returns the line of the staff (counted from bottom up) on which the clef is.
+	 * @return the line of the staff on which the clef is.
+	 */
+	public int getLine() {
+		return line;
+	}
+
 	private Clef(Symbol symbol, int line) {
 		this.symbol = symbol;
 		this.line = line;

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
@@ -72,8 +72,6 @@ class MusicXmlFileChecks {
 	 * Expects the contents of the file "twoMeasures.xml"
 	 */
 	static void assertChordsAndMultipleVoicesReadCorrectly(Score score) {
-		assertEquals("Two bar sample", score.getAttribute(Score.Attribute.MOVEMENT_TITLE));
-		assertEquals("TestFile Composer", score.getAttribute(Score.Attribute.COMPOSER));
 		assertEquals(1, score.getParts().size());
 
 		final Part part = score.getParts().get(0);

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
@@ -4,21 +4,145 @@
 package org.wmn4j.io.musicxml;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.wmn4j.io.ParsingFailureException;
 import org.wmn4j.notation.TestHelper;
+import org.wmn4j.notation.builders.MeasureBuilder;
+import org.wmn4j.notation.builders.NoteBuilder;
+import org.wmn4j.notation.builders.PartBuilder;
+import org.wmn4j.notation.builders.ScoreBuilder;
+import org.wmn4j.notation.elements.Durations;
+import org.wmn4j.notation.elements.Note;
+import org.wmn4j.notation.elements.Pitch;
 import org.wmn4j.notation.elements.Score;
+import org.wmn4j.notation.iterators.PartWiseScoreIterator;
+import org.wmn4j.notation.iterators.ScoreIterator;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class MusicXmlWriterDomTest {
 
-	MusicXmlWriterDomTest() {
+	@TempDir
+	Path temporaryDirectory;
+
+	private static final String MUSICXML_FILE_PATH = "musicxml/";
+
+
+	private Score readMusicXmlTestFile(String testFileName, boolean validate) {
+		final MusicXmlReader reader = new MusicXmlReaderDom(validate);
+		Score score = null;
+		final Path path = Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + testFileName);
+
+		try {
+			score = reader.readScore(path);
+		} catch (final IOException | ParsingFailureException e) {
+			fail("Parsing failed with exception " + e);
+		}
+
+		assertNotNull(score);
+		return score;
 	}
 
-	Score readScore(String path) {
-		return TestHelper.readScore(path);
+	private Score writeScore(Score score) {
+		MusicXmlWriterDom writer = new MusicXmlWriterDom(score);
+		Path file = temporaryDirectory.resolve("file.xml");
+		writer.writeToFile(file.toString());
+
+		//For debugging
+		//printLines(file);
+
+		final MusicXmlReader reader = new MusicXmlReaderDom(true);
+		Score writtenScore = null;
+
+		try {
+			writtenScore = reader.readScore(file);
+		} catch (final IOException | ParsingFailureException e) {
+			fail("Reading score written by MusicXmlWriterDom failed with exception " + e);
+		}
+
+		assertNotNull(writtenScore);
+		return writtenScore;
+	}
+
+	/**
+	 * Easy way to print the contents of a file for debugging
+	 * @param file Path to the file to print
+	 */
+	private void printLines(Path file) {
+		List<String> lines = null;
+		try {
+			lines = Files.readAllLines(file);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		for(String line : lines) {
+			System.out.println(line);
+		}
 	}
 
 	@Test
-	void testWritingSingleC() {
+	void testWritingNotes() {
+		ScoreBuilder scoreBuilder = new ScoreBuilder();
+		PartBuilder partBuilder = new PartBuilder("Part1");
+		MeasureBuilder measureBuilder = new MeasureBuilder(1);
 
+		measureBuilder.addToVoice(1, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 0), Durations.QUARTER));
+		measureBuilder.addToVoice(1, new NoteBuilder(Pitch.of(Pitch.Base.D, 1, 1), Durations.HALF));
+		measureBuilder.addToVoice(1, new NoteBuilder(Pitch.of(Pitch.Base.E, -2, 2), Durations.QUARTER_TRIPLET));
+
+		partBuilder.add(measureBuilder);
+		scoreBuilder.addPart(partBuilder);
+		Score score = scoreBuilder.build();
+
+		Score writtenScore = writeScore(score);
+
+		ScoreIterator iterator = new PartWiseScoreIterator(writtenScore);
+
+		Note note = (Note) iterator.next();
+		assertEquals(Pitch.Base.C, note.getPitch().getBase());
+		assertEquals(0, note.getPitch().getAlter());
+		assertEquals(0, note.getPitch().getOctave());
+		assertEquals(Durations.QUARTER, note.getDuration());
+
+		note = (Note) iterator.next();
+		assertEquals(Pitch.Base.D, note.getPitch().getBase());
+		assertEquals(1, note.getPitch().getAlter());
+		assertEquals(1, note.getPitch().getOctave());
+		assertEquals(Durations.HALF, note.getDuration());
+
+		note = (Note) iterator.next();
+		assertEquals(Pitch.Base.E, note.getPitch().getBase());
+		assertEquals(-2, note.getPitch().getAlter());
+		assertEquals(2, note.getPitch().getOctave());
+		assertEquals(Durations.QUARTER_TRIPLET, note.getDuration());
+
+		assertFalse(iterator.hasNext());
 	}
 
+	@Test
+	void testWritingKeySignatures() {
+		Score score = readMusicXmlTestFile("keysigs.xml", false);
+		Score writtenScore = writeScore(score);
+
+		MusicXmlFileChecks.assertKeySignaturesReadToScoreCorrectly(writtenScore);
+	}
+
+	@Test
+	void testWritingTimeSignatures() {
+		Score score = readMusicXmlTestFile("timesigs.xml", false);
+		Score writtenScore = writeScore(score);
+
+		MusicXmlFileChecks.assertTimeSignaturesReadCorrectly(writtenScore);
+	}
+	
 }

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
@@ -144,5 +144,13 @@ class MusicXmlWriterDomTest {
 
 		MusicXmlFileChecks.assertTimeSignaturesReadCorrectly(writtenScore);
 	}
+
+	@Test
+	void testWritingBarlines() {
+		Score score = readMusicXmlTestFile("barlines.xml", false);
+		Score writtenScore = writeScore(score);
+
+		MusicXmlFileChecks.assertBarlinesReadCorrectly(writtenScore);
+	}
 	
 }

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
@@ -161,4 +161,12 @@ class MusicXmlWriterDomTest {
 		MusicXmlFileChecks.assertChordsAndMultipleVoicesReadCorrectly(writtenScore);
 	}
 
+	@Test
+	void testWritingPickupMeasure() {
+		Score score = readMusicXmlTestFile("pickup_measure_test.xml", false);
+		Score writtenScore = writeScore(score);
+
+		MusicXmlFileChecks.assertPickupMeasureReadCorrectly(writtenScore);
+	}
+
 }

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
@@ -55,7 +55,7 @@ class MusicXmlWriterDomTest {
 	private Score writeScore(Score score) {
 		MusicXmlWriterDom writer = new MusicXmlWriterDom(score);
 		Path file = temporaryDirectory.resolve("file.xml");
-		writer.writeToFile(file.toString());
+		writer.writeToFile(file);
 
 		//For debugging
 		//printLines(file);

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
@@ -152,5 +152,13 @@ class MusicXmlWriterDomTest {
 
 		MusicXmlFileChecks.assertBarlinesReadCorrectly(writtenScore);
 	}
-	
+
+	@Test
+	void testWritingMultipleVoicesAndChords() {
+		Score score = readMusicXmlTestFile("twoMeasures.xml", false);
+		Score writtenScore = writeScore(score);
+
+		MusicXmlFileChecks.assertChordsAndMultipleVoicesReadCorrectly(writtenScore);
+	}
+
 }

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
@@ -19,10 +19,8 @@ import org.wmn4j.notation.iterators.PartWiseScoreIterator;
 import org.wmn4j.notation.iterators.ScoreIterator;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -34,11 +32,10 @@ class MusicXmlWriterDomTest {
 	@TempDir
 	Path temporaryDirectory;
 
-	private static final String MUSICXML_FILE_PATH = "musicxml/";
-
+	private final String MUSICXML_FILE_PATH = "musicxml/";
 
 	private Score readMusicXmlTestFile(String testFileName, boolean validate) {
-		final MusicXmlReader reader = new MusicXmlReaderDom(validate);
+		final MusicXmlReader reader = MusicXmlReader.getReader(validate);
 		Score score = null;
 		final Path path = Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + testFileName);
 
@@ -52,15 +49,12 @@ class MusicXmlWriterDomTest {
 		return score;
 	}
 
-	private Score writeScore(Score score) {
+	private Score writeAndReadScore(Score score) {
 		MusicXmlWriterDom writer = new MusicXmlWriterDom(score);
 		Path file = temporaryDirectory.resolve("file.xml");
 		writer.writeToFile(file);
 
-		//For debugging
-		//printLines(file);
-
-		final MusicXmlReader reader = new MusicXmlReaderDom(true);
+		final MusicXmlReader reader = MusicXmlReader.getReader(true);
 		Score writtenScore = null;
 
 		try {
@@ -71,23 +65,6 @@ class MusicXmlWriterDomTest {
 
 		assertNotNull(writtenScore);
 		return writtenScore;
-	}
-
-	/**
-	 * Easy way to print the contents of a file for debugging
-	 * @param file Path to the file to print
-	 */
-	private void printLines(Path file) {
-		List<String> lines = null;
-		try {
-			lines = Files.readAllLines(file);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-
-		for(String line : lines) {
-			System.out.println(line);
-		}
 	}
 
 	@Test
@@ -104,7 +81,7 @@ class MusicXmlWriterDomTest {
 		scoreBuilder.addPart(partBuilder);
 		Score score = scoreBuilder.build();
 
-		Score writtenScore = writeScore(score);
+		Score writtenScore = writeAndReadScore(score);
 
 		ScoreIterator iterator = new PartWiseScoreIterator(writtenScore);
 
@@ -132,7 +109,7 @@ class MusicXmlWriterDomTest {
 	@Test
 	void testWritingKeySignatures() {
 		Score score = readMusicXmlTestFile("keysigs.xml", false);
-		Score writtenScore = writeScore(score);
+		Score writtenScore = writeAndReadScore(score);
 
 		MusicXmlFileChecks.assertKeySignaturesReadToScoreCorrectly(writtenScore);
 	}
@@ -140,7 +117,7 @@ class MusicXmlWriterDomTest {
 	@Test
 	void testWritingTimeSignatures() {
 		Score score = readMusicXmlTestFile("timesigs.xml", false);
-		Score writtenScore = writeScore(score);
+		Score writtenScore = writeAndReadScore(score);
 
 		MusicXmlFileChecks.assertTimeSignaturesReadCorrectly(writtenScore);
 	}
@@ -148,7 +125,7 @@ class MusicXmlWriterDomTest {
 	@Test
 	void testWritingBarlines() {
 		Score score = readMusicXmlTestFile("barlines.xml", false);
-		Score writtenScore = writeScore(score);
+		Score writtenScore = writeAndReadScore(score);
 
 		MusicXmlFileChecks.assertBarlinesReadCorrectly(writtenScore);
 	}
@@ -156,7 +133,7 @@ class MusicXmlWriterDomTest {
 	@Test
 	void testWritingMultipleVoicesAndChords() {
 		Score score = readMusicXmlTestFile("twoMeasures.xml", false);
-		Score writtenScore = writeScore(score);
+		Score writtenScore = writeAndReadScore(score);
 
 		MusicXmlFileChecks.assertChordsAndMultipleVoicesReadCorrectly(writtenScore);
 	}
@@ -164,7 +141,7 @@ class MusicXmlWriterDomTest {
 	@Test
 	void testWritingPickupMeasure() {
 		Score score = readMusicXmlTestFile("pickup_measure_test.xml", false);
-		Score writtenScore = writeScore(score);
+		Score writtenScore = writeAndReadScore(score);
 
 		MusicXmlFileChecks.assertPickupMeasureReadCorrectly(writtenScore);
 	}


### PR DESCRIPTION
Support for writing some basic notation to MusicXML added. There are still some fairly basic things that need to be added, such as support for multistaff parts and adding the [type](http://usermanuals.musicxml.com/MusicXML/Content/EL-MusicXML-type.htm) for notes (opening written MusicXML files with e.g. MuseScore doesn't quite work, because it shows each note as a quarter note even if their duration in MusicXML are set correctly). I still thought creating a pull request would be a good idea at this point to confirm that this is heading to the right direction :)