### PR TITLE
Issue #124: Provide unified way of handling version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The [API Documentation](https://otsob.github.io/wmn4j) provides a comprehensive 
 ### Building wmn4j
 
 wmn4j uses Gradle and can be built by running Gradle build. With the current configuration the build consists of compilation, unit tests, and static analysis.
+It is recommended to delegate the building of the project to Gradle using the provided Gradle wrapper in the IDE to ensure all dependencies etc. are handled correctly.
 
 ## Contributing
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,11 @@ tasks.withType(JavaCompile) {
 
 task createProjectPropertiesFile(dependsOn: processResources) {
     doLast {
+        String versionNumber = project.version.toString()
+        println 'Creating properties file for ' + project.name + " version " + versionNumber
         new File("$buildDir/resources/main/wmn4j.properties").withWriter { writer ->
             Properties properties = new Properties()
-            properties['version'] = project.version.toString()
+            properties['version'] = versionNumber
             properties.store writer, null
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ javadoc {
 }
 
 group = 'wmn4j'
-version = '0.0.1-SNAPSHOT'
+version = '0.1-SNAPSHOT'
 description = 'wmn4j'
 sourceCompatibility = '12'
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 test {
     useJUnitPlatform()
     testLogging {
-      events "skipped", "failed"
+        events "skipped", "failed"
     }
 }
 
@@ -42,4 +42,18 @@ sourceCompatibility = '12'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
+}
+
+task createProjectPropertiesFile(dependsOn: processResources) {
+    doLast {
+        new File("$buildDir/resources/main/wmn4j.properties").withWriter { writer ->
+            Properties properties = new Properties()
+            properties['version'] = project.version.toString()
+            properties.store writer, null
+        }
+    }
+}
+
+classes {
+    dependsOn createProjectPropertiesFile
 }

--- a/src/main/java/org/wmn4j/Wmn4j.java
+++ b/src/main/java/org/wmn4j/Wmn4j.java
@@ -1,0 +1,56 @@
+package org.wmn4j;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * The properties of the project.
+ */
+public final class Wmn4j {
+
+	private static final Logger LOG = LoggerFactory.getLogger(Wmn4j.class);
+
+	private static final Wmn4j INSTANCE = new Wmn4j();
+
+	private static final String PROPERTIES_FILE_NAME = "wmn4j.properties";
+	private static final String VERSION = "version";
+
+	private final String version;
+
+	private Wmn4j() {
+		version = readVersionFromProperties();
+	}
+
+	private String readVersionFromProperties() {
+		String versionNumberFromProperties = "";
+
+		try (InputStream input = this.getClass().getClassLoader().getResourceAsStream(PROPERTIES_FILE_NAME)) {
+
+			if (input != null) {
+				Properties projectProperties = new Properties();
+				projectProperties.load(input);
+				versionNumberFromProperties = projectProperties.getProperty(VERSION);
+			} else {
+				LOG.warn("Unable to read auto-generated Wmn4j properties file: " + PROPERTIES_FILE_NAME);
+			}
+
+		} catch (IOException exception) {
+			LOG.warn("Reading Wmn4j properties failed with ", exception);
+		}
+
+		return versionNumberFromProperties;
+	}
+
+	/**
+	 * Returns the version number of the project.
+	 *
+	 * @return the version number of the project
+	 */
+	public static String getVersion() {
+		return INSTANCE.version;
+	}
+}

--- a/src/main/java/org/wmn4j/package-info.java
+++ b/src/main/java/org/wmn4j/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The root package of the project.
+ */
+package org.wmn4j;

--- a/src/test/java/org/wmn4j/Wmn4jTest.java
+++ b/src/test/java/org/wmn4j/Wmn4jTest.java
@@ -1,0 +1,16 @@
+package org.wmn4j;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class Wmn4jTest {
+
+	@Test
+	void testGetVersionReturnsNotEmpty() {
+		final String versionNumber = Wmn4j.getVersion();
+		assertNotNull(versionNumber);
+		assertFalse(versionNumber.isEmpty());
+	}
+}


### PR DESCRIPTION
Implements issue #124 

Adds a programmatic way of accessing version number that is defined in the Gradle build file.
Updates version number to be 0.1-SNAPSHOT