### PR TITLE
Issue #37: Add support for writing single note articulations into MusicXML

### DIFF
--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
@@ -195,6 +195,14 @@ class MusicXmlWriterDomTest {
 	}
 
 	@Test
+	void testWritingArticulations() {
+		Score score = readMusicXmlTestFile("articulations.xml", false);
+		Score writtenScore = writeAndReadScore(score);
+
+		MusicXmlFileChecks.assertScoreWithArticulationsReadCorrectly(writtenScore);
+	}
+
+	@Test
 	void testWritingBasicNoteAppearances() {
 		final Score score = readMusicXmlTestFile("basic_duration_appearances.xml", false);
 


### PR DESCRIPTION
Adds support for writing accent, staccato, tenuto and fermata articulations to MusicXML. MusicXML doesn't handle fermatas as articulations (like wmn4j does), so it needed some special treatment in the code.