### PR TITLE
Add note appearance elements when writing MusicXML

### DIFF
--- a/src/main/java/org/wmn4j/io/musicxml/DurationAppearanceProvider.java
+++ b/src/main/java/org/wmn4j/io/musicxml/DurationAppearanceProvider.java
@@ -55,11 +55,32 @@ enum DurationAppearanceProvider {
 
 		final Collection<Element> elements = new ArrayList<>();
 		if (basicDurationAppearances.containsKey(duration)) {
-			final Element typeElement = document.createElement(MusicXmlTags.NOTE_DURATION_TYPE);
-			typeElement.setTextContent(basicDurationAppearances.get(duration));
-			elements.add(typeElement);
+			elements.add(getBasicDurationType(duration, document));
+		} else if (isBasicDottedDuration(duration)) {
+			final Duration basicDurationType = Duration.of(2 * duration.getNumerator() / 3, duration.getDenominator());
+			if (basicDurationAppearances.containsKey(basicDurationType)) {
+				elements.add(getBasicDurationType(basicDurationType, document));
+				elements.add(createDotElement(document));
+			}
 		}
 
 		return elements;
 	}
+
+	private boolean isBasicDottedDuration(Duration duration) {
+		// Basic dotted durations always have a numerator that is divisible by 3 and a denominator that is a power of 2.
+		final int denominator = duration.getDenominator();
+		return duration.getNumerator() % 3 == 0 && ((denominator & (denominator - 1)) == 0);
+	}
+
+	private Element createDotElement(Document document) {
+		return document.createElement(MusicXmlTags.DOT);
+	}
+
+	private Element getBasicDurationType(Duration duration, Document document) {
+		final Element typeElement = document.createElement(MusicXmlTags.NOTE_DURATION_TYPE);
+		typeElement.setTextContent(basicDurationAppearances.get(duration));
+		return typeElement;
+	}
+
 }

