### PR TITLE
Issue #125: Write basic encoding information to MusicXml

### DIFF
--- a/src/main/java/org/wmn4j/Wmn4j.java
+++ b/src/main/java/org/wmn4j/Wmn4j.java
@@ -53,4 +53,22 @@ public final class Wmn4j {
 	public static String getVersion() {
 		return INSTANCE.version;
 	}
+
+	/**
+	 * Returns the name of this project.
+	 *
+	 * @return the name of this project
+	 */
+	public static String getName() {
+		return "Western Music Notation for Java (wmn4j)";
+	}
+
+	/**
+	 * Returns the name of this project along with the version number.
+	 *
+	 * @return the name of this project along with the version number
+	 */
+	public static String getNameWithVersion() {
+		return getName() + " " + getVersion();
+	}
 }

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
@@ -132,6 +132,9 @@ final class MusicXmlTags {
 	static final String SCORE_IDENTIFICATION_ARRANGER = "arranger";
 	static final String SCORE_PARTWISE = "score-partwise";
 	static final String MUSICXML_VERSION = "version";
+	static final String ENCODING = "encoding";
+	static final String SOFTWARE = "software";
+	static final String ENCODING_DATE = "encoding-date";
 
 	private MusicXmlTags() {
 	}

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
@@ -7,6 +7,7 @@ import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.DocumentType;
 import org.w3c.dom.Element;
+import org.wmn4j.Wmn4j;
 import org.wmn4j.notation.elements.Articulation;
 import org.wmn4j.notation.elements.Barline;
 import org.wmn4j.notation.elements.Chord;
@@ -39,9 +40,12 @@ import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.math.BigInteger;
 import java.nio.file.Path;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -178,7 +182,25 @@ class MusicXmlWriterDom implements MusicXmlWriter {
 			identificationElement.appendChild(arrangerElement);
 		}
 
+		identificationElement.appendChild(createEncodingElement());
+
 		return identificationElement;
+	}
+
+	private Element createEncodingElement() {
+
+		final Element encodingElement = doc.createElement(MusicXmlTags.ENCODING);
+		final Element softwareElement = doc.createElement(MusicXmlTags.SOFTWARE);
+		softwareElement.setTextContent(Wmn4j.getNameWithVersion());
+		encodingElement.appendChild(softwareElement);
+
+		final Element encodingDateElement = doc.createElement(MusicXmlTags.ENCODING_DATE);
+		final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+		encodingDateElement.setTextContent(dateFormat.format(new Date()));
+
+		encodingElement.appendChild(encodingDateElement);
+
+		return encodingElement;
 	}
 
 	private void writePartList(Element scoreRoot) {

--- a/src/test/java/org/wmn4j/notation/TestHelper.java
+++ b/src/test/java/org/wmn4j/notation/TestHelper.java
@@ -7,6 +7,7 @@ import org.wmn4j.io.musicxml.MusicXmlReader;
 import org.wmn4j.notation.builders.ChordBuilder;
 import org.wmn4j.notation.builders.MeasureBuilder;
 import org.wmn4j.notation.builders.NoteBuilder;
+import org.wmn4j.notation.builders.PartBuilder;
 import org.wmn4j.notation.builders.RestBuilder;
 import org.wmn4j.notation.elements.Durations;
 import org.wmn4j.notation.elements.Measure;
@@ -15,6 +16,8 @@ import org.wmn4j.notation.elements.Score;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 public class TestHelper {
 
@@ -59,5 +62,20 @@ public class TestHelper {
 		}
 
 		return score;
+	}
+
+	public static List<PartBuilder> getTestPartBuilders(int partCount, int measureCount) {
+		final List<PartBuilder> partBuilders = new ArrayList<>();
+
+		for (int p = 1; p <= partCount; ++p) {
+			final PartBuilder partBuilder = new PartBuilder("Part" + p);
+			for (int m = 1; m <= measureCount; ++m) {
+				partBuilder.add(TestHelper.getTestMeasureBuilder(m));
+			}
+
+			partBuilders.add(partBuilder);
+		}
+
+		return partBuilders;
 	}
 }

--- a/src/test/java/org/wmn4j/notation/builders/ScoreBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/ScoreBuilderTest.java
@@ -10,7 +10,6 @@ import org.wmn4j.notation.elements.Score;
 import org.wmn4j.notation.elements.ScoreTest;
 import org.wmn4j.notation.elements.TimeSignatures;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -18,26 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ScoreBuilderTest {
 
-	private static List<PartBuilder> getTestPartBuilders(int partCount, int measureCount) {
-		final List<PartBuilder> partBuilders = new ArrayList<>();
-
-		for (int p = 1; p <= partCount; ++p) {
-			final PartBuilder partBuilder = new PartBuilder("Part" + p);
-			for (int m = 1; m <= measureCount; ++m) {
-				partBuilder.add(TestHelper.getTestMeasureBuilder(m));
-			}
-
-			partBuilders.add(partBuilder);
-		}
-
-		return partBuilders;
-	}
-
 	@Test
 	void testBuildingScore() {
 		final ScoreBuilder builder = new ScoreBuilder();
 		final Map<Score.Attribute, String> attributes = ScoreTest.getTestAttributes();
-		final List<PartBuilder> partBuilders = getTestPartBuilders(5, 5);
+		final List<PartBuilder> partBuilders = TestHelper.getTestPartBuilders(5, 5);
 
 		for (Score.Attribute attr : attributes.keySet()) {
 			builder.setAttribute(attr, attributes.get(attr));
@@ -56,7 +40,7 @@ class ScoreBuilderTest {
 
 	@Test
 	void testPartsAreOfEqualLengthWhenBuilt() {
-		final List<PartBuilder> partBuilders = getTestPartBuilders(3, 1);
+		final List<PartBuilder> partBuilders = TestHelper.getTestPartBuilders(3, 1);
 		PartBuilder first = partBuilders.get(0);
 		first.add(new MeasureBuilder(2));
 


### PR DESCRIPTION
Implements issue #125 

Write basic encoding information to MusicXML when outputting.
Adds software name and encoding date to files.