### PR TITLE
Add test for writing articulations on multiple staves to MusicXML

### DIFF
--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
@@ -442,6 +442,34 @@ class MusicXmlFileChecks {
 	}
 
 	/*
+	 * Expects the content of "articulationsOnMultipleStaves.xml".
+	 */
+	static void assertArticulationsReadCorrectlyFromMultipleStaves(Score score) {
+		MultiStaffPart part = (MultiStaffPart) score.getPart(0);
+		final Staff topStaff = part.getStaff(1);
+		final Staff bottomStaff = part.getStaff(2);
+
+		final Measure topStaffMeasure = topStaff.getMeasure(1);
+
+		assertTrue(((Note) topStaffMeasure.get(1,0)).hasArticulation(Articulation.FERMATA));
+		assertFalse(((Note) topStaffMeasure.get(1,1)).hasArticulations());
+		assertTrue(((Note) topStaffMeasure.get(1,2)).hasArticulation(Articulation.ACCENT));
+		assertTrue(((Note) topStaffMeasure.get(1,2)).hasArticulation(Articulation.TENUTO));
+		assertFalse(((Note) topStaffMeasure.get(1,3)).hasArticulations());
+
+		final Measure bottomStaffMeasure = bottomStaff.getMeasure(1);
+		final int bottomStaffSingleVoiceNumber = bottomStaffMeasure.getVoiceNumbers().get(0);
+
+		assertTrue(((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber,0)).hasArticulation(Articulation.STACCATO));
+		assertTrue(((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber,1)).hasArticulation(Articulation.TENUTO));
+		assertTrue(((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber,2)).hasArticulation(Articulation.ACCENT));
+		assertTrue(((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber,3)).hasArticulation(Articulation.STACCATO));
+		assertTrue(((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber,3)).hasArticulation(Articulation.TENUTO));
+		assertTrue(((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber,3)).hasArticulation(Articulation.ACCENT));
+		assertTrue(((Chord) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber,4)).hasArticulation(Articulation.TENUTO));
+	}
+
+	/*
 	 * Expects the contents of "pickup_measure_test.xml".
 	 */
 	static void assertPickupMeasureReadCorrectly(Score score) {

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlWriterDomTest.java
@@ -203,6 +203,14 @@ class MusicXmlWriterDomTest {
 	}
 
 	@Test
+	void testArticulationsOnMultipleStaves() {
+		Score score = readMusicXmlTestFile("articulationsOnMultipleStaves.xml", false);
+		Score writtenScore = writeAndReadScore(score);
+
+		MusicXmlFileChecks.assertArticulationsReadCorrectlyFromMultipleStaves(writtenScore);
+	}
+
+	@Test
 	void testWritingBasicNoteAppearances() {
 		final Score score = readMusicXmlTestFile("basic_duration_appearances.xml", false);
 

--- a/src/test/resources/musicxml/articulationsOnMultipleStaves.xml
+++ b/src/test/resources/musicxml/articulationsOnMultipleStaves.xml
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise>
+  <identification>
+    <encoding>
+      <software>MuseScore 2.1.0</software>
+      <encoding-date>2019-07-08</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1683.78</page-height>
+      <page-width>1190.55</page-width>
+      <page-margins type="even">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name></instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="416.63">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>21.00</left-margin>
+            <right-margin>639.53</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        <staff-layout number="2">
+          <staff-distance>65.00</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>2</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="77.35" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <notations>
+          <fermata type="upright"/>
+          </notations>
+        </note>
+      <note default-x="168.65" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        </note>
+      <note default-x="259.95" default-y="-5.00">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <notations>
+          <articulations>
+            <accent/>
+            <tenuto/>
+            </articulations>
+          </notations>
+        </note>
+      <note default-x="332.99" default-y="0.00">
+        <pitch>
+          <step>F</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>8</duration>
+        </backup>
+      <note default-x="77.35" default-y="-130.00">
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <notations>
+          <articulations>
+            <staccato/>
+            </articulations>
+          </notations>
+        </note>
+      <note default-x="123.00" default-y="-125.00">
+        <pitch>
+          <step>D</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <notations>
+          <articulations>
+            <tenuto/>
+            </articulations>
+          </notations>
+        </note>
+      <note default-x="168.65" default-y="-120.00">
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <notations>
+          <articulations>
+            <accent/>
+            </articulations>
+          </notations>
+        </note>
+      <note default-x="214.30" default-y="-115.00">
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <notations>
+          <articulations>
+            <accent/>
+            <staccato/>
+            <tenuto/>
+            </articulations>
+          </notations>
+        </note>
+      <note default-x="259.59" default-y="-130.00">
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <notations>
+          <articulations>
+            <tenuto/>
+            </articulations>
+          </notations>
+        </note>
+      <note default-x="259.59" default-y="-120.00">
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        </note>
+      <note default-x="259.59" default-y="-110.00">
+        <chord/>
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>


### PR DESCRIPTION
Addition to the last pull request (#128) to ensure that articulations on multiple staves are written into valid MusicXML.