### PR TITLE
Issue #6: Add implementation for some of the methods in PolyphonicPattern 

### DIFF
--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -12,6 +12,7 @@ import org.wmn4j.notation.elements.Pitched;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -21,6 +22,9 @@ import java.util.stream.Collectors;
  * consist of multiple voices. This class is immutable.
  */
 final class MonophonicPattern implements Pattern {
+
+	private static final int SINGLE_VOICE_NUMBER = 1;
+	private static final List<Integer> SINGLE_VOICE_NUMBER_LIST = Collections.singletonList(SINGLE_VOICE_NUMBER);
 
 	private final List<Durational> contents;
 
@@ -60,6 +64,25 @@ final class MonophonicPattern implements Pattern {
 	@Override
 	public boolean isMonophonic() {
 		return true;
+	}
+
+	@Override
+	public int getNumberOfVoices() {
+		return 1;
+	}
+
+	@Override
+	public List<Integer> getVoiceNumbers() {
+		return SINGLE_VOICE_NUMBER_LIST;
+	}
+
+	@Override
+	public List<Durational> getVoice(int voiceNumber) {
+		if (voiceNumber != SINGLE_VOICE_NUMBER) {
+			throw new NoSuchElementException("No voice in pattern with number " + voiceNumber);
+		}
+
+		return getContents();
 	}
 
 	@Override

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -29,7 +29,7 @@ final class MonophonicPattern implements Pattern {
 	 *
 	 * @param contents non-empty list containing the notation elements of the pattern in temporal order
 	 */
-	MonophonicPattern(List<Durational> contents) {
+	MonophonicPattern(List<? extends Durational> contents) {
 		this.contents = Collections.unmodifiableList(new ArrayList<>(contents));
 		if (this.contents == null) {
 			throw new NullPointerException("Cannot create pattern with null contents");

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -3,9 +3,11 @@
  */
 package org.wmn4j.mir;
 
+import org.wmn4j.notation.elements.Chord;
 import org.wmn4j.notation.elements.Durational;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Interface for musical patterns. The patterns can represent motifs, melodies,
@@ -18,14 +20,28 @@ import java.util.List;
 public interface Pattern {
 
 	/**
-	 * Returns a monophonic pattern with the given contents. The contents must be strictly monophonic, i.e., they cannot
-	 * contain any chords.
+	 * Returns a pattern with the given contents.
 	 *
 	 * @param contents non-empty list containing the notation elements of the pattern in temporal order
 	 * @return a pattern with the given contents
 	 */
-	static Pattern monophonicOf(List<Durational> contents) {
+	static Pattern of(List<? extends Durational> contents) {
+		final boolean isPolyphonic = contents.stream().anyMatch(durational -> durational instanceof Chord);
+		if (isPolyphonic) {
+			return new PolyphonicPattern(contents);
+		}
+
 		return new MonophonicPattern(contents);
+	}
+
+	/**
+	 * Returns a polyphonic pattern with the given voices.
+	 *
+	 * @param voices the voices of the pattern
+	 * @return polyphonic pattern with the given voices
+	 */
+	static Pattern of(Map<Integer, List<? extends Durational>> voices) {
+		return new PolyphonicPattern(voices);
 	}
 
 	/**

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -62,6 +62,28 @@ public interface Pattern {
 	boolean isMonophonic();
 
 	/**
+	 * Returns the number of voices in this pattern.
+	 *
+	 * @return the number of voices in this pattern
+	 */
+	int getNumberOfVoices();
+
+	/**
+	 * Returns the voice numbers in this pattern from smallest to greatest.
+	 *
+	 * @return the voice numbers in this pattern from smallest to greatest
+	 */
+	List<Integer> getVoiceNumbers();
+
+	/**
+	 * Returns the contents of the voice with the given number.
+	 *
+	 * @param voiceNumber the number of the voice whose contents are returned
+	 * @return the contents of the voice with the given number
+	 */
+	List<Durational> getVoice(int voiceNumber);
+
+	/**
 	 * Returns true if this pattern contains the same pitches in the
 	 * same order as other, otherwise returns false. The pitches must be spelled the
 	 * same way for the patterns to be considered equal in pitch. Rhythm is ignored.

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -53,11 +53,11 @@ public interface Pattern {
 	List<Durational> getContents();
 
 	/**
-	 * Returns true if this pattern does not contain any notes occur simultaneously,
-	 * otherwise returns false.
+	 * Returns true if this pattern contains only a single voice and does not contain
+	 * any notes that occur simultaneously, otherwise returns false.
 	 *
-	 * @return true if this pattern does not contain any notes occur simultaneously.
-	 * Otherwise returns false.
+	 * @return true if this pattern contains only a single voice and does not contain
+	 * any notes that occur simultaneously
 	 */
 	boolean isMonophonic();
 

--- a/src/main/java/org/wmn4j/mir/PatternBuilder.java
+++ b/src/main/java/org/wmn4j/mir/PatternBuilder.java
@@ -74,6 +74,6 @@ public final class PatternBuilder {
 	 * @return a pattern instance with the contents set into this builder
 	 */
 	public Pattern build() {
-		return Pattern.monophonicOf(voices.get(DEFAULT_VOICE_NUMBER));
+		return Pattern.of(voices.get(DEFAULT_VOICE_NUMBER));
 	}
 }

--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Class that represents a polyphonic pattern. In a polyphonic pattern there can be
@@ -61,7 +62,7 @@ final class PolyphonicPattern implements Pattern {
 
 	@Override
 	public List<Durational> getContents() {
-		return null;
+		return voices.values().stream().flatMap(voice -> voice.stream()).collect(Collectors.toList());
 	}
 
 	@Override

--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -3,11 +3,61 @@
  */
 package org.wmn4j.mir;
 
+import org.wmn4j.notation.elements.Chord;
 import org.wmn4j.notation.elements.Durational;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-public final class PolyphonicPattern implements Pattern {
+/**
+ * Class that represents a polyphonic pattern. In a polyphonic pattern there can be
+ * multiple voices and chords.
+ */
+final class PolyphonicPattern implements Pattern {
+
+	private final Integer DEFAULT_VOICE_NUMBER = 1;
+
+	private final Map<Integer, List<Durational>> voices;
+
+	PolyphonicPattern(Map<Integer, List<? extends Durational>> voices) {
+		Map<Integer, List<Durational>> voicesCopy = new HashMap<>();
+
+		for (Integer voiceNumber : voices.keySet()) {
+			List<Durational> voiceContents = new ArrayList<>();
+			voiceContents.addAll(voices.get(voiceNumber));
+			if (voiceContents.isEmpty()) {
+				throw new IllegalArgumentException("Cannot create pattern with empty voice");
+			}
+			voicesCopy.put(voiceNumber, Collections.unmodifiableList(voiceContents));
+		}
+
+		this.voices = Collections.unmodifiableMap(voicesCopy);
+		if (this.voices.isEmpty()) {
+			throw new IllegalArgumentException("Cannot create polyphonic pattern from empty voices");
+		}
+		if (this.voices.keySet().size() == 1) {
+			final Integer voiceNumber = this.voices.keySet().iterator().next();
+			final boolean isMonophonic = this.voices.get(voiceNumber).stream()
+					.noneMatch(durational -> durational instanceof Chord);
+			if (isMonophonic) {
+				throw new IllegalArgumentException("Trying to create a polyphonic pattern with monophonic contents");
+			}
+		}
+	}
+
+	PolyphonicPattern(List<? extends Durational> voice) {
+		List<Durational> voiceCopy = Collections.unmodifiableList(new ArrayList<>(voice));
+		if (voiceCopy.isEmpty()) {
+			throw new IllegalArgumentException("Cannot create pattern from empty voice");
+		}
+
+		Map<Integer, List<Durational>> voicesCopy = new HashMap<>();
+		voicesCopy.put(DEFAULT_VOICE_NUMBER, voiceCopy);
+		voices = Collections.unmodifiableMap(voicesCopy);
+	}
 
 	@Override
 	public List<Durational> getContents() {

--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
  */
 final class PolyphonicPattern implements Pattern {
 
-	private final Integer DEFAULT_VOICE_NUMBER = 1;
+	private static final Integer DEFAULT_VOICE_NUMBER = 1;
 
 	private final Map<Integer, List<Durational>> voices;
 
@@ -68,6 +68,23 @@ final class PolyphonicPattern implements Pattern {
 	@Override
 	public boolean isMonophonic() {
 		return false;
+	}
+
+	@Override
+	public int getNumberOfVoices() {
+		return voices.size();
+	}
+
+	@Override
+	public List<Integer> getVoiceNumbers() {
+		List<Integer> voiceNumbers = new ArrayList<>(voices.keySet());
+		voiceNumbers.sort(Integer::compareTo);
+		return voiceNumbers;
+	}
+
+	@Override
+	public List<Durational> getVoice(int voiceNumber) {
+		return voices.get(voiceNumber);
 	}
 
 	/*

--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2018 Otso Björklund.
  * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
  */
 package org.wmn4j.mir;
@@ -8,9 +7,6 @@ import org.wmn4j.notation.elements.Durational;
 
 import java.util.List;
 
-/**
- * @author Otso Björklund
- */
 public final class PolyphonicPattern implements Pattern {
 
 	@Override

--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -11,6 +11,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 /**
@@ -87,12 +89,59 @@ final class PolyphonicPattern implements Pattern {
 		return voices.get(voiceNumber);
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (!(o instanceof Pattern)) {
+			return false;
+		}
+
+		return containsEqualVoices((Pattern) o, List::equals);
+	}
+
+	private boolean containsEqualVoices(Pattern other,
+			BiFunction<List<Durational>, List<Durational>, Boolean> voiceEquality) {
+		if (other.getNumberOfVoices() != getNumberOfVoices()) {
+			return false;
+		}
+
+		for (List<Durational> voice : voices.values()) {
+			boolean isVoicePresentInOther = false;
+
+			for (Integer voiceNumber : other.getVoiceNumbers()) {
+				List<Durational> voiceInOther = other.getVoice(voiceNumber);
+				if (voiceEquality.apply(voice, voiceInOther)) {
+					isVoicePresentInOther = true;
+					break;
+				}
+			}
+
+			if (!isVoicePresentInOther) {
+				return false;
+			}
+		}
+
+		for (Integer voiceNumber : other.getVoiceNumbers()) {
+			List<Durational> voiceInOther = other.getVoice(voiceNumber);
+
+			if (voices.values().stream().noneMatch(voice -> voiceEquality.apply(voice, voiceInOther))) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 *
 	 * @see wmnlibmir.Pattern#equalsInPitch(wmnlibmir.Pattern)
 	 */
 	@Override
+
 	public boolean equalsInPitch(Pattern other) {
 		// TODO Auto-generated method stub
 		return false;
@@ -129,5 +178,10 @@ final class PolyphonicPattern implements Pattern {
 	public boolean equalsInDurations(Pattern other) {
 		// TODO Auto-generated method stub
 		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(voices);
 	}
 }

--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -64,14 +64,8 @@ final class PolyphonicPattern implements Pattern {
 		return null;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see wmnlibmir.Pattern#isMonophonic()
-	 */
 	@Override
 	public boolean isMonophonic() {
-		// TODO Auto-generated method stub
 		return false;
 	}
 

--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -204,15 +204,11 @@ final class PolyphonicPattern implements Pattern {
 		return true;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see wmnlibmir.Pattern#equalsEnharmonically(wmnlibmir.Pattern)
-	 */
 	@Override
 	public boolean equalsEnharmonically(Pattern other) {
-		// TODO Auto-generated method stub
-		return false;
+		BiFunction<List<Durational>, List<Durational>, Boolean> equalsEnharmonically = (voiceA, voiceB) ->
+				isNoteContentEqualWithTransformation(voiceA, voiceB, note -> note.getPitch().toInt());
+		return containsEqualVoices(other, equalsEnharmonically);
 	}
 
 	/*

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -85,6 +85,25 @@ class MonophonicPatternTest {
 	}
 
 	@Test
+	void testGetNumberOfVoicesReturnsOne() {
+		final Pattern pattern = new MonophonicPattern(this.referenceNotes);
+		assertEquals(1, pattern.getNumberOfVoices());
+	}
+
+	@Test
+	void testGetVoiceNumbersReturnsSingleValue() {
+		final Pattern pattern = new MonophonicPattern(this.referenceNotes);
+		assertEquals(1, pattern.getVoiceNumbers().size());
+	}
+
+	@Test
+	void testGetVoiceReturnsContents() {
+		final Pattern pattern = new MonophonicPattern(this.referenceNotes);
+		List<Durational> voiceContents = pattern.getVoice(pattern.getVoiceNumbers().get(0));
+		assertEquals(this.referenceNotes, voiceContents);
+	}
+
+	@Test
 	void testEquals() {
 		final Pattern pattern1 = new MonophonicPattern(this.referenceNotes);
 		final Pattern pattern2 = new MonophonicPattern(this.referenceNotes);

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -36,16 +36,10 @@ class MonophonicPatternTest {
 		this.referenceNotes = Collections.unmodifiableList(notes);
 	}
 
-	private Pattern createMonophonicPattern(List<Durational> contents) {
-		Pattern monophonicPattern = Pattern.monophonicOf(contents);
-		assertTrue(monophonicPattern instanceof MonophonicPattern, "Created pattern was of incorrect class");
-		return monophonicPattern;
-	}
-
 	@Test
 	void testCreatingMonophonicPatternFromListOfDurationals() {
 		try {
-			createMonophonicPattern(null);
+			new MonophonicPattern(null);
 			fail("Was able to create pattern with null contents");
 		} catch (final Exception e) {
 			assertTrue(e instanceof NullPointerException);
@@ -54,7 +48,7 @@ class MonophonicPatternTest {
 		final List<Durational> notes = new ArrayList<>();
 
 		try {
-			createMonophonicPattern(notes);
+			new MonophonicPattern(notes);
 			fail("Was able to create pattern with empty contents");
 		} catch (final Exception e) {
 			assertTrue(e instanceof IllegalArgumentException);
@@ -65,7 +59,7 @@ class MonophonicPatternTest {
 				Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH)));
 
 		try {
-			createMonophonicPattern(chordList);
+			new MonophonicPattern(chordList);
 			fail("Was able to create pattern with Chord in contents");
 		} catch (final Exception e) {
 			assertTrue(e instanceof IllegalArgumentException);
@@ -76,7 +70,7 @@ class MonophonicPatternTest {
 	void testImmutability() {
 		List<Durational> contents = new ArrayList<>(referenceNotes);
 
-		final Pattern pattern = createMonophonicPattern(contents);
+		final Pattern pattern = new MonophonicPattern(contents);
 		assertEquals(contents, pattern.getContents());
 
 		contents.add(Rest.of(Durations.QUARTER));
@@ -92,8 +86,8 @@ class MonophonicPatternTest {
 
 	@Test
 	void testEquals() {
-		final Pattern pattern1 = createMonophonicPattern(this.referenceNotes);
-		final Pattern pattern2 = createMonophonicPattern(this.referenceNotes);
+		final Pattern pattern1 = new MonophonicPattern(this.referenceNotes);
+		final Pattern pattern2 = new MonophonicPattern(this.referenceNotes);
 
 		assertEquals(pattern1, pattern1);
 
@@ -103,18 +97,18 @@ class MonophonicPatternTest {
 		final List<Durational> modifiedNotes = new ArrayList<>(this.referenceNotes);
 		modifiedNotes.add(Rest.of(Durations.QUARTER));
 
-		assertFalse(pattern1.equals(createMonophonicPattern(modifiedNotes)));
+		assertFalse(pattern1.equals(new MonophonicPattern(modifiedNotes)));
 	}
 
 	@Test
 	void testIsMonophonic() {
-		final Pattern pattern = createMonophonicPattern(this.referenceNotes);
+		final Pattern pattern = new MonophonicPattern(this.referenceNotes);
 		assertTrue(pattern.isMonophonic());
 	}
 
 	@Test
 	void testEqualsInPitch() {
-		final Pattern pattern = createMonophonicPattern(this.referenceNotes);
+		final Pattern pattern = new MonophonicPattern(this.referenceNotes);
 
 		final List<Durational> notes = new ArrayList<>();
 		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
@@ -122,26 +116,26 @@ class MonophonicPatternTest {
 		notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
 		notes.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.WHOLE));
 
-		assertTrue(pattern.equalsInPitch(createMonophonicPattern(notes)));
+		assertTrue(pattern.equalsInPitch(new MonophonicPattern(notes)));
 
 		notes.add(Rest.of(Durations.QUARTER));
 
-		assertTrue(pattern.equalsInPitch(createMonophonicPattern(notes)),
+		assertTrue(pattern.equalsInPitch(new MonophonicPattern(notes)),
 				"Adding rest to end of pattern should not make pattern inequal in pitches");
 
 		notes.set(1, Note.of(Pitch.of(Pitch.Base.E, -1, 3), Durations.WHOLE));
-		assertFalse(pattern.equalsInPitch(createMonophonicPattern(notes)));
+		assertFalse(pattern.equalsInPitch(new MonophonicPattern(notes)));
 
 		List<Durational> referenceNotesWithAddition = new ArrayList<>(referenceNotes);
 		referenceNotesWithAddition.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
-		assertFalse(pattern.equalsInPitch(createMonophonicPattern(referenceNotesWithAddition)));
+		assertFalse(pattern.equalsInPitch(new MonophonicPattern(referenceNotesWithAddition)));
 	}
 
 	@Test
 	void testEqualsEnharmonically() {
-		final Pattern pattern = createMonophonicPattern(this.referenceNotes);
+		final Pattern pattern = new MonophonicPattern(this.referenceNotes);
 
-		assertTrue(pattern.equalsEnharmonically(createMonophonicPattern(referenceNotes)));
+		assertTrue(pattern.equalsEnharmonically(new MonophonicPattern(referenceNotes)));
 
 		final List<Durational> samePitchesWithDifferentDurations = new ArrayList<>();
 		samePitchesWithDifferentDurations.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
@@ -150,7 +144,7 @@ class MonophonicPatternTest {
 		samePitchesWithDifferentDurations.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
 		samePitchesWithDifferentDurations.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.WHOLE));
 
-		assertTrue(pattern.equalsEnharmonically(createMonophonicPattern(samePitchesWithDifferentDurations)),
+		assertTrue(pattern.equalsEnharmonically(new MonophonicPattern(samePitchesWithDifferentDurations)),
 				"Difference in durations affected enharmonic equality when it shouldn't have affected it.");
 
 		final List<Durational> samePitchesWithDifferentSpellings = new ArrayList<>();
@@ -160,13 +154,13 @@ class MonophonicPatternTest {
 		samePitchesWithDifferentSpellings.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
 		samePitchesWithDifferentSpellings.add(Note.of(Pitch.of(Pitch.Base.A, 1, 3), Durations.QUARTER));
 
-		assertTrue(pattern.equalsEnharmonically(createMonophonicPattern(samePitchesWithDifferentSpellings)),
+		assertTrue(pattern.equalsEnharmonically(new MonophonicPattern(samePitchesWithDifferentSpellings)),
 				"Difference in note spellings affected enharmonic equality when it shouldn't have affected it.");
 
 		final List<Durational> notesWithAdditionalRestAtEnd = new ArrayList<>(referenceNotes);
 		notesWithAdditionalRestAtEnd.add(Rest.of(Durations.QUARTER));
 
-		assertTrue(pattern.equalsEnharmonically(createMonophonicPattern(notesWithAdditionalRestAtEnd)),
+		assertTrue(pattern.equalsEnharmonically(new MonophonicPattern(notesWithAdditionalRestAtEnd)),
 				"Adding rest to end of pattern should not make patterns unequal enharmonically.");
 
 		final List<Durational> enharmonicallyUnequalPitches = new ArrayList<>();
@@ -176,13 +170,13 @@ class MonophonicPatternTest {
 		enharmonicallyUnequalPitches.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
 		enharmonicallyUnequalPitches.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
 
-		assertFalse(pattern.equalsEnharmonically(createMonophonicPattern(enharmonicallyUnequalPitches)));
+		assertFalse(pattern.equalsEnharmonically(new MonophonicPattern(enharmonicallyUnequalPitches)));
 	}
 
 	@Test
 	void testEqualsTranspositionally() {
-		final Pattern pattern = createMonophonicPattern(referenceNotes);
-		assertTrue(pattern.equalsTranspositionally(createMonophonicPattern(referenceNotes)));
+		final Pattern pattern = new MonophonicPattern(referenceNotes);
+		assertTrue(pattern.equalsTranspositionally(new MonophonicPattern(referenceNotes)));
 
 		final List<Durational> transposedUpByMajorSecond = new ArrayList<>();
 		transposedUpByMajorSecond.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
@@ -191,7 +185,7 @@ class MonophonicPatternTest {
 		transposedUpByMajorSecond.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER));
 		transposedUpByMajorSecond.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
 
-		assertTrue(pattern.equalsTranspositionally(createMonophonicPattern(transposedUpByMajorSecond)));
+		assertTrue(pattern.equalsTranspositionally(new MonophonicPattern(transposedUpByMajorSecond)));
 
 		final List<Durational> transposedDownByOctave = new ArrayList<>();
 		transposedDownByOctave.add(Note.of(Pitch.of(Pitch.Base.C, 0, 3), Durations.EIGHTH));
@@ -200,7 +194,7 @@ class MonophonicPatternTest {
 		transposedDownByOctave.add(Note.of(Pitch.of(Pitch.Base.D, 0, 3), Durations.QUARTER));
 		transposedDownByOctave.add(Note.of(Pitch.of(Pitch.Base.B, -1, 2), Durations.QUARTER));
 
-		assertTrue(pattern.equalsTranspositionally(createMonophonicPattern(transposedDownByOctave)));
+		assertTrue(pattern.equalsTranspositionally(new MonophonicPattern(transposedDownByOctave)));
 
 		final List<Durational> withOneNoteInDifferentOctaveThanInReferencePattern = new ArrayList<>();
 		withOneNoteInDifferentOctaveThanInReferencePattern.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
@@ -212,7 +206,7 @@ class MonophonicPatternTest {
 				.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
 
 		assertFalse(pattern.equalsTranspositionally(
-				createMonophonicPattern(withOneNoteInDifferentOctaveThanInReferencePattern)));
+				new MonophonicPattern(withOneNoteInDifferentOctaveThanInReferencePattern)));
 
 		final List<Durational> transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond = new ArrayList<>();
 		transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond
@@ -226,18 +220,18 @@ class MonophonicPatternTest {
 				.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
 
 		assertFalse(pattern.equalsTranspositionally(
-				createMonophonicPattern(transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond)));
+				new MonophonicPattern(transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond)));
 
 		final List<Durational> notesWithAdditionalRestAtEnd = new ArrayList<>(referenceNotes);
 		notesWithAdditionalRestAtEnd.add(Rest.of(Durations.QUARTER));
-		assertTrue(pattern.equalsTranspositionally(createMonophonicPattern(notesWithAdditionalRestAtEnd)),
+		assertTrue(pattern.equalsTranspositionally(new MonophonicPattern(notesWithAdditionalRestAtEnd)),
 				"Adding rest to end of pattern should not make patterns unequal enharmonically.");
 	}
 
 	@Test
 	void testEqualsInDurations() {
-		final Pattern pattern = createMonophonicPattern(referenceNotes);
-		assertTrue(pattern.equalsInDurations(createMonophonicPattern(referenceNotes)));
+		final Pattern pattern = new MonophonicPattern(referenceNotes);
+		assertTrue(pattern.equalsInDurations(new MonophonicPattern(referenceNotes)));
 
 		List<Durational> withSameDurationsButDifferentPitches = new ArrayList<>();
 		withSameDurationsButDifferentPitches.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
@@ -246,7 +240,7 @@ class MonophonicPatternTest {
 		withSameDurationsButDifferentPitches.add(Note.of(Pitch.of(Pitch.Base.D, -1, 4), Durations.QUARTER));
 		withSameDurationsButDifferentPitches.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
 
-		assertTrue(pattern.equalsInDurations(createMonophonicPattern(withSameDurationsButDifferentPitches)));
+		assertTrue(pattern.equalsInDurations(new MonophonicPattern(withSameDurationsButDifferentPitches)));
 
 		List<Durational> withDifferentNoteDurations = new ArrayList<>();
 		withDifferentNoteDurations.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
@@ -255,7 +249,7 @@ class MonophonicPatternTest {
 		withDifferentNoteDurations.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
 		withDifferentNoteDurations.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
 
-		assertFalse(pattern.equalsInDurations(createMonophonicPattern(withDifferentNoteDurations)));
+		assertFalse(pattern.equalsInDurations(new MonophonicPattern(withDifferentNoteDurations)));
 
 		List<Durational> withDifferentRestDurations = new ArrayList<>();
 		withDifferentRestDurations.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
@@ -264,7 +258,7 @@ class MonophonicPatternTest {
 		withDifferentRestDurations.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
 		withDifferentRestDurations.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
 
-		assertFalse(pattern.equalsInDurations(createMonophonicPattern(withDifferentRestDurations)));
+		assertFalse(pattern.equalsInDurations(new MonophonicPattern(withDifferentRestDurations)));
 
 		final List<Durational> withRestInAPlaceWhereReferenceHasANote = new ArrayList<>();
 		withRestInAPlaceWhereReferenceHasANote.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
@@ -273,11 +267,11 @@ class MonophonicPatternTest {
 		withRestInAPlaceWhereReferenceHasANote.add(Rest.of(Durations.QUARTER));
 		withRestInAPlaceWhereReferenceHasANote.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
 
-		assertFalse(pattern.equalsInDurations(createMonophonicPattern(withRestInAPlaceWhereReferenceHasANote)));
+		assertFalse(pattern.equalsInDurations(new MonophonicPattern(withRestInAPlaceWhereReferenceHasANote)));
 
 		final List<Durational> withAddedDurationAtEnd = new ArrayList<>(referenceNotes);
 		withAddedDurationAtEnd.add(Rest.of(Durations.SIXTEENTH));
 
-		assertFalse(pattern.equalsInDurations(createMonophonicPattern(withAddedDurationAtEnd)));
+		assertFalse(pattern.equalsInDurations(new MonophonicPattern(withAddedDurationAtEnd)));
 	}
 }

--- a/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -135,5 +136,30 @@ public class PolyphonicPatternTest {
 
 		assertEquals(contents.get(1), pattern.getVoice(1));
 		assertEquals(contents.get(2), pattern.getVoice(2));
+	}
+
+	@Test
+	void testEquals() {
+		final Pattern pattern1 = new PolyphonicPattern(createReferencePatternVoices());
+		final Pattern pattern2 = new PolyphonicPattern(createReferencePatternVoices());
+
+		assertEquals(pattern1, pattern1);
+		assertEquals(pattern1, pattern2);
+
+		Map<Integer, List<? extends Durational>> modifiedVoices = createReferencePatternVoices();
+		List<Durational> modifiedVoice = new ArrayList<>(modifiedVoices.get(2));
+		Note note = Note.of(Pitch.of(Pitch.Base.C, 1, 5), Durations.EIGHTH);
+		modifiedVoice.add(note);
+		modifiedVoices.put(2, modifiedVoice);
+
+		final Pattern modifiedPattern = new PolyphonicPattern(modifiedVoices);
+		assertNotEquals(modifiedPattern, pattern1);
+
+		Map<Integer, List<? extends Durational>> contentsWithAddedVoice = createReferencePatternVoices();
+		List<Note> notes = Collections.singletonList(note);
+		contentsWithAddedVoice.put(3, notes);
+		final Pattern withAddedVoice = new PolyphonicPattern(contentsWithAddedVoice);
+
+		assertNotEquals(withAddedVoice, pattern1);
 	}
 }

--- a/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
@@ -104,4 +104,36 @@ public class PolyphonicPatternTest {
 		expectedContents.forEach(notationElement -> assertTrue(contents.contains(notationElement)));
 	}
 
+	@Test
+	void testGetNumberOfVoicesReturnsCorrectNumber() {
+		final Pattern pattern = new PolyphonicPattern(createReferencePatternVoices());
+		assertEquals(2, pattern.getNumberOfVoices());
+	}
+
+	@Test
+	void testGetVoiceNumbersReturnsCorrectNumbers() {
+		final Map<Integer, List<? extends Durational>> contents = createReferencePatternVoices();
+		final Pattern pattern = new PolyphonicPattern(createReferencePatternVoices());
+
+		final List<Integer> voiceNumbers = pattern.getVoiceNumbers();
+		assertEquals(contents.keySet().size(), voiceNumbers.size());
+		for (Integer voiceNumber : voiceNumbers) {
+			assertTrue(contents.containsKey(voiceNumber),
+					"Voice number " + voiceNumber + " not expected to be in voice numbers");
+		}
+
+		for (Integer expectedVoiceNumber : contents.keySet()) {
+			assertTrue(voiceNumbers.contains(expectedVoiceNumber),
+					"Expected voice number " + expectedVoiceNumber + " missing from voice numbers");
+		}
+	}
+
+	@Test
+	void testGetVoiceReturnsCorrectContents() {
+		final Map<Integer, List<? extends Durational>> contents = createReferencePatternVoices();
+		final Pattern pattern = new PolyphonicPattern(createReferencePatternVoices());
+
+		assertEquals(contents.get(1), pattern.getVoice(1));
+		assertEquals(contents.get(2), pattern.getVoice(2));
+	}
 }

--- a/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
@@ -1,0 +1,62 @@
+package org.wmn4j.mir;
+
+import org.junit.jupiter.api.Test;
+import org.wmn4j.notation.elements.Chord;
+import org.wmn4j.notation.elements.Durational;
+import org.wmn4j.notation.elements.Durations;
+import org.wmn4j.notation.elements.Note;
+import org.wmn4j.notation.elements.Pitch;
+import org.wmn4j.notation.elements.Rest;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class PolyphonicPatternTest {
+
+	private Map<Integer, List<? extends Durational>> createReferencePatternVoices() {
+		final Map<Integer, List<? extends Durational>> voices = new HashMap<>();
+		List<Durational> voice1 = new ArrayList<>();
+		voice1.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
+		voice1.add(Rest.of(Durations.QUARTER));
+		voice1.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+
+		List<Durational> voice2 = new ArrayList<>();
+
+		voice2.add(Note.of(Pitch.of(Pitch.Base.E, 0, 3), Durations.QUARTER));
+		voice2.add(Rest.of(Durations.EIGHTH));
+		voice2.add(Note.of(Pitch.of(Pitch.Base.F, 1, 3), Durations.EIGHTH));
+
+		voices.put(1, voice1);
+		voices.put(2, voice2);
+
+		return voices;
+	}
+
+	@Test
+	void testIsMonophonicReturnsFalseForMultiVoicePattern() {
+		final Pattern polyphonicPattern = new PolyphonicPattern(createReferencePatternVoices());
+		assertFalse(polyphonicPattern.isMonophonic());
+	}
+
+	@Test
+	void testIsMonophonicReturnsFalseForPatternWithChords() {
+		final Map<Integer, List<? extends Durational>> voices = new HashMap<>();
+		List<Durational> voice = new ArrayList<>();
+		List<Note> chordContents = new ArrayList<>();
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH));
+		voice.add(Chord.of(chordContents));
+		voice.add(Rest.of(Durations.QUARTER));
+		voice.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+		voices.put(1, voice);
+
+		final Pattern patternWithChord = new PolyphonicPattern(voices);
+		assertFalse(patternWithChord.isMonophonic());
+	}
+
+}

--- a/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
@@ -9,11 +9,13 @@ import org.wmn4j.notation.elements.Pitch;
 import org.wmn4j.notation.elements.Rest;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PolyphonicPatternTest {
 
@@ -34,6 +36,31 @@ public class PolyphonicPatternTest {
 		voices.put(2, voice2);
 
 		return voices;
+	}
+
+	@Test
+	void testCreatingPatternWithInvalidContentsPossible() {
+		List<Durational> nullContents = null;
+		Map<Integer, List<? extends Durational>> nullVoices = null;
+
+		assertThrows(NullPointerException.class, () -> new PolyphonicPattern(nullContents),
+				"Did not throw NullPointerException when trying to create polyphonic pattern with null contents");
+
+		assertThrows(NullPointerException.class, () -> new PolyphonicPattern(nullVoices),
+				"Did not throw NullPointerException when trying to create polyphonic pattern with null voices");
+
+		assertThrows(IllegalArgumentException.class, () -> new PolyphonicPattern(Collections.emptyMap()),
+				"Did not throw IllegalArgumentException when trying to create polyphonic pattern with empty voices");
+
+		List<Note> notes = new ArrayList<>();
+		notes.add(Note.of(Pitch.of(Pitch.Base.B, 0, 3), Durations.QUARTER));
+		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 3), Durations.QUARTER));
+
+		Map<Integer, List<? extends Durational>> voices = new HashMap<>();
+		voices.put(1, notes);
+
+		assertThrows(IllegalArgumentException.class, () -> new PolyphonicPattern(voices),
+				"Did not throw IllegalArgumentException when trying to create polyphonic pattern with monophonic contents");
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
@@ -254,4 +254,77 @@ public class PolyphonicPatternTest {
 
 		assertFalse(patternA.equalsInPitch(patternB));
 	}
+
+	@Test
+	void testEqualsEnharmonicallyReturnsTrueForExactEquality() {
+		final Pattern pattern1 = new PolyphonicPattern(createReferencePatternVoices());
+		final Pattern pattern2 = new PolyphonicPattern(createReferencePatternVoices());
+
+		assertTrue(pattern1.equalsEnharmonically(pattern1));
+		assertTrue(pattern1.equalsEnharmonically(pattern2));
+	}
+
+	@Test
+	void testEqualsEnharmonicallyReturnsTrueWhenPatternsHaveEnharmonicallySamePitches() {
+		final Pattern pattern = new PolyphonicPattern(createReferencePatternVoices());
+
+		Map<Integer, List<? extends Durational>> modifiedVoices = createReferencePatternVoices();
+		List<Durational> modifiedVoice = new ArrayList<>(modifiedVoices.get(1));
+		Note note = Note.of(Pitch.of(Pitch.Base.D, -2, 4), Durations.SIXTEENTH);
+		modifiedVoice.set(0, note);
+		modifiedVoices.put(1, modifiedVoice);
+
+		final Pattern modifiedPattern = new PolyphonicPattern(modifiedVoices);
+		assertTrue(modifiedPattern.equalsEnharmonically(pattern));
+
+		final Map<Integer, List<? extends Durational>> voicesWithDifferentRests = new HashMap<>();
+		List<Durational> voice1 = new ArrayList<>();
+		voice1.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
+		voice1.add(Rest.of(Durations.EIGHTH));
+		voice1.add(Rest.of(Durations.SIXTEENTH));
+		voice1.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+
+		List<Durational> voice2 = new ArrayList<>();
+
+		voice2.add(Note.of(Pitch.of(Pitch.Base.E, 0, 3), Durations.QUARTER));
+		voice2.add(Rest.of(Durations.SIXTEENTH));
+		voice2.add(Note.of(Pitch.of(Pitch.Base.G, -1, 3), Durations.EIGHTH));
+
+		voicesWithDifferentRests.put(1, voice1);
+		voicesWithDifferentRests.put(2, voice2);
+
+		final Pattern patternWithDifferentRests = new PolyphonicPattern(voicesWithDifferentRests);
+		assertTrue(pattern.equalsEnharmonically(patternWithDifferentRests));
+	}
+
+	@Test
+	void testEqualsEnharmonicallyWithChords() {
+		List<Durational> contentsA = new ArrayList<>();
+		List<Note> chordContents = new ArrayList<>();
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.F, 2, 4), Durations.EIGHTH));
+		contentsA.add(Chord.of(chordContents));
+		contentsA.add(Rest.of(Durations.QUARTER));
+		contentsA.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+
+		final Pattern patternA = new PolyphonicPattern(contentsA);
+		final Pattern patternACopy = new PolyphonicPattern(contentsA);
+
+		assertTrue(patternA.equalsEnharmonically(patternA));
+		assertTrue(patternA.equalsEnharmonically(patternACopy));
+
+		List<Durational> contentsB = new ArrayList<>(contentsA);
+
+		List<Note> differentChordContents = new ArrayList<>();
+		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
+		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH));
+		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.G, 1, 4), Durations.EIGHTH));
+		contentsB.set(0, Chord.of(differentChordContents));
+
+		final Pattern patternB = new PolyphonicPattern(contentsB);
+
+		assertFalse(patternA.equalsEnharmonically(patternB));
+	}
+
 }

--- a/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
@@ -139,7 +139,7 @@ public class PolyphonicPatternTest {
 	}
 
 	@Test
-	void testEquals() {
+	void testEqualsReturnsTrueOnlyForExactEquality() {
 		final Pattern pattern1 = new PolyphonicPattern(createReferencePatternVoices());
 		final Pattern pattern2 = new PolyphonicPattern(createReferencePatternVoices());
 
@@ -161,5 +161,97 @@ public class PolyphonicPatternTest {
 		final Pattern withAddedVoice = new PolyphonicPattern(contentsWithAddedVoice);
 
 		assertNotEquals(withAddedVoice, pattern1);
+	}
+
+	@Test
+	void testEqualsInPitchReturnsTrueForExactEquality() {
+		final Pattern pattern1 = new PolyphonicPattern(createReferencePatternVoices());
+		final Pattern pattern2 = new PolyphonicPattern(createReferencePatternVoices());
+
+		assertTrue(pattern1.equalsInPitch(pattern1));
+		assertTrue(pattern1.equalsInPitch(pattern2));
+	}
+
+	@Test
+	void testEqualsInPitchReturnsTrueWhenPatternsHaveSamePitches() {
+		final Pattern pattern = new PolyphonicPattern(createReferencePatternVoices());
+
+		Map<Integer, List<? extends Durational>> modifiedVoices = createReferencePatternVoices();
+		List<Durational> modifiedVoice = new ArrayList<>(modifiedVoices.get(1));
+		Note note = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.SIXTEENTH);
+		modifiedVoice.set(0, note);
+		modifiedVoices.put(1, modifiedVoice);
+
+		final Pattern modifiedPattern = new PolyphonicPattern(modifiedVoices);
+		assertTrue(modifiedPattern.equalsInPitch(pattern));
+
+		final Map<Integer, List<? extends Durational>> voicesWithDifferentRests = new HashMap<>();
+		List<Durational> voice1 = new ArrayList<>();
+		voice1.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
+		voice1.add(Rest.of(Durations.EIGHTH));
+		voice1.add(Rest.of(Durations.SIXTEENTH));
+		voice1.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+
+		List<Durational> voice2 = new ArrayList<>();
+
+		voice2.add(Note.of(Pitch.of(Pitch.Base.E, 0, 3), Durations.QUARTER));
+		voice2.add(Rest.of(Durations.SIXTEENTH));
+		voice2.add(Note.of(Pitch.of(Pitch.Base.F, 1, 3), Durations.EIGHTH));
+
+		voicesWithDifferentRests.put(1, voice1);
+		voicesWithDifferentRests.put(2, voice2);
+
+		final Pattern patternWithDifferentRests = new PolyphonicPattern(voicesWithDifferentRests);
+		assertTrue(pattern.equalsInPitch(patternWithDifferentRests));
+	}
+
+	@Test
+	void testEqualsInPitchReturnsFalseForPatternsWithDifferentPitches() {
+		final Pattern pattern = new PolyphonicPattern(createReferencePatternVoices());
+		Map<Integer, List<? extends Durational>> modifiedVoices = createReferencePatternVoices();
+		List<Durational> modifiedVoice = new ArrayList<>(modifiedVoices.get(2));
+		Note note = Note.of(Pitch.of(Pitch.Base.C, 1, 5), Durations.EIGHTH);
+		modifiedVoice.set(0, note);
+		modifiedVoices.put(2, modifiedVoice);
+
+		final Pattern modifiedPattern = new PolyphonicPattern(modifiedVoices);
+		assertFalse(modifiedPattern.equalsInPitch(pattern));
+
+		Map<Integer, List<? extends Durational>> contentsWithAddedVoice = createReferencePatternVoices();
+		List<Note> notes = Collections.singletonList(note);
+		contentsWithAddedVoice.put(3, notes);
+		final Pattern withAddedVoice = new PolyphonicPattern(contentsWithAddedVoice);
+
+		assertFalse(withAddedVoice.equalsInPitch(pattern));
+	}
+
+	@Test
+	void testEqualsInPitchWithChords() {
+		List<Durational> contentsA = new ArrayList<>();
+		List<Note> chordContents = new ArrayList<>();
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH));
+		contentsA.add(Chord.of(chordContents));
+		contentsA.add(Rest.of(Durations.QUARTER));
+		contentsA.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+
+		final Pattern patternA = new PolyphonicPattern(contentsA);
+		final Pattern patternACopy = new PolyphonicPattern(contentsA);
+
+		assertTrue(patternA.equalsInPitch(patternA));
+		assertTrue(patternA.equalsInPitch(patternACopy));
+
+		List<Durational> contentsB = new ArrayList<>(contentsA);
+
+		List<Note> differentChordContents = new ArrayList<>();
+		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
+		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH));
+		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.G, 1, 4), Durations.EIGHTH));
+		contentsB.set(0, Chord.of(differentChordContents));
+
+		final Pattern patternB = new PolyphonicPattern(contentsB);
+
+		assertFalse(patternA.equalsInPitch(patternB));
 	}
 }

--- a/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
@@ -13,9 +13,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PolyphonicPatternTest {
 
@@ -84,6 +87,21 @@ public class PolyphonicPatternTest {
 
 		final Pattern patternWithChord = new PolyphonicPattern(voices);
 		assertFalse(patternWithChord.isMonophonic());
+	}
+
+	@Test
+	void testGetContentsReturnsAllContentsOfPattern() {
+		final Map<Integer, List<? extends Durational>> voiceContents = createReferencePatternVoices();
+
+		final Pattern pattern = new PolyphonicPattern(voiceContents);
+		final List<Durational> contents = pattern.getContents();
+
+		assertEquals(6, contents.size());
+
+		List<? extends Durational> expectedContents = voiceContents.values().stream().flatMap(voice -> voice.stream())
+				.collect(Collectors.toList());
+
+		expectedContents.forEach(notationElement -> assertTrue(contents.contains(notationElement)));
 	}
 
 }


### PR DESCRIPTION
Implements part of issue #6 

Adds implementations for some of the comparison methods.
The implementations are not necessarily the fastest possible, they can be 
optimized in the future if necessary. The implementations for the rest will follow soon, I thought that splitting the changes would make them a bit easier to review :)