### PR TITLE
Remove timestamps from javadocs to avoid unnecessary changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@
 
 plugins {
     id 'java'
-    id 'maven-publish'
     id 'checkstyle'
 }
 
@@ -36,14 +35,6 @@ group = 'wmn4j'
 version = '0.0.1-SNAPSHOT'
 description = 'wmn4j'
 sourceCompatibility = '12'
-
-publishing {
-    publications {
-        maven(MavenPublication) {
-            from(components.java)
-        }
-    }
-}
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ test {
     }
 }
 
+javadoc {
+    options.header().setNoTimestamp(true)
+}
+
 group = 'wmn4j'
 version = '0.0.1-SNAPSHOT'
 description = 'wmn4j'


### PR DESCRIPTION
Timestamps are not necessary for the html files in javadoc because the files are in Git.