--- a/src/main/java/org/wmn4j/io/musicxml/DurationAppearanceProvider.java
+++ b/src/main/java/org/wmn4j/io/musicxml/DurationAppearanceProvider.java
@@ -18,6 +18,10 @@ enum DurationAppearanceProvider {
 
 	INSTANCE;
 
+	private static final int TRIPLET_DIVISOR = 3;
+	private static final int QUINTUPLET_DIVISOR = 5;
+	private static final int SEPTUPLET_DIVISOR = 7;
+
 	private final Map<Duration, String> basicDurationAppearances;
 
 	DurationAppearanceProvider() {
@@ -62,9 +66,68 @@ enum DurationAppearanceProvider {
 				elements.add(getBasicDurationType(basicDurationType, document));
 				elements.add(createDotElement(document));
 			}
+		} else {
+			addTupletElementsIfNeeded(elements, duration, document);
 		}
 
 		return elements;
+	}
+
+	private void addTupletElementsIfNeeded(Collection<Element> elements, Duration duration, Document document) {
+
+		final int denominator = duration.getDenominator();
+		int tupletNotesThatFitInTheDividedDuration = 0;
+		Duration showTypeDuration = null;
+
+		if (denominator % SEPTUPLET_DIVISOR == 0) {
+			tupletNotesThatFitInTheDividedDuration = SEPTUPLET_DIVISOR;
+			showTypeDuration = getShowableDurationTypeForTuplet(denominator);
+		} else if (denominator % QUINTUPLET_DIVISOR == 0) {
+			tupletNotesThatFitInTheDividedDuration = QUINTUPLET_DIVISOR;
+			showTypeDuration = getShowableDurationTypeForTuplet(denominator);
+		} else if (denominator % TRIPLET_DIVISOR == 0) {
+			tupletNotesThatFitInTheDividedDuration = TRIPLET_DIVISOR;
+			showTypeDuration = getShowableDurationTypeForTuplet(denominator);
+		}
+
+		// If the basic note symbol appearance type cannot be deduced, then do not add any appearance elements.
+		if (showTypeDuration != null && basicDurationAppearances.containsKey(showTypeDuration)) {
+			elements.add(getBasicDurationType(showTypeDuration, document));
+
+			final Duration durationThatIsSplitByTuplet = duration.multiplyBy(tupletNotesThatFitInTheDividedDuration);
+
+			final int normalNotesThatWouldFitInTheSplitDuration =
+					(durationThatIsSplitByTuplet.getNumerator() * showTypeDuration.getDenominator())
+							/ durationThatIsSplitByTuplet.getDenominator();
+
+			final Element timeModificationElement = document.createElement(MusicXmlTags.TIME_MODIFICATION);
+
+			final Element actualNotesElement = document.createElement(MusicXmlTags.TIME_MODIFICATION_ACTUAL_NOTES);
+			actualNotesElement.setTextContent(Integer.toString(tupletNotesThatFitInTheDividedDuration));
+			timeModificationElement.appendChild(actualNotesElement);
+
+			final Element normalNotesElement = document.createElement(MusicXmlTags.TIME_MODIFICATION_NORMAL_NOTES);
+			normalNotesElement.setTextContent(Integer.toString(normalNotesThatWouldFitInTheSplitDuration));
+			timeModificationElement.appendChild(normalNotesElement);
+
+			elements.add(timeModificationElement);
+		}
+	}
+
+	private Duration getShowableDurationTypeForTuplet(int denominator) {
+
+		// The symbol used for a tuplet is typically the basic duration (quarter, eighth, etc.) that is the shortest
+		// basic duration that is longer than the tuplet duration. This can be found by finding the greatest power
+		// of two that is smaller than the denominator of the tuplet duration.
+		int greatestPowerOfTwoUnderDenominator = 1;
+
+		while (greatestPowerOfTwoUnderDenominator < denominator) {
+			greatestPowerOfTwoUnderDenominator *= 2;
+		}
+
+		greatestPowerOfTwoUnderDenominator /= 2;
+
+		return Duration.of(1, greatestPowerOfTwoUnderDenominator);
 	}
 
 	private boolean isBasicDottedDuration(Duration duration) {

--- a/src/main/java/org/wmn4j/io/musicxml/DurationAppearanceProvider.java
+++ b/src/main/java/org/wmn4j/io/musicxml/DurationAppearanceProvider.java
@@ -1,0 +1,65 @@
+package org.wmn4j.io.musicxml;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.wmn4j.notation.elements.Duration;
+import org.wmn4j.notation.elements.Durations;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provides a mapping from {@link Duration} to MusicXML note duration appearance elements, such as type and dot.
+ */
+enum DurationAppearanceProvider {
+
+	INSTANCE;
+
+	private final Map<Duration, String> basicDurationAppearances;
+
+	DurationAppearanceProvider() {
+		basicDurationAppearances = createBasicDurationAppearances();
+	}
+
+	private Map<Duration, String> createBasicDurationAppearances() {
+		Map<Duration, String> appearences = new HashMap<>();
+		appearences.put(Duration.of(1, 1024), MusicXmlTags.NOTE_TYPE_1024TH);
+		appearences.put(Duration.of(1, 512), MusicXmlTags.NOTE_TYPE_512TH);
+		appearences.put(Duration.of(1, 256), MusicXmlTags.NOTE_TYPE_256TH);
+		appearences.put(Duration.of(1, 128), MusicXmlTags.NOTE_TYPE_128TH);
+		appearences.put(Duration.of(1, 64), MusicXmlTags.NOTE_TYPE_64TH);
+		appearences.put(Duration.of(1, 32), MusicXmlTags.NOTE_TYPE_32TH);
+		appearences.put(Durations.SIXTEENTH, MusicXmlTags.NOTE_TYPE_16TH);
+		appearences.put(Durations.EIGHTH, MusicXmlTags.NOTE_TYPE_EIGHTH);
+		appearences.put(Durations.QUARTER, MusicXmlTags.NOTE_TYPE_QUARTER);
+		appearences.put(Durations.HALF, MusicXmlTags.NOTE_TYPE_HALF);
+		appearences.put(Durations.WHOLE, MusicXmlTags.NOTE_TYPE_WHOLE);
+		appearences.put(Duration.of(2, 1), MusicXmlTags.NOTE_TYPE_BREVE);
+		appearences.put(Duration.of(4, 1), MusicXmlTags.NOTE_TYPE_LONG);
+		appearences.put(Duration.of(8, 1), MusicXmlTags.NOTE_TYPE_MAXIMA);
+
+		return Collections.unmodifiableMap(appearences);
+	}
+
+	/**
+	 * Returns the elements that are needed to define the appearance of the duration in music notation.
+	 *
+	 * @param duration the duration for which the appearance elements are returned
+	 * @param document the document to which the elements are meant to be added
+	 * @return the elements that are needed to define the appearance of the duration in music notation
+	 */
+	Collection<Element> getAppearanceElements(Duration duration, Document document) {
+
+		final Collection<Element> elements = new ArrayList<>();
+		if (basicDurationAppearances.containsKey(duration)) {
+			final Element typeElement = document.createElement(MusicXmlTags.NOTE_DURATION_TYPE);
+			typeElement.setTextContent(basicDurationAppearances.get(duration));
+			elements.add(typeElement);
+		}
+
+		return elements;
+	}
+}

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
@@ -88,6 +88,10 @@ final class MusicXmlTags {
 	static final String NOTE_TYPE_LONG = "long";
 	static final String NOTE_TYPE_MAXIMA = "maxima";
 
+	static final String TIME_MODIFICATION = "time-modification";
+	static final String TIME_MODIFICATION_ACTUAL_NOTES = "actual-notes";
+	static final String TIME_MODIFICATION_NORMAL_NOTES = "normal-notes";
+
 	// Articulations
 	static final String STACCATO = "staccato";
 	static final String ACCENT = "accent";

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
@@ -70,6 +70,7 @@ final class MusicXmlTags {
 	static final String NOTATIONS = "notations";
 	static final String NOTE_ARTICULATIONS = "articulations";
 	static final String NOTE_DURATION_TYPE = "type";
+	static final String DOT = "dot";
 
 	// Note appearances supported in MusicXML
 	static final String NOTE_TYPE_1024TH = "1024th";

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
@@ -69,6 +69,23 @@ final class MusicXmlTags {
 	static final String TIE_STOP = "stop";
 	static final String NOTATIONS = "notations";
 	static final String NOTE_ARTICULATIONS = "articulations";
+	static final String NOTE_DURATION_TYPE = "type";
+
+	// Note appearances supported in MusicXML
+	static final String NOTE_TYPE_1024TH = "1024th";
+	static final String NOTE_TYPE_512TH = "512th";
+	static final String NOTE_TYPE_256TH = "256th";
+	static final String NOTE_TYPE_128TH = "128th";
+	static final String NOTE_TYPE_64TH = "64th";
+	static final String NOTE_TYPE_32TH = "32th";
+	static final String NOTE_TYPE_16TH = "16th";
+	static final String NOTE_TYPE_EIGHTH = "eighth";
+	static final String NOTE_TYPE_QUARTER = "quarter";
+	static final String NOTE_TYPE_HALF = "half";
+	static final String NOTE_TYPE_WHOLE = "whole";
+	static final String NOTE_TYPE_BREVE = "breve";
+	static final String NOTE_TYPE_LONG = "long";
+	static final String NOTE_TYPE_MAXIMA = "maxima";
 
 	// Articulations
 	static final String STACCATO = "staccato";

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
@@ -379,16 +379,16 @@ class MusicXmlWriterDom implements MusicXmlWriter {
 
 		switch (clef.getSymbol()) {
 			case G:
-				signElement.setTextContent("G");
+				signElement.setTextContent(MusicXmlTags.CLEF_G);
 				break;
 			case F:
-				signElement.setTextContent("F");
+				signElement.setTextContent(MusicXmlTags.CLEF_F);
 				break;
 			case C:
-				signElement.setTextContent("C");
+				signElement.setTextContent(MusicXmlTags.CLEF_C);
 				break;
 			case PERCUSSION:
-				signElement.setTextContent("percussion");
+				signElement.setTextContent(MusicXmlTags.CLEF_PERC);
 				break;
 			default:
 				throw new IllegalStateException("Unexpected clef symbol: " + clef.getSymbol());

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
@@ -466,14 +466,17 @@ class MusicXmlWriterDom implements MusicXmlWriter {
 			noteElement.appendChild(chordElement);
 		}
 
-		//Pitch
+		// Pitch
 		noteElement.appendChild(createPitchElement(note.getPitch()));
 
-		//Duration
+		// Duration
 		noteElement.appendChild(createDurationElement(note.getDuration()));
 
-		//Voice
+		// Voice
 		noteElement.appendChild(createVoiceElement(voice));
+
+		// Appearance
+		addDurationAppearanceElementsToNoteElement(noteElement, note.getDuration());
 
 		return noteElement;
 	}
@@ -522,10 +525,17 @@ class MusicXmlWriterDom implements MusicXmlWriter {
 		restElement.appendChild(createDurationElement(rest.getDuration()));
 
 		// TODO: Set staff
-		//Voice
+		// Add voice
 		restElement.appendChild(createVoiceElement(voice));
+
+		// Add duration appearance
+		addDurationAppearanceElementsToNoteElement(restElement, rest.getDuration());
 
 		return restElement;
 	}
 
+	private void addDurationAppearanceElementsToNoteElement(Element noteElement, Duration duration) {
+		DurationAppearanceProvider.INSTANCE.getAppearanceElements(duration, this.doc)
+				.forEach(element -> noteElement.appendChild(element));
+	}
 }

--- a/src/test/java/org/wmn4j/io/musicxml/DurationAppearanceProviderTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/DurationAppearanceProviderTest.java
@@ -1,0 +1,85 @@
+package org.wmn4j.io.musicxml;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.wmn4j.notation.elements.Duration;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class DurationAppearanceProviderTest {
+
+	private Document createDocument() {
+		try {
+			final DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+			final DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+
+			return docBuilder.newDocument();
+		} catch (Exception e) {
+			fail("Failed to created document due to " + e);
+		}
+
+		return null;
+	}
+
+	@Test
+	void testGivenBasicDurationCorrectTypeElementIsReturned() {
+		final DurationAppearanceProvider provider = DurationAppearanceProvider.INSTANCE;
+		final Document document = createDocument();
+
+		assertBasicDurationsReturnSingleElementOfCorrectType(
+				provider.getAppearanceElements(Duration.of(1, 1024), document), MusicXmlTags.NOTE_TYPE_1024TH);
+
+		assertBasicDurationsReturnSingleElementOfCorrectType(
+				provider.getAppearanceElements(Duration.of(1, 512), document), MusicXmlTags.NOTE_TYPE_512TH);
+
+		assertBasicDurationsReturnSingleElementOfCorrectType(
+				provider.getAppearanceElements(Duration.of(1, 256), document), MusicXmlTags.NOTE_TYPE_256TH);
+
+		assertBasicDurationsReturnSingleElementOfCorrectType(
+				provider.getAppearanceElements(Duration.of(1, 128), document), MusicXmlTags.NOTE_TYPE_128TH);
+
+		assertBasicDurationsReturnSingleElementOfCorrectType(
+				provider.getAppearanceElements(Duration.of(1, 64), document), MusicXmlTags.NOTE_TYPE_64TH);
+
+		assertBasicDurationsReturnSingleElementOfCorrectType(
+				provider.getAppearanceElements(Duration.of(1, 32), document), MusicXmlTags.NOTE_TYPE_32TH);
+
+		assertBasicDurationsReturnSingleElementOfCorrectType(
+				provider.getAppearanceElements(Duration.of(1, 16), document), MusicXmlTags.NOTE_TYPE_16TH);
+
+		assertBasicDurationsReturnSingleElementOfCorrectType(
+				provider.getAppearanceElements(Duration.of(1, 8), document), MusicXmlTags.NOTE_TYPE_EIGHTH);
+
+		assertBasicDurationsReturnSingleElementOfCorrectType(
+				provider.getAppearanceElements(Duration.of(1, 4), document), MusicXmlTags.NOTE_TYPE_QUARTER);
+
+		assertBasicDurationsReturnSingleElementOfCorrectType(
+				provider.getAppearanceElements(Duration.of(1, 2), document), MusicXmlTags.NOTE_TYPE_HALF);
+
+		assertBasicDurationsReturnSingleElementOfCorrectType(
+				provider.getAppearanceElements(Duration.of(1, 1), document), MusicXmlTags.NOTE_TYPE_WHOLE);
+
+		assertBasicDurationsReturnSingleElementOfCorrectType(
+				provider.getAppearanceElements(Duration.of(2, 1), document), MusicXmlTags.NOTE_TYPE_BREVE);
+
+		assertBasicDurationsReturnSingleElementOfCorrectType(
+				provider.getAppearanceElements(Duration.of(4, 1), document), MusicXmlTags.NOTE_TYPE_LONG);
+
+		assertBasicDurationsReturnSingleElementOfCorrectType(
+				provider.getAppearanceElements(Duration.of(8, 1), document), MusicXmlTags.NOTE_TYPE_MAXIMA);
+	}
+
+	private void assertBasicDurationsReturnSingleElementOfCorrectType(Collection<Element> elements,
+			String expectedContent) {
+		assertEquals(1, elements.size());
+		Element onlyElement = elements.iterator().next();
+		assertEquals(MusicXmlTags.NOTE_DURATION_TYPE, onlyElement.getNodeName());
+		assertEquals(expectedContent, onlyElement.getTextContent());
+	}
+}

--- a/src/test/java/org/wmn4j/io/musicxml/DurationAppearanceProviderTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/DurationAppearanceProviderTest.java
@@ -8,8 +8,10 @@ import org.wmn4j.notation.elements.Duration;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.util.Collection;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class DurationAppearanceProviderTest {
@@ -81,5 +83,67 @@ class DurationAppearanceProviderTest {
 		Element onlyElement = elements.iterator().next();
 		assertEquals(MusicXmlTags.NOTE_DURATION_TYPE, onlyElement.getNodeName());
 		assertEquals(expectedContent, onlyElement.getTextContent());
+	}
+
+	@Test
+	void testGivenDottedDurationCorrectTypeAndDotElementAreReturned() {
+
+		final DurationAppearanceProvider provider = DurationAppearanceProvider.INSTANCE;
+		final Document document = createDocument();
+
+		final Duration dottedSixteenth = Duration.of(1, 16).addDot();
+
+		assertDottedDurationHasCorrectTypeAndDot(
+				provider.getAppearanceElements(dottedSixteenth, document), MusicXmlTags.NOTE_TYPE_16TH);
+
+		final Duration dottedEighth = Duration.of(1, 8).addDot();
+
+		assertDottedDurationHasCorrectTypeAndDot(
+				provider.getAppearanceElements(dottedEighth, document), MusicXmlTags.NOTE_TYPE_EIGHTH);
+
+		final Duration dottedQuarter = Duration.of(1, 4).addDot();
+
+		assertDottedDurationHasCorrectTypeAndDot(
+				provider.getAppearanceElements(dottedQuarter, document), MusicXmlTags.NOTE_TYPE_QUARTER);
+
+		final Duration dottedHalf = Duration.of(1, 2).addDot();
+
+		assertDottedDurationHasCorrectTypeAndDot(
+				provider.getAppearanceElements(dottedHalf, document), MusicXmlTags.NOTE_TYPE_HALF);
+	}
+
+	private void assertDottedDurationHasCorrectTypeAndDot(Collection<Element> elements, String expectedContent) {
+		assertEquals(2, elements.size(), "Elements should contains two elements, type and dot.");
+
+		Optional<Element> onlyElementOpt = elements.stream()
+				.filter(element -> element.getNodeName().equals(MusicXmlTags.NOTE_DURATION_TYPE)).findAny();
+
+		assertTrue(onlyElementOpt.isPresent(), "Did not find expected type element");
+
+		Element typeElement = onlyElementOpt.get();
+		assertEquals(MusicXmlTags.NOTE_DURATION_TYPE, typeElement.getNodeName());
+		assertEquals(expectedContent, typeElement.getTextContent());
+
+		assertTrue(elements.stream().filter(element -> element.getNodeName().equals(MusicXmlTags.DOT)).findAny()
+				.isPresent(), "elements list does not contain dot element");
+	}
+
+	@Test
+	void testGivenNonDottedDurationNoDotElementIsReturned() {
+		final DurationAppearanceProvider provider = DurationAppearanceProvider.INSTANCE;
+		final Document document = createDocument();
+
+		final Duration eight = Duration.of(1, 8);
+		Collection<Element> eighthAppearanceElements = provider.getAppearanceElements(eight, document);
+		assertTrue(eighthAppearanceElements.stream().filter(element -> element.getNodeName().equals(MusicXmlTags.DOT))
+				.findAny()
+				.isEmpty(), "elements contained dot element that it should not contain");
+
+		final Duration quintupletDuration = Duration.of(3, 1111);
+		Collection<Element> quintupletAppearanceElements = provider.getAppearanceElements(quintupletDuration, document);
+		assertTrue(
+				quintupletAppearanceElements.stream().filter(element -> element.getNodeName().equals(MusicXmlTags.DOT))
+						.findAny()
+						.isEmpty(), "elements contained dot element that it should not contain");
 	}
 }

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
@@ -253,4 +253,66 @@ class MusicXmlWriterDomTest {
 		List<Node> dotNodes = DocHelper.findChildren(noteNode, MusicXmlTags.DOT);
 		assertEquals(1, dotNodes.size(), "Incorrect number of dot nodes");
 	}
+
+	@Test
+	void testWritingTupletAppearances() {
+		final Score score = readMusicXmlTestFile("tuplet_writing_test.xml", false);
+
+		MusicXmlWriter writer = new MusicXmlWriterDom(score);
+		Path filePath = temporaryDirectory.resolve("temporary_file.xml");
+		writer.writeToFile(filePath);
+
+		final Document document = readDocument(filePath);
+		final Node partNode = document.getElementsByTagName(MusicXmlTags.PART).item(0);
+		assertNotNull(partNode);
+
+		final Optional<Node> measureNode = DocHelper.findChild(partNode, MusicXmlTags.MEASURE);
+		assertTrue(measureNode.isPresent());
+
+		final List<Node> noteNodes = DocHelper.findChildren(measureNode.get(), MusicXmlTags.NOTE).stream()
+				.filter(node -> DocHelper.findChild(node, MusicXmlTags.NOTE_REST).isEmpty())
+				.collect(Collectors.toList());
+
+		assertEquals(15, noteNodes.size());
+
+		assertTupletAppearanceNodes("eighth", noteNodes.get(0), 3, 2);
+		assertTupletAppearanceNodes("eighth", noteNodes.get(1), 3, 2);
+		assertTupletAppearanceNodes("eighth", noteNodes.get(2), 3, 2);
+
+		assertTupletAppearanceNodes("16th", noteNodes.get(3), 5, 4);
+		assertTupletAppearanceNodes("16th", noteNodes.get(4), 5, 4);
+		assertTupletAppearanceNodes("16th", noteNodes.get(5), 5, 4);
+		assertTupletAppearanceNodes("16th", noteNodes.get(6), 5, 4);
+		assertTupletAppearanceNodes("16th", noteNodes.get(7), 5, 4);
+
+		assertTupletAppearanceNodes("16th", noteNodes.get(8), 7, 4);
+		assertTupletAppearanceNodes("16th", noteNodes.get(9), 7, 4);
+		assertTupletAppearanceNodes("16th", noteNodes.get(10), 7, 4);
+		assertTupletAppearanceNodes("16th", noteNodes.get(11), 7, 4);
+		assertTupletAppearanceNodes("16th", noteNodes.get(12), 7, 4);
+		assertTupletAppearanceNodes("16th", noteNodes.get(13), 7, 4);
+		assertTupletAppearanceNodes("16th", noteNodes.get(14), 7, 4);
+	}
+
+	private void assertTupletAppearanceNodes(String expectedDurationTypeText, Node noteNode,
+			int expectedActualNotesNumber, int expectedNormalNotesNumber) {
+
+		assertNoteNodeDurationTypeElement(expectedDurationTypeText, noteNode);
+		final List<Node> timeModificationNodes = DocHelper.findChildren(noteNode, MusicXmlTags.TIME_MODIFICATION);
+		assertEquals(1, timeModificationNodes.size(), "Found incorrect number of time-modification nodes");
+
+		final Node timeModification = timeModificationNodes.get(0);
+
+		final List<Node> actualNotesNodes = DocHelper
+				.findChildren(timeModification, MusicXmlTags.TIME_MODIFICATION_ACTUAL_NOTES);
+		assertEquals(1, actualNotesNodes.size(), "Found incorrect number of actual-notes nodes");
+		assertEquals(expectedActualNotesNumber, Integer.parseInt(actualNotesNodes.get(0).getTextContent()),
+				"Incorrect value for actual-notes");
+
+		final List<Node> normalNotesNodes = DocHelper
+				.findChildren(timeModification, MusicXmlTags.TIME_MODIFICATION_NORMAL_NOTES);
+		assertEquals(1, normalNotesNodes.size(), "Found incorrect number of normal-notes nodes");
+		assertEquals(expectedNormalNotesNumber, Integer.parseInt(normalNotesNodes.get(0).getTextContent()),
+				"Incorrect value for normal-notes");
+	}
 }

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
@@ -216,4 +216,41 @@ class MusicXmlWriterDomTest {
 		final Node durationTypeNode = durationTypeNodes.get(0);
 		assertEquals(expectedDurationTypeText, durationTypeNode.getTextContent());
 	}
+
+	@Test
+	void testWritingBasicDottedNoteAppearances() {
+		final Score score = readMusicXmlTestFile("basic_dotted_duration_appearances.xml", false);
+
+		MusicXmlWriter writer = new MusicXmlWriterDom(score);
+		Path filePath = temporaryDirectory.resolve("temporary_file.xml");
+		writer.writeToFile(filePath);
+
+		final Document document = readDocument(filePath);
+		final Node partNode = document.getElementsByTagName(MusicXmlTags.PART).item(0);
+		assertNotNull(partNode);
+
+		final Optional<Node> measureNode = DocHelper.findChild(partNode, MusicXmlTags.MEASURE);
+		assertTrue(measureNode.isPresent());
+
+		final List<Node> noteNodes = DocHelper.findChildren(measureNode.get(), MusicXmlTags.NOTE).stream()
+				.filter(node -> DocHelper.findChild(node, MusicXmlTags.NOTE_REST).isEmpty())
+				.collect(Collectors.toList());
+
+		assertEquals(8, noteNodes.size(), "Wrong number of note notes found in written test document");
+
+		assertBasicDottedNoteAppearance("32th", noteNodes.get(0));
+		assertBasicDottedNoteAppearance("16th", noteNodes.get(1));
+		assertBasicDottedNoteAppearance("eighth", noteNodes.get(2));
+		assertBasicDottedNoteAppearance("quarter", noteNodes.get(3));
+		assertBasicDottedNoteAppearance("half", noteNodes.get(4));
+		assertBasicDottedNoteAppearance("whole", noteNodes.get(5));
+		assertBasicDottedNoteAppearance("breve", noteNodes.get(6));
+		assertBasicDottedNoteAppearance("long", noteNodes.get(7));
+	}
+
+	private void assertBasicDottedNoteAppearance(String expectedDurationTypeText, Node noteNode) {
+		assertNoteNodeDurationTypeElement(expectedDurationTypeText, noteNode);
+		List<Node> dotNodes = DocHelper.findChildren(noteNode, MusicXmlTags.DOT);
+		assertEquals(1, dotNodes.size(), "Incorrect number of dot nodes");
+	}
 }

--- a/src/test/resources/musicxml/basic_dotted_duration_appearances.xml
+++ b/src/test/resources/musicxml/basic_dotted_duration_appearances.xml
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Duration appearance test</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore 3.0.0</software>
+      <encoding-date>2019-06-12</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <credit page="1">
+    <credit-words default-x="595.44" default-y="1626.67" justify="center" valign="top" font-size="24">Duration appearance test, dotted</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="1077.49">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>0.00</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>16</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>32</beats>
+          <beat-type>1</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="91.13" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>32nd</type>
+        <dot/>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        <beam number="3">forward hook</beam>
+        </note>
+      <note default-x="120.76" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <dot/>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">end</beam>
+        </note>
+      <note default-x="159.51" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <dot/>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        </note>
+      <note default-x="207.38" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>24</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <dot/>
+        <stem>up</stem>
+        </note>
+      <note default-x="263.99" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>48</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot/>
+        <stem>up</stem>
+        </note>
+      <note default-x="327.12" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>96</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <dot/>
+        </note>
+      <note default-x="400.76" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>1</voice>
+        <type>breve</type>
+        <dot/>
+        </note>
+      <note default-x="485.07" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>long</type>
+        <dot/>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>64th</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>32nd</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>256</duration>
+        <voice>1</voice>
+        <type>long</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>256</duration>
+        <voice>1</voice>
+        <type>long</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>256</duration>
+        <voice>1</voice>
+        <type>long</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>256</duration>
+        <voice>1</voice>
+        <type>long</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>256</duration>
+        <voice>1</voice>
+        <type>long</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/test/resources/musicxml/basic_duration_appearances.xml
+++ b/src/test/resources/musicxml/basic_duration_appearances.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Duration appearance test</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore 3.0.0</software>
+      <encoding-date>2019-06-12</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <credit page="1">
+    <credit-words default-x="595.44" default-y="1626.67" justify="center" valign="top" font-size="24">Duration appearance test</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="1077.49">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>0.00</left-margin>
+            <right-margin>-0.00</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>8</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>32</beats>
+          <beat-type>1</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="91.13" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>32nd</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        <beam number="3">forward hook</beam>
+        </note>
+      <note default-x="108.25" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">end</beam>
+        </note>
+      <note default-x="135.64" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        </note>
+      <note default-x="173.30" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="220.87" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>16</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="276.11" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>32</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <note default-x="343.01" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>64</duration>
+        <voice>1</voice>
+        <type>breve</type>
+        </note>
+      <note default-x="421.76" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>128</duration>
+        <voice>1</voice>
+        <type>long</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>32nd</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>128</duration>
+        <voice>1</voice>
+        <type>long</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>128</duration>
+        <voice>1</voice>
+        <type>long</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>128</duration>
+        <voice>1</voice>
+        <type>long</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>128</duration>
+        <voice>1</voice>
+        <type>long</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>128</duration>
+        <voice>1</voice>
+        <type>long</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>128</duration>
+        <voice>1</voice>
+        <type>long</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/test/resources/musicxml/tuplet_writing_test.xml
+++ b/src/test/resources/musicxml/tuplet_writing_test.xml
@@ -1,0 +1,341 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Title</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer</creator>
+    <encoding>
+      <software>MuseScore 3.0.0</software>
+      <encoding-date>2019-06-18</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <credit page="1">
+    <credit-words default-x="595.275" default-y="1599.91" justify="center" valign="top" font-size="24">Tuplet writing test
+</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="170.078" default-y="1527.08" justify="right" valign="bottom" font-size="12">Composer</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="636.48">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>0.00</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>105</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="83.07" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>35</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no"/>
+          </notations>
+        </note>
+      <note default-x="127.64" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>35</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        </note>
+      <note default-x="172.21" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>35</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop"/>
+          </notations>
+        </note>
+      <note default-x="216.79" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>21</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>5</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no"/>
+          </notations>
+        </note>
+      <note default-x="250.20" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>21</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>5</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note default-x="283.62" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>21</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>5</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note default-x="317.03" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>21</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>5</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note default-x="350.45" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>21</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>5</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+        <notations>
+          <tuplet type="stop"/>
+          </notations>
+        </note>
+      <note default-x="383.86" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>15</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>7</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no"/>
+          </notations>
+        </note>
+      <note default-x="410.07" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>15</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>7</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note default-x="436.27" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>15</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>7</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note default-x="462.47" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>15</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>7</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note default-x="488.68" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>15</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>7</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note default-x="514.88" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>15</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>7</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note default-x="541.08" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>15</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>7</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+        <notations>
+          <tuplet type="stop"/>
+          </notations>
+        </note>
+      <backup>
+        <duration>3</duration>
+        </backup>
+      <note>
+        <rest/>
+        <duration>105</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    </part>
+  </score-partwise>


### PR DESCRIPTION
Implements issue #119 
Add support for writing the note appearance elements based on the duration of the note.
This does not ensure that the appearance of the note will remain the same 
as it was when read from a file, because the same mathematical duration of 
a note can be written in multiple ways (e.g. dotted eighth note triplet has the same duration as an eighth note).

If note appearance is to be kept unchanged, then the issue #123 needs to be implemented.