### PR TITLE
Issue #5: Implement monophonic pattern handling

### DIFF
--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -9,6 +9,7 @@ import org.wmn4j.notation.elements.Durational;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A class for representing monophonic musical patterns. In a monophonic pattern
@@ -89,5 +90,23 @@ public final class MonophonicPattern implements Pattern {
 	public boolean equalsInOnsets(Pattern other) {
 		// TODO Auto-generated method stub
 		return false;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (!(o instanceof MonophonicPattern)) {
+			return false;
+		}
+
+		return getContents().equals(((MonophonicPattern) o).getContents());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(contents);
 	}
 }

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -97,7 +97,7 @@ final class MonophonicPattern implements Pattern {
 	}
 
 	@Override
-	public boolean equalsInTransposedPitch(Pattern other) {
+	public boolean equalsTranspositionally(Pattern other) {
 		// TODO Auto-generated method stub
 		return false;
 	}

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -103,7 +103,7 @@ final class MonophonicPattern implements Pattern {
 	}
 
 	@Override
-	public boolean equalsInRhythm(Pattern other) {
+	public boolean equalsInDurations(Pattern other) {
 		// TODO Auto-generated method stub
 		return false;
 	}

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -109,12 +109,6 @@ final class MonophonicPattern implements Pattern {
 	}
 
 	@Override
-	public boolean equalsInOnsets(Pattern other) {
-		// TODO Auto-generated method stub
-		return false;
-	}
-
-	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
 			return true;

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -1,22 +1,19 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.mir;
+
+import org.wmn4j.notation.elements.Chord;
+import org.wmn4j.notation.elements.Durational;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.wmn4j.notation.elements.Chord;
-import org.wmn4j.notation.elements.Durational;
-
 /**
  * A class for representing monophonic musical patterns. In a monophonic pattern
  * no notes occur simultaneously. The pattern cannot contain chords and does not
  * consist of multiple voices. This class is immutable.
- *
- * @author Otso Björklund
  */
 public final class MonophonicPattern implements Pattern {
 

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -5,11 +5,14 @@ package org.wmn4j.mir;
 
 import org.wmn4j.notation.elements.Chord;
 import org.wmn4j.notation.elements.Durational;
+import org.wmn4j.notation.elements.Note;
+import org.wmn4j.notation.elements.Pitch;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * A class for representing monophonic musical patterns. In a monophonic pattern
@@ -64,8 +67,21 @@ public final class MonophonicPattern implements Pattern {
 
 	@Override
 	public boolean equalsInPitch(Pattern other) {
-		// TODO Auto-generated method stub
+		if (other instanceof MonophonicPattern) {
+			List<Pitch> pitchesOfOther = ((MonophonicPattern) other).toPitchList();
+			List<Pitch> pitchesOfThis = this.toPitchList();
+
+			return pitchesOfThis.equals(pitchesOfOther);
+		}
+
 		return false;
+	}
+
+	private List<Pitch> toPitchList() {
+		return getContents().stream()
+				.filter(durational -> durational instanceof Note)
+				.map(durational -> ((Note) durational).getPitch())
+				.collect(Collectors.toList());
 	}
 
 	@Override

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -57,12 +57,6 @@ public final class MonophonicPattern implements Pattern {
 	}
 
 	@Override
-	public boolean equals(Pattern other) {
-		// TODO Auto-generated method stub
-		return false;
-	}
-
-	@Override
 	public boolean isMonophonic() {
 		return true;
 	}

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
  * no notes occur simultaneously. The pattern cannot contain chords and does not
  * consist of multiple voices. This class is immutable.
  */
-public final class MonophonicPattern implements Pattern {
+final class MonophonicPattern implements Pattern {
 
 	private final List<Durational> contents;
 
@@ -28,7 +28,7 @@ public final class MonophonicPattern implements Pattern {
 	 *
 	 * @param contents non-empty list containing the notation elements of the pattern in temporal order
 	 */
-	public MonophonicPattern(List<Durational> contents) {
+	MonophonicPattern(List<Durational> contents) {
 		this.contents = Collections.unmodifiableList(new ArrayList<>(contents));
 		if (this.contents == null) {
 			throw new NullPointerException("Cannot create pattern with null contents");
@@ -41,11 +41,7 @@ public final class MonophonicPattern implements Pattern {
 		}
 	}
 
-	/**
-	 * Returns an unmodifiable view of the notation elements in temporal order that make up the pattern.
-	 *
-	 * @return an unmodifiable view of the notation elements in temporal order that make up the pattern
-	 */
+	@Override
 	public List<Durational> getContents() {
 		return this.contents;
 	}
@@ -67,9 +63,9 @@ public final class MonophonicPattern implements Pattern {
 
 	@Override
 	public boolean equalsInPitch(Pattern other) {
-		if (other instanceof MonophonicPattern) {
-			List<Pitch> pitchesOfOther = ((MonophonicPattern) other).toPitchList();
-			List<Pitch> pitchesOfThis = this.toPitchList();
+		if (other.isMonophonic()) {
+			List<Pitch> pitchesOfOther = toPitchList(other.getContents());
+			List<Pitch> pitchesOfThis = toPitchList(getContents());
 
 			return pitchesOfThis.equals(pitchesOfOther);
 		}
@@ -77,8 +73,8 @@ public final class MonophonicPattern implements Pattern {
 		return false;
 	}
 
-	private List<Pitch> toPitchList() {
-		return getContents().stream()
+	private static List<Pitch> toPitchList(List<Durational> contents) {
+		return contents.stream()
 				.filter(durational -> durational instanceof Note)
 				.map(durational -> ((Note) durational).getPitch())
 				.collect(Collectors.toList());
@@ -86,12 +82,12 @@ public final class MonophonicPattern implements Pattern {
 
 	@Override
 	public boolean equalsEnharmonically(Pattern other) {
-		if (other instanceof MonophonicPattern) {
-			List<Integer> pitchNumbersOfOther = ((MonophonicPattern) other).toPitchList().stream()
+		if (other.isMonophonic()) {
+			List<Integer> pitchNumbersOfOther = toPitchList(other.getContents()).stream()
 					.map(pitch -> pitch.toInt()).collect(
 							Collectors.toList());
 
-			List<Integer> pitchNumbersOfThis = this.toPitchList().stream().map(pitch -> pitch.toInt()).collect(
+			List<Integer> pitchNumbersOfThis = toPitchList(getContents()).stream().map(pitch -> pitch.toInt()).collect(
 					Collectors.toList());
 
 			return pitchNumbersOfOther.equals(pitchNumbersOfThis);
@@ -124,11 +120,17 @@ public final class MonophonicPattern implements Pattern {
 			return true;
 		}
 
-		if (!(o instanceof MonophonicPattern)) {
+		if (!(o instanceof Pattern)) {
 			return false;
 		}
 
-		return getContents().equals(((MonophonicPattern) o).getContents());
+		Pattern other = (Pattern) o;
+
+		if (!other.isMonophonic()) {
+			return false;
+		}
+
+		return getContents().equals(other.getContents());
 	}
 
 	@Override

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -86,7 +86,17 @@ public final class MonophonicPattern implements Pattern {
 
 	@Override
 	public boolean equalsEnharmonically(Pattern other) {
-		// TODO Auto-generated method stub
+		if (other instanceof MonophonicPattern) {
+			List<Integer> pitchNumbersOfOther = ((MonophonicPattern) other).toPitchList().stream()
+					.map(pitch -> pitch.toInt()).collect(
+							Collectors.toList());
+
+			List<Integer> pitchNumbersOfThis = this.toPitchList().stream().map(pitch -> pitch.toInt()).collect(
+					Collectors.toList());
+
+			return pitchNumbersOfOther.equals(pitchNumbersOfThis);
+		}
+
 		return false;
 	}
 

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -7,6 +7,7 @@ import org.wmn4j.notation.elements.Chord;
 import org.wmn4j.notation.elements.Durational;
 import org.wmn4j.notation.elements.Note;
 import org.wmn4j.notation.elements.Pitch;
+import org.wmn4j.notation.elements.Pitched;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -98,8 +99,36 @@ final class MonophonicPattern implements Pattern {
 
 	@Override
 	public boolean equalsTranspositionally(Pattern other) {
-		// TODO Auto-generated method stub
-		return false;
+		if (!other.isMonophonic()) {
+			return false;
+		}
+
+		return createIntervalNumberList(getContents()).equals(createIntervalNumberList(other.getContents()));
+	}
+
+	/*
+	 * Returns a list of the intervals between consecutive pitches in the contents list. The intervals
+	 * are expressed as integers denoting how many half-steps the interval consists of.
+	 */
+	private static List<Integer> createIntervalNumberList(List<Durational> contents) {
+		List<Pitched> pitchedElements = contents.stream().filter(durational -> durational instanceof Pitched)
+				.map(durational -> (Pitched) durational).collect(Collectors.toList());
+
+		// If size is at most 1, then there are no intervals between adjacent notes of the pattern.
+		if (pitchedElements.size() <= 1) {
+			return Collections.emptyList();
+		}
+
+		List<Integer> intervalNumbers = new ArrayList<>();
+		int previous = pitchedElements.get(0).getPitch().toInt();
+
+		for (int i = 1; i < pitchedElements.size(); ++i) {
+			final int current = pitchedElements.get(i).getPitch().toInt();
+			intervalNumbers.add(current - previous);
+			previous = current;
+		}
+
+		return intervalNumbers;
 	}
 
 	@Override

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -22,8 +22,7 @@ public final class MonophonicPattern implements Pattern {
 	/**
 	 * Constructor.
 	 *
-	 * @param contents the notation elements in temporal order that make up the
-	 *                 pattern
+	 * @param contents non-empty list containing the notation elements of the pattern in temporal order
 	 */
 	public MonophonicPattern(List<Durational> contents) {
 		this.contents = Collections.unmodifiableList(new ArrayList<>(contents));
@@ -39,9 +38,9 @@ public final class MonophonicPattern implements Pattern {
 	}
 
 	/**
-	 * Returns the notation elements in temporal order that make up the pattern.
+	 * Returns an unmodifiable view of the notation elements in temporal order that make up the pattern.
 	 *
-	 * @return the notation elements in temporal order that make up the pattern
+	 * @return an unmodifiable view of the notation elements in temporal order that make up the pattern
 	 */
 	public List<Durational> getContents() {
 		return this.contents;

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -85,7 +85,7 @@ public final class MonophonicPattern implements Pattern {
 	}
 
 	@Override
-	public boolean equalsEnharmonicallyInPitch(Pattern other) {
+	public boolean equalsEnharmonically(Pattern other) {
 		// TODO Auto-generated method stub
 		return false;
 	}

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -104,7 +104,33 @@ final class MonophonicPattern implements Pattern {
 
 	@Override
 	public boolean equalsInDurations(Pattern other) {
-		// TODO Auto-generated method stub
+		if (other.isMonophonic()) {
+			final List<Durational> contentsOfThis = getContents();
+			final List<Durational> contentsOfOther = other.getContents();
+
+			if (contentsOfThis.size() == contentsOfOther.size()) {
+				for (int i = 0; i < contentsOfThis.size(); ++i) {
+
+					final Durational durationalInThis = contentsOfThis.get(i);
+					final Durational durationalInOther = contentsOfOther.get(i);
+
+					final boolean bothAreOfSameType =
+							(durationalInThis.isRest() && durationalInOther.isRest()) || (!durationalInThis.isRest()
+									&& !durationalInOther.isRest());
+
+					if (!bothAreOfSameType) {
+						return false;
+					}
+
+					if (!contentsOfThis.get(i).getDuration().equals(contentsOfOther.get(i).getDuration())) {
+						return false;
+					}
+				}
+
+				return true;
+			}
+		}
+
 		return false;
 	}
 

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -64,8 +64,7 @@ public final class MonophonicPattern implements Pattern {
 
 	@Override
 	public boolean isMonophonic() {
-		// TODO Auto-generated method stub
-		return false;
+		return true;
 	}
 
 	@Override

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -3,6 +3,10 @@
  */
 package org.wmn4j.mir;
 
+import org.wmn4j.notation.elements.Durational;
+
+import java.util.List;
+
 /**
  * Interface for musical patterns. The patterns can represent motifs, melodies,
  * or segments of polyphonic music. A pattern is a sequence of notes, chords,
@@ -12,6 +16,25 @@ package org.wmn4j.mir;
  * in multiple voices.
  */
 public interface Pattern {
+
+	/**
+	 * Returns a monophonic pattern with the given contents. The contents must be strictly monophonic, i.e., they cannot
+	 * contain any chords.
+	 *
+	 * @param contents non-empty list containing the notation elements of the pattern in temporal order
+	 * @return a pattern with the given contents
+	 */
+	static Pattern monophonicOf(List<Durational> contents) {
+		return new MonophonicPattern(contents);
+	}
+
+	/**
+	 * Returns the contents of this pattern. For monophonic patterns the contents are returned in temporal order. For
+	 * polyphonic patterns the order is not specified.
+	 *
+	 * @return the contents of this pattern
+	 */
+	List<Durational> getContents();
 
 	/**
 	 * Returns true if this pattern does not contain any notes occur simultaneously,

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -23,62 +23,62 @@ public interface Pattern {
 	boolean isMonophonic();
 
 	/**
-	 * Returns true if this <code>Pattern</code> contains the same pitches in the
+	 * Returns true if this pattern contains the same pitches in the
 	 * same order as other, otherwise returns false. The pitches must be spelled the
 	 * same way for the patterns to be considered equal in pitch. Rhythm is ignored.
 	 *
-	 * @param other the <code>Pattern</code> against which this is compared for
+	 * @param other the pattern against which this is compared for
 	 *              pitch equality.
-	 * @return true if this <code>Pattern</code> contains the same pitches in the
+	 * @return true if this pattern contains the same pitches in the
 	 * same order as other, otherwise returns false
 	 */
 	boolean equalsInPitch(Pattern other);
 
 	/**
-	 * Returns true if this <code>Pattern</code> contains the enharmonically same
+	 * Returns true if this pattern contains the enharmonically same
 	 * pitches in the same order as other, otherwise returns false. The pitch
 	 * spellings are not considered, but they are compared using enharmonic
 	 * equality. Rhythm is ignored.
 	 *
-	 * @param other the <code>Pattern</code> against which this is compared for
+	 * @param other the pattern against which this is compared for
 	 *              enharmonic pitch equality.
-	 * @return true if this <code>Pattern</code> contains the enharmonically same
+	 * @return true if this pattern contains the enharmonically same
 	 * pitches in the same order as other, otherwise returns false
 	 */
 	boolean equalsEnharmonicallyInPitch(Pattern other);
 
 	/**
-	 * Returns true if this <code>Pattern</code> can be transposed so that its
+	 * Returns true if this pattern can be transposed so that its
 	 * pitches are enharmonically equal to those of other, otherwise returns false.
 	 *
-	 * @param other the <code>Pattern</code> against which this is compared for
+	 * @param other the pattern against which this is compared for
 	 *              transposed enharmonic pitch equality.
-	 * @return true if this <code>Pattern</code> can be transposed so that its
+	 * @return true if this pattern can be transposed so that its
 	 * pitches are enharmonically equal to those of other, otherwise returns
 	 * false
 	 */
 	boolean equalsInTransposedPitch(Pattern other);
 
 	/**
-	 * Returns true if this <code>Pattern</code> has the same rhythm as other. Both
+	 * Returns true if this pattern has the same rhythm as other. Both
 	 * the onsets and durations must match for rhythms to be considered equal.
 	 * Pitches are ignored.
 	 *
-	 * @param other the <code>Pattern</code> against which this is compared for
+	 * @param other the pattern against which this is compared for
 	 *              rhythm equality.
-	 * @return true if this <code>Pattern</code> has the same rhythm as other,
+	 * @return true if this pattern has the same rhythm as other,
 	 * otherwise returns false
 	 */
 	boolean equalsInRhythm(Pattern other);
 
 	/**
-	 * Returns true if the onset times of notes in this <code>Pattern</code> match
+	 * Returns true if the onset times of notes in this pattern match
 	 * the onset times of notes in other, otherwise returns false. Pitches are
 	 * ignored.
 	 *
-	 * @param other the <code>Pattern</code> against which this is compared for
+	 * @param other the pattern against which this is compared for
 	 *              onset equality.
-	 * @return true if the onset times of notes in this <code>Pattern</code> match
+	 * @return true if the onset times of notes in this pattern match
 	 * the onset times of notes in other, otherwise returns false
 	 */
 	boolean equalsInOnsets(Pattern other);

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -73,6 +73,7 @@ public interface Pattern {
 	/**
 	 * Returns true if this pattern can be transposed chromatically so that its
 	 * pitches are enharmonically equal to those of other, otherwise returns false.
+	 * Durations are not considered in the comparison.
 	 *
 	 * @param other the pattern against which this is compared for
 	 *              transposed enharmonic pitch equality.

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.mir;
@@ -11,8 +10,6 @@ package org.wmn4j.mir;
  * there are no simultaneously occurring notes or chords. In a polyphonic
  * pattern there can be multiple notes occurring at the same time in chords or
  * in multiple voices.
- *
- * @author Otso Björklund
  */
 public interface Pattern {
 
@@ -21,7 +18,7 @@ public interface Pattern {
 	 *
 	 * @param other the <code>Pattern</code> this is compared against for equality
 	 * @return true if this pattern contains the exact same notes, rest, and chords
-	 *         in the same order as other. Otherwise returns false.
+	 * in the same order as other. Otherwise returns false.
 	 */
 	boolean equals(Pattern other);
 
@@ -30,7 +27,7 @@ public interface Pattern {
 	 * otherwise returns false.
 	 *
 	 * @return true if this pattern does not contain any notes occur simultaneously.
-	 *         Otherwise returns false.
+	 * Otherwise returns false.
 	 */
 	boolean isMonophonic();
 
@@ -42,7 +39,7 @@ public interface Pattern {
 	 * @param other the <code>Pattern</code> against which this is compared for
 	 *              pitch equality.
 	 * @return true if this <code>Pattern</code> contains the same pitches in the
-	 *         same order as other, otherwise returns false
+	 * same order as other, otherwise returns false
 	 */
 	boolean equalsInPitch(Pattern other);
 
@@ -55,7 +52,7 @@ public interface Pattern {
 	 * @param other the <code>Pattern</code> against which this is compared for
 	 *              enharmonic pitch equality.
 	 * @return true if this <code>Pattern</code> contains the enharmonically same
-	 *         pitches in the same order as other, otherwise returns false
+	 * pitches in the same order as other, otherwise returns false
 	 */
 	boolean equalsEnharmonicallyInPitch(Pattern other);
 
@@ -66,8 +63,8 @@ public interface Pattern {
 	 * @param other the <code>Pattern</code> against which this is compared for
 	 *              transposed enharmonic pitch equality.
 	 * @return true if this <code>Pattern</code> can be transposed so that its
-	 *         pitches are enharmonically equal to those of other, otherwise returns
-	 *         false
+	 * pitches are enharmonically equal to those of other, otherwise returns
+	 * false
 	 */
 	boolean equalsInTransposedPitch(Pattern other);
 
@@ -79,7 +76,7 @@ public interface Pattern {
 	 * @param other the <code>Pattern</code> against which this is compared for
 	 *              rhythm equality.
 	 * @return true if this <code>Pattern</code> has the same rhythm as other,
-	 *         otherwise returns false
+	 * otherwise returns false
 	 */
 	boolean equalsInRhythm(Pattern other);
 
@@ -91,7 +88,7 @@ public interface Pattern {
 	 * @param other the <code>Pattern</code> against which this is compared for
 	 *              onset equality.
 	 * @return true if the onset times of notes in this <code>Pattern</code> match
-	 *         the onset times of notes in other, otherwise returns false
+	 * the onset times of notes in other, otherwise returns false
 	 */
 	boolean equalsInOnsets(Pattern other);
 }

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -14,15 +14,6 @@ package org.wmn4j.mir;
 public interface Pattern {
 
 	/**
-	 * Returns true if this <code>Pattern</code> is equal to other.
-	 *
-	 * @param other the <code>Pattern</code> this is compared against for equality
-	 * @return true if this pattern contains the exact same notes, rest, and chords
-	 * in the same order as other. Otherwise returns false.
-	 */
-	boolean equals(Pattern other);
-
-	/**
 	 * Returns true if this pattern does not contain any notes occur simultaneously,
 	 * otherwise returns false.
 	 *

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -83,14 +83,14 @@ public interface Pattern {
 	boolean equalsInTransposedPitch(Pattern other);
 
 	/**
-	 * Returns true if this pattern has the same rhythm as other. Both
-	 * the onsets and durations must match for rhythms to be considered equal.
+	 * Returns true if this pattern has the same durations as the other pattern. The durations of notes in this pattern
+	 * must match the durations of notes in the given pattern and the durations of rests in this must match the
+	 * durations of the rests in the given pattern.
 	 * Pitches are ignored.
 	 *
 	 * @param other the pattern against which this is compared for
-	 *              rhythm equality.
-	 * @return true if this pattern has the same rhythm as other,
-	 * otherwise returns false
+	 *              durational equality
+	 * @return true if this pattern has the same durations as the other pattern
 	 */
-	boolean equalsInRhythm(Pattern other);
+	boolean equalsInDurations(Pattern other);
 }

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -93,16 +93,4 @@ public interface Pattern {
 	 * otherwise returns false
 	 */
 	boolean equalsInRhythm(Pattern other);
-
-	/**
-	 * Returns true if the onset times of notes in this pattern match
-	 * the onset times of notes in other, otherwise returns false. Pitches are
-	 * ignored.
-	 *
-	 * @param other the pattern against which this is compared for
-	 *              onset equality.
-	 * @return true if the onset times of notes in this pattern match
-	 * the onset times of notes in other, otherwise returns false
-	 */
-	boolean equalsInOnsets(Pattern other);
 }

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -71,16 +71,16 @@ public interface Pattern {
 	boolean equalsEnharmonically(Pattern other);
 
 	/**
-	 * Returns true if this pattern can be transposed so that its
+	 * Returns true if this pattern can be transposed chromatically so that its
 	 * pitches are enharmonically equal to those of other, otherwise returns false.
 	 *
 	 * @param other the pattern against which this is compared for
 	 *              transposed enharmonic pitch equality.
-	 * @return true if this pattern can be transposed so that its
+	 * @return true if this pattern can be transposed chromatically so that its
 	 * pitches are enharmonically equal to those of other, otherwise returns
 	 * false
 	 */
-	boolean equalsInTransposedPitch(Pattern other);
+	boolean equalsTranspositionally(Pattern other);
 
 	/**
 	 * Returns true if this pattern has the same durations as the other pattern. The durations of notes in this pattern

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -45,7 +45,7 @@ public interface Pattern {
 	 * @return true if this pattern contains the enharmonically same
 	 * pitches in the same order as other, otherwise returns false
 	 */
-	boolean equalsEnharmonicallyInPitch(Pattern other);
+	boolean equalsEnharmonically(Pattern other);
 
 	/**
 	 * Returns true if this pattern can be transposed so that its

--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -65,10 +65,10 @@ public final class PolyphonicPattern implements Pattern {
 	/*
 	 * (non-Javadoc)
 	 *
-	 * @see wmnlibmir.Pattern#equalsInRhythm(wmnlibmir.Pattern)
+	 * @see wmnlibmir.Pattern#equalsInDurations(wmnlibmir.Pattern)
 	 */
 	@Override
-	public boolean equalsInRhythm(Pattern other) {
+	public boolean equalsInDurations(Pattern other) {
 		// TODO Auto-generated method stub
 		return false;
 	}

--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -54,10 +54,10 @@ public final class PolyphonicPattern implements Pattern {
 	/*
 	 * (non-Javadoc)
 	 *
-	 * @see wmnlibmir.Pattern#equalsInTransposedPitch(wmnlibmir.Pattern)
+	 * @see wmnlibmir.Pattern#equalsTranspositionally(wmnlibmir.Pattern)
 	 */
 	@Override
-	public boolean equalsInTransposedPitch(Pattern other) {
+	public boolean equalsTranspositionally(Pattern other) {
 		// TODO Auto-generated method stub
 		return false;
 	}

--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -72,16 +72,4 @@ public final class PolyphonicPattern implements Pattern {
 		// TODO Auto-generated method stub
 		return false;
 	}
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see wmnlibmir.Pattern#equalsInOnsets(wmnlibmir.Pattern)
-	 */
-	@Override
-	public boolean equalsInOnsets(Pattern other) {
-		// TODO Auto-generated method stub
-		return false;
-	}
-
 }

--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -4,10 +4,19 @@
  */
 package org.wmn4j.mir;
 
+import org.wmn4j.notation.elements.Durational;
+
+import java.util.List;
+
 /**
  * @author Otso Björklund
  */
 public final class PolyphonicPattern implements Pattern {
+
+	@Override
+	public List<Durational> getContents() {
+		return null;
+	}
 
 	/*
 	 * (non-Javadoc)

--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -5,21 +5,9 @@
 package org.wmn4j.mir;
 
 /**
- *
  * @author Otso Björklund
  */
 public final class PolyphonicPattern implements Pattern {
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see wmnlibmir.Pattern#equals(wmnlibmir.Pattern)
-	 */
-	@Override
-	public boolean equals(Pattern other) {
-		// TODO Auto-generated method stub
-		return false;
-	}
 
 	/*
 	 * (non-Javadoc)

--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -34,10 +34,10 @@ public final class PolyphonicPattern implements Pattern {
 	/*
 	 * (non-Javadoc)
 	 *
-	 * @see wmnlibmir.Pattern#equalsEnharmonicallyInPitch(wmnlibmir.Pattern)
+	 * @see wmnlibmir.Pattern#equalsEnharmonically(wmnlibmir.Pattern)
 	 */
 	@Override
-	public boolean equalsEnharmonicallyInPitch(Pattern other) {
+	public boolean equalsEnharmonically(Pattern other) {
 		// TODO Auto-generated method stub
 		return false;
 	}

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -107,28 +107,29 @@ class MonophonicPatternTest {
 		assertTrue(pattern.isMonophonic());
 	}
 
-	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")
 	@Test
 	void testEqualsInPitch() {
-		final MonophonicPattern pattern1 = new MonophonicPattern(this.referenceNotes);
+		final MonophonicPattern pattern = new MonophonicPattern(this.referenceNotes);
 
 		final List<Durational> notes = new ArrayList<>();
 		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
 		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
-		notes.add(Rest.of(Durations.QUARTER));
 		notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
 		notes.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.WHOLE));
 
-		assertTrue(pattern1.equalsInPitch(new MonophonicPattern(notes)));
+		assertTrue(pattern.equalsInPitch(new MonophonicPattern(notes)));
 
 		notes.add(Rest.of(Durations.QUARTER));
 
-		assertTrue(pattern1.equalsInPitch(new MonophonicPattern(notes)),
+		assertTrue(pattern.equalsInPitch(new MonophonicPattern(notes)),
 				"Adding rest to end of pattern should not make pattern inequal in pitches");
 
-		notes.add(Note.of(Pitch.of(Pitch.Base.E, -1, 3), Durations.WHOLE));
+		notes.set(1, Note.of(Pitch.of(Pitch.Base.E, -1, 3), Durations.WHOLE));
+		assertFalse(pattern.equalsInPitch(new MonophonicPattern(notes)));
 
-		assertFalse(pattern1.equalsInPitch(new MonophonicPattern(notes)));
+		List<Durational> referenceNotesWithAddition = new ArrayList<>(referenceNotes);
+		referenceNotesWithAddition.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
+		assertFalse(pattern.equalsInPitch(new MonophonicPattern(referenceNotesWithAddition)));
 	}
 
 	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -132,19 +132,46 @@ class MonophonicPatternTest {
 		assertFalse(pattern.equalsInPitch(new MonophonicPattern(referenceNotesWithAddition)));
 	}
 
-	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")
 	@Test
 	void testEqualsEnharmonically() {
-		final MonophonicPattern pattern1 = new MonophonicPattern(this.referenceNotes);
+		final MonophonicPattern pattern = new MonophonicPattern(this.referenceNotes);
 
-		final List<Durational> notes = new ArrayList<>();
-		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
-		notes.add(Rest.of(Durations.QUARTER));
-		notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
-		notes.add(Note.of(Pitch.of(Pitch.Base.A, 1, 3), Durations.WHOLE));
+		assertTrue(pattern.equalsEnharmonically(new MonophonicPattern(referenceNotes)));
 
-		assertTrue(pattern1.equalsEnharmonically(new MonophonicPattern(notes)));
+		final List<Durational> samePitchesWithDifferentDurations = new ArrayList<>();
+		samePitchesWithDifferentDurations.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		samePitchesWithDifferentDurations.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
+		samePitchesWithDifferentDurations.add(Rest.of(Durations.QUARTER));
+		samePitchesWithDifferentDurations.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
+		samePitchesWithDifferentDurations.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.WHOLE));
+
+		assertTrue(pattern.equalsEnharmonically(new MonophonicPattern(samePitchesWithDifferentDurations)),
+				"Difference in durations affected enharmonic equality when it shouldn't have affected it.");
+
+		final List<Durational> samePitchesWithDifferentSpellings = new ArrayList<>();
+		samePitchesWithDifferentSpellings.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT));
+		samePitchesWithDifferentSpellings.add(Note.of(Pitch.of(Pitch.Base.D, -2, 5), Durations.EIGHT));
+		samePitchesWithDifferentSpellings.add(Rest.of(Durations.QUARTER));
+		samePitchesWithDifferentSpellings.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
+		samePitchesWithDifferentSpellings.add(Note.of(Pitch.of(Pitch.Base.A, 1, 3), Durations.QUARTER));
+
+		assertTrue(pattern.equalsEnharmonically(new MonophonicPattern(samePitchesWithDifferentSpellings)),
+				"Difference in note spellings affected enharmonic equality when it shouldn't have affected it.");
+
+		final List<Durational> notesWithAdditionalRestAtEnd = new ArrayList<>(referenceNotes);
+		notesWithAdditionalRestAtEnd.add(Rest.of(Durations.QUARTER));
+
+		assertTrue(pattern.equalsEnharmonically(new MonophonicPattern(notesWithAdditionalRestAtEnd)),
+				"Adding rest to end of pattern should not make patterns unequal enharmonically.");
+
+		final List<Durational> enharmonicallyUnequalPitches = new ArrayList<>();
+		enharmonicallyUnequalPitches.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT));
+		enharmonicallyUnequalPitches.add(Note.of(Pitch.of(Pitch.Base.D, 0, 5), Durations.EIGHT));
+		enharmonicallyUnequalPitches.add(Rest.of(Durations.QUARTER));
+		enharmonicallyUnequalPitches.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
+		enharmonicallyUnequalPitches.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
+
+		assertFalse(pattern.equalsEnharmonically(new MonophonicPattern(enharmonicallyUnequalPitches)));
 	}
 
 	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -66,13 +66,15 @@ class MonophonicPatternTest {
 		}
 	}
 
-	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")
 	@Test
-	void testEqualsPattern() {
+	void testEquals() {
 		final MonophonicPattern pattern1 = new MonophonicPattern(this.referenceNotes);
 		final MonophonicPattern pattern2 = new MonophonicPattern(this.referenceNotes);
 
+		assertEquals(pattern1, pattern1);
+
 		assertEquals(pattern1, pattern2);
+		assertEquals(pattern2, pattern1);
 
 		final List<Durational> modifiedNotes = new ArrayList<>(this.referenceNotes);
 		modifiedNotes.add(Rest.of(Durations.QUARTER));

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -191,10 +191,4 @@ class MonophonicPatternTest {
 	void testEqualsInRhythm() {
 		// TODO
 	}
-
-	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")
-	@Test
-	void testEqualsInOnsets() {
-		// TODO
-	}
 }

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -186,9 +186,50 @@ class MonophonicPatternTest {
 		// TODO
 	}
 
-	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")
 	@Test
 	void testEqualsInDurations() {
-		// TODO
+		final Pattern pattern = createMonophonicPattern(referenceNotes);
+		assertTrue(pattern.equalsInDurations(createMonophonicPattern(referenceNotes)));
+
+		List<Durational> withSameDurationsButDifferentPitches = new ArrayList<>();
+		withSameDurationsButDifferentPitches.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHT));
+		withSameDurationsButDifferentPitches.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHT));
+		withSameDurationsButDifferentPitches.add(Rest.of(Durations.QUARTER));
+		withSameDurationsButDifferentPitches.add(Note.of(Pitch.of(Pitch.Base.D, -1, 4), Durations.QUARTER));
+		withSameDurationsButDifferentPitches.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
+
+		assertTrue(pattern.equalsInDurations(createMonophonicPattern(withSameDurationsButDifferentPitches)));
+
+		List<Durational> withDifferentNoteDurations = new ArrayList<>();
+		withDifferentNoteDurations.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT));
+		withDifferentNoteDurations.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
+		withDifferentNoteDurations.add(Rest.of(Durations.QUARTER));
+		withDifferentNoteDurations.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
+		withDifferentNoteDurations.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
+
+		assertFalse(pattern.equalsInDurations(createMonophonicPattern(withDifferentNoteDurations)));
+
+		List<Durational> withDifferentRestDurations = new ArrayList<>();
+		withDifferentRestDurations.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT));
+		withDifferentRestDurations.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHT));
+		withDifferentRestDurations.add(Rest.of(Durations.EIGHT));
+		withDifferentRestDurations.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
+		withDifferentRestDurations.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
+
+		assertFalse(pattern.equalsInDurations(createMonophonicPattern(withDifferentRestDurations)));
+
+		final List<Durational> withRestInAPlaceWhereReferenceHasANote = new ArrayList<>();
+		withRestInAPlaceWhereReferenceHasANote.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT));
+		withRestInAPlaceWhereReferenceHasANote.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHT));
+		withRestInAPlaceWhereReferenceHasANote.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
+		withRestInAPlaceWhereReferenceHasANote.add(Rest.of(Durations.QUARTER));
+		withRestInAPlaceWhereReferenceHasANote.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
+
+		assertFalse(pattern.equalsInDurations(createMonophonicPattern(withRestInAPlaceWhereReferenceHasANote)));
+
+		final List<Durational> withAddedDurationAtEnd = new ArrayList<>(referenceNotes);
+		withAddedDurationAtEnd.add(Rest.of(Durations.SIXTEENTH));
+
+		assertFalse(pattern.equalsInDurations(createMonophonicPattern(withAddedDurationAtEnd)));
 	}
 }

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -188,7 +188,7 @@ class MonophonicPatternTest {
 
 	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")
 	@Test
-	void testEqualsInRhythm() {
+	void testEqualsInDurations() {
 		// TODO
 	}
 }

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -182,7 +182,7 @@ class MonophonicPatternTest {
 
 	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")
 	@Test
-	void testEqualsInTransposedPitch() {
+	void testEqualsTranspositionally() {
 		// TODO
 	}
 

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -134,7 +134,7 @@ class MonophonicPatternTest {
 
 	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")
 	@Test
-	void testEqualsEnharmonicallyInPitch() {
+	void testEqualsEnharmonically() {
 		final MonophonicPattern pattern1 = new MonophonicPattern(this.referenceNotes);
 
 		final List<Durational> notes = new ArrayList<>();
@@ -144,7 +144,7 @@ class MonophonicPatternTest {
 		notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
 		notes.add(Note.of(Pitch.of(Pitch.Base.A, 1, 3), Durations.WHOLE));
 
-		assertTrue(pattern1.equalsEnharmonicallyInPitch(new MonophonicPattern(notes)));
+		assertTrue(pattern1.equalsEnharmonically(new MonophonicPattern(notes)));
 	}
 
 	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -37,7 +37,7 @@ class MonophonicPatternTest {
 	}
 
 	@Test
-	void testMonophonicPatternListOfDurational() {
+	void testCreatingMonophonicPatternFromListOfDurationals() {
 		try {
 			new MonophonicPattern(null);
 			fail("Was able to create pattern with null contents");

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -37,10 +37,16 @@ class MonophonicPatternTest {
 		this.referenceNotes = Collections.unmodifiableList(notes);
 	}
 
+	private Pattern createMonophonicPattern(List<Durational> contents) {
+		Pattern monophonicPattern = Pattern.monophonicOf(contents);
+		assertTrue(monophonicPattern instanceof MonophonicPattern, "Created pattern was of incorrect class");
+		return monophonicPattern;
+	}
+
 	@Test
 	void testCreatingMonophonicPatternFromListOfDurationals() {
 		try {
-			new MonophonicPattern(null);
+			createMonophonicPattern(null);
 			fail("Was able to create pattern with null contents");
 		} catch (final Exception e) {
 			assertTrue(e instanceof NullPointerException);
@@ -49,7 +55,7 @@ class MonophonicPatternTest {
 		final List<Durational> notes = new ArrayList<>();
 
 		try {
-			new MonophonicPattern(notes);
+			createMonophonicPattern(notes);
 			fail("Was able to create pattern with empty contents");
 		} catch (final Exception e) {
 			assertTrue(e instanceof IllegalArgumentException);
@@ -60,7 +66,7 @@ class MonophonicPatternTest {
 				Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHT)));
 
 		try {
-			new MonophonicPattern(chordList);
+			createMonophonicPattern(chordList);
 			fail("Was able to create pattern with Chord in contents");
 		} catch (final Exception e) {
 			assertTrue(e instanceof IllegalArgumentException);
@@ -71,7 +77,7 @@ class MonophonicPatternTest {
 	void testImmutability() {
 		List<Durational> contents = new ArrayList<>(referenceNotes);
 
-		final MonophonicPattern pattern = new MonophonicPattern(contents);
+		final Pattern pattern = createMonophonicPattern(contents);
 		assertEquals(contents, pattern.getContents());
 
 		contents.add(Rest.of(Durations.QUARTER));
@@ -87,8 +93,8 @@ class MonophonicPatternTest {
 
 	@Test
 	void testEquals() {
-		final MonophonicPattern pattern1 = new MonophonicPattern(this.referenceNotes);
-		final MonophonicPattern pattern2 = new MonophonicPattern(this.referenceNotes);
+		final Pattern pattern1 = createMonophonicPattern(this.referenceNotes);
+		final Pattern pattern2 = createMonophonicPattern(this.referenceNotes);
 
 		assertEquals(pattern1, pattern1);
 
@@ -98,18 +104,18 @@ class MonophonicPatternTest {
 		final List<Durational> modifiedNotes = new ArrayList<>(this.referenceNotes);
 		modifiedNotes.add(Rest.of(Durations.QUARTER));
 
-		assertFalse(pattern1.equals(new MonophonicPattern(modifiedNotes)));
+		assertFalse(pattern1.equals(createMonophonicPattern(modifiedNotes)));
 	}
 
 	@Test
 	void testIsMonophonic() {
-		final MonophonicPattern pattern = new MonophonicPattern(this.referenceNotes);
+		final Pattern pattern = createMonophonicPattern(this.referenceNotes);
 		assertTrue(pattern.isMonophonic());
 	}
 
 	@Test
 	void testEqualsInPitch() {
-		final MonophonicPattern pattern = new MonophonicPattern(this.referenceNotes);
+		final Pattern pattern = createMonophonicPattern(this.referenceNotes);
 
 		final List<Durational> notes = new ArrayList<>();
 		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
@@ -117,26 +123,26 @@ class MonophonicPatternTest {
 		notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
 		notes.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.WHOLE));
 
-		assertTrue(pattern.equalsInPitch(new MonophonicPattern(notes)));
+		assertTrue(pattern.equalsInPitch(createMonophonicPattern(notes)));
 
 		notes.add(Rest.of(Durations.QUARTER));
 
-		assertTrue(pattern.equalsInPitch(new MonophonicPattern(notes)),
+		assertTrue(pattern.equalsInPitch(createMonophonicPattern(notes)),
 				"Adding rest to end of pattern should not make pattern inequal in pitches");
 
 		notes.set(1, Note.of(Pitch.of(Pitch.Base.E, -1, 3), Durations.WHOLE));
-		assertFalse(pattern.equalsInPitch(new MonophonicPattern(notes)));
+		assertFalse(pattern.equalsInPitch(createMonophonicPattern(notes)));
 
 		List<Durational> referenceNotesWithAddition = new ArrayList<>(referenceNotes);
 		referenceNotesWithAddition.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
-		assertFalse(pattern.equalsInPitch(new MonophonicPattern(referenceNotesWithAddition)));
+		assertFalse(pattern.equalsInPitch(createMonophonicPattern(referenceNotesWithAddition)));
 	}
 
 	@Test
 	void testEqualsEnharmonically() {
-		final MonophonicPattern pattern = new MonophonicPattern(this.referenceNotes);
+		final Pattern pattern = createMonophonicPattern(this.referenceNotes);
 
-		assertTrue(pattern.equalsEnharmonically(new MonophonicPattern(referenceNotes)));
+		assertTrue(pattern.equalsEnharmonically(createMonophonicPattern(referenceNotes)));
 
 		final List<Durational> samePitchesWithDifferentDurations = new ArrayList<>();
 		samePitchesWithDifferentDurations.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
@@ -145,7 +151,7 @@ class MonophonicPatternTest {
 		samePitchesWithDifferentDurations.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
 		samePitchesWithDifferentDurations.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.WHOLE));
 
-		assertTrue(pattern.equalsEnharmonically(new MonophonicPattern(samePitchesWithDifferentDurations)),
+		assertTrue(pattern.equalsEnharmonically(createMonophonicPattern(samePitchesWithDifferentDurations)),
 				"Difference in durations affected enharmonic equality when it shouldn't have affected it.");
 
 		final List<Durational> samePitchesWithDifferentSpellings = new ArrayList<>();
@@ -155,13 +161,13 @@ class MonophonicPatternTest {
 		samePitchesWithDifferentSpellings.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
 		samePitchesWithDifferentSpellings.add(Note.of(Pitch.of(Pitch.Base.A, 1, 3), Durations.QUARTER));
 
-		assertTrue(pattern.equalsEnharmonically(new MonophonicPattern(samePitchesWithDifferentSpellings)),
+		assertTrue(pattern.equalsEnharmonically(createMonophonicPattern(samePitchesWithDifferentSpellings)),
 				"Difference in note spellings affected enharmonic equality when it shouldn't have affected it.");
 
 		final List<Durational> notesWithAdditionalRestAtEnd = new ArrayList<>(referenceNotes);
 		notesWithAdditionalRestAtEnd.add(Rest.of(Durations.QUARTER));
 
-		assertTrue(pattern.equalsEnharmonically(new MonophonicPattern(notesWithAdditionalRestAtEnd)),
+		assertTrue(pattern.equalsEnharmonically(createMonophonicPattern(notesWithAdditionalRestAtEnd)),
 				"Adding rest to end of pattern should not make patterns unequal enharmonically.");
 
 		final List<Durational> enharmonicallyUnequalPitches = new ArrayList<>();
@@ -171,7 +177,7 @@ class MonophonicPatternTest {
 		enharmonicallyUnequalPitches.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
 		enharmonicallyUnequalPitches.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
 
-		assertFalse(pattern.equalsEnharmonically(new MonophonicPattern(enharmonicallyUnequalPitches)));
+		assertFalse(pattern.equalsEnharmonically(createMonophonicPattern(enharmonicallyUnequalPitches)));
 	}
 
 	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@Disabled("These tests are unfinished and should be unignored once the logic is implemented") class MonophonicPatternTest {
+class MonophonicPatternTest {
 
 	private final List<Durational> referenceNotes;
 
@@ -66,6 +66,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 		}
 	}
 
+	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")
 	@Test
 	void testEqualsPattern() {
 		final MonophonicPattern pattern1 = new MonophonicPattern(this.referenceNotes);
@@ -79,6 +80,13 @@ import static org.junit.jupiter.api.Assertions.fail;
 		assertFalse(pattern1.equals(new MonophonicPattern(modifiedNotes)));
 	}
 
+	@Test
+	void testIsMonophonic() {
+		final MonophonicPattern pattern = new MonophonicPattern(this.referenceNotes);
+		assertTrue(pattern.isMonophonic());
+	}
+
+	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")
 	@Test
 	void testEqualsInPitch() {
 		final MonophonicPattern pattern1 = new MonophonicPattern(this.referenceNotes);
@@ -102,6 +110,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 		assertFalse(pattern1.equalsInPitch(new MonophonicPattern(notes)));
 	}
 
+	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")
 	@Test
 	void testEqualsEnharmonicallyInPitch() {
 		final MonophonicPattern pattern1 = new MonophonicPattern(this.referenceNotes);
@@ -116,16 +125,19 @@ import static org.junit.jupiter.api.Assertions.fail;
 		assertTrue(pattern1.equalsEnharmonicallyInPitch(new MonophonicPattern(notes)));
 	}
 
+	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")
 	@Test
 	void testEqualsInTransposedPitch() {
 		// TODO
 	}
 
+	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")
 	@Test
 	void testEqualsInRhythm() {
 		// TODO
 	}
 
+	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")
 	@Test
 	void testEqualsInOnsets() {
 		// TODO

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -3,7 +3,6 @@
  */
 package org.wmn4j.mir;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.wmn4j.notation.elements.Chord;
 import org.wmn4j.notation.elements.Durational;
@@ -180,10 +179,59 @@ class MonophonicPatternTest {
 		assertFalse(pattern.equalsEnharmonically(createMonophonicPattern(enharmonicallyUnequalPitches)));
 	}
 
-	@Disabled("These tests are unfinished and should be unignored once the logic is implemented")
 	@Test
 	void testEqualsTranspositionally() {
-		// TODO
+		final Pattern pattern = createMonophonicPattern(referenceNotes);
+		assertTrue(pattern.equalsTranspositionally(createMonophonicPattern(referenceNotes)));
+
+		final List<Durational> transposedUpByMajorSecond = new ArrayList<>();
+		transposedUpByMajorSecond.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHT));
+		transposedUpByMajorSecond.add(Note.of(Pitch.of(Pitch.Base.D, 0, 5), Durations.EIGHT));
+		transposedUpByMajorSecond.add(Rest.of(Durations.QUARTER));
+		transposedUpByMajorSecond.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER));
+		transposedUpByMajorSecond.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
+
+		assertTrue(pattern.equalsTranspositionally(createMonophonicPattern(transposedUpByMajorSecond)));
+
+		final List<Durational> transposedDownByOctave = new ArrayList<>();
+		transposedDownByOctave.add(Note.of(Pitch.of(Pitch.Base.C, 0, 3), Durations.EIGHT));
+		transposedDownByOctave.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT));
+		transposedDownByOctave.add(Rest.of(Durations.QUARTER));
+		transposedDownByOctave.add(Note.of(Pitch.of(Pitch.Base.D, 0, 3), Durations.QUARTER));
+		transposedDownByOctave.add(Note.of(Pitch.of(Pitch.Base.B, -1, 2), Durations.QUARTER));
+
+		assertTrue(pattern.equalsTranspositionally(createMonophonicPattern(transposedDownByOctave)));
+
+		final List<Durational> withOneNoteInDifferentOctaveThanInReferencePattern = new ArrayList<>();
+		withOneNoteInDifferentOctaveThanInReferencePattern.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT));
+		withOneNoteInDifferentOctaveThanInReferencePattern.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHT));
+		withOneNoteInDifferentOctaveThanInReferencePattern.add(Rest.of(Durations.QUARTER));
+		withOneNoteInDifferentOctaveThanInReferencePattern
+				.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
+		withOneNoteInDifferentOctaveThanInReferencePattern
+				.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
+
+		assertFalse(pattern.equalsTranspositionally(
+				createMonophonicPattern(withOneNoteInDifferentOctaveThanInReferencePattern)));
+
+		final List<Durational> transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond = new ArrayList<>();
+		transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond
+				.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHT));
+		transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond
+				.add(Note.of(Pitch.of(Pitch.Base.D, 0, 5), Durations.EIGHT));
+		transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond.add(Rest.of(Durations.QUARTER));
+		transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond
+				.add(Note.of(Pitch.of(Pitch.Base.D, 1, 4), Durations.QUARTER));
+		transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond
+				.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
+
+		assertFalse(pattern.equalsTranspositionally(
+				createMonophonicPattern(transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond)));
+
+		final List<Durational> notesWithAdditionalRestAtEnd = new ArrayList<>(referenceNotes);
+		notesWithAdditionalRestAtEnd.add(Rest.of(Durations.QUARTER));
+		assertTrue(pattern.equalsTranspositionally(createMonophonicPattern(notesWithAdditionalRestAtEnd)),
+				"Adding rest to end of pattern should not make patterns unequal enharmonically.");
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -63,6 +64,24 @@ class MonophonicPatternTest {
 			fail("Was able to create pattern with Chord in contents");
 		} catch (final Exception e) {
 			assertTrue(e instanceof IllegalArgumentException);
+		}
+	}
+
+	@Test
+	void testImmutability() {
+		List<Durational> contents = new ArrayList<>(referenceNotes);
+
+		final MonophonicPattern pattern = new MonophonicPattern(contents);
+		assertEquals(contents, pattern.getContents());
+
+		contents.add(Rest.of(Durations.QUARTER));
+		assertNotEquals(pattern.getContents().size(), contents.size());
+
+		try {
+			pattern.getContents().add(Rest.of(Durations.QUARTER));
+			fail("Was able to add to contents of pattern");
+		} catch (Exception e) {
+			// Pass, exception is expected.
 		}
 	}
 


### PR DESCRIPTION
Implements part of issue #5 
Adds an implementation with tests for checking if monophonic patterns equal in:
* pitch
* durations
* enharmonically in pitch 
* transpositionally in pitch 

--
The implementation of a pattern builder will be done in a separate pull request. This PR already got a bit out of hand in size.