### PR TITLE
Issue #137: Use DurationalBuilder instead of Durational in PatternBuilder

### DIFF
--- a/src/main/java/org/wmn4j/notation/builders/ChordBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/ChordBuilder.java
@@ -3,19 +3,19 @@
  */
 package org.wmn4j.notation.builders;
 
+import org.wmn4j.notation.elements.Chord;
+import org.wmn4j.notation.elements.Duration;
+import org.wmn4j.notation.elements.Note;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Predicate;
 
-import org.wmn4j.notation.elements.Chord;
-import org.wmn4j.notation.elements.Duration;
-import org.wmn4j.notation.elements.Note;
-
 /**
  * Class for building <code>Chord</code> objects.
  */
-public class ChordBuilder implements DurationalBuilder, Iterable<NoteBuilder> {
+public final class ChordBuilder implements DurationalBuilder, Iterable<NoteBuilder> {
 
 	private final List<NoteBuilder> noteBuilders;
 	private Duration duration;
@@ -38,9 +38,23 @@ public class ChordBuilder implements DurationalBuilder, Iterable<NoteBuilder> {
 	 * @param noteBuilders the note builders that are placed into this builder
 	 */
 	public ChordBuilder(List<NoteBuilder> noteBuilders) {
-		final List<NoteBuilder> noteBuildersCopy = new ArrayList<>();
+		final List<NoteBuilder> noteBuildersCopy = new ArrayList<>(noteBuilders.size());
 		noteBuilders.forEach(builder -> noteBuildersCopy.add(new NoteBuilder(builder)));
 		this.noteBuilders = noteBuildersCopy;
+		this.duration = noteBuilders.get(0).getDuration();
+	}
+
+	/**
+	 * Constructor that creates a new builder with the contents of the given chord.
+	 * Ties and connected markings in the notes of the given chord are not copied.
+	 *
+	 * @param chord the chord from which the contents of notes are copied to this builder
+	 */
+	public ChordBuilder(Chord chord) {
+		this.noteBuilders = new ArrayList<>(chord.getNoteCount());
+		for (Note note : chord) {
+			this.noteBuilders.add(new NoteBuilder(note));
+		}
 		this.duration = noteBuilders.get(0).getDuration();
 	}
 

--- a/src/main/java/org/wmn4j/notation/builders/NoteBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/NoteBuilder.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 /**
  * Class for building {@link Note} objects. The built note is cached.
  */
-public class NoteBuilder implements DurationalBuilder {
+public final class NoteBuilder implements DurationalBuilder {
 
 	private Pitch pitch;
 	private Duration duration;
@@ -63,6 +63,18 @@ public class NoteBuilder implements DurationalBuilder {
 		this.isTiedFromPrevious = builder.isTiedFromPrevious();
 		builder.getFollowingTied()
 				.ifPresent(tied -> this.followingTied = new NoteBuilder(tied));
+	}
+
+	/**
+	 * Constructor that creates a builder with the pitch, duration, and articulations of the given note.
+	 * Ties and connected markings are not copied.
+	 *
+	 * @param note the note from which pitch, duration, and articulations are copied to the created builder
+	 */
+	public NoteBuilder(Note note) {
+		this(note.getPitch(), note.getDuration());
+		note.getArticulations()
+				.forEach(articulation -> this.articulations.add(articulation));
 	}
 
 	/**

--- a/src/main/java/org/wmn4j/notation/builders/RestBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/RestBuilder.java
@@ -3,10 +3,10 @@
  */
 package org.wmn4j.notation.builders;
 
-import java.util.Objects;
-
 import org.wmn4j.notation.elements.Duration;
 import org.wmn4j.notation.elements.Rest;
+
+import java.util.Objects;
 
 /**
  * Class for building {@link Rest} objects.
@@ -22,6 +22,15 @@ public final class RestBuilder implements DurationalBuilder {
 	 */
 	public RestBuilder(Duration duration) {
 		setDuration(duration);
+	}
+
+	/**
+	 * Constructor that creates a builder with the duration of the given rest.
+	 *
+	 * @param rest the rest to whose duration this builder is set
+	 */
+	public RestBuilder(Rest rest) {
+		setDuration(rest.getDuration());
 	}
 
 	/**

--- a/src/test/java/org/wmn4j/mir/PatternBuilderTest.java
+++ b/src/test/java/org/wmn4j/mir/PatternBuilderTest.java
@@ -1,6 +1,9 @@
 package org.wmn4j.mir;
 
 import org.junit.jupiter.api.Test;
+import org.wmn4j.notation.builders.ChordBuilder;
+import org.wmn4j.notation.builders.NoteBuilder;
+import org.wmn4j.notation.builders.RestBuilder;
 import org.wmn4j.notation.elements.Chord;
 import org.wmn4j.notation.elements.Durational;
 import org.wmn4j.notation.elements.Durations;
@@ -21,22 +24,22 @@ class PatternBuilderTest {
 		final PatternBuilder builder = new PatternBuilder();
 
 		final Note firstElement = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
-		builder.add(firstElement);
+		builder.add(new NoteBuilder(firstElement));
 
 		final Note secondElement = Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH);
-		builder.add(secondElement);
+		builder.add(new NoteBuilder(secondElement));
 
 		final Rest thirdElement = Rest.of(Durations.QUARTER);
-		builder.add(thirdElement);
+		builder.add(new RestBuilder(thirdElement));
 
 		final Note fourthElement = Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.SIXTEENTH);
-		builder.add(fourthElement);
+		builder.add(new NoteBuilder(fourthElement));
 
 		final Rest fifthElement = Rest.of(Durations.EIGHTH);
-		builder.add(fifthElement);
+		builder.add(new RestBuilder(fifthElement));
 
 		final Note sixthElement = Note.of(Pitch.of(Pitch.Base.B, -1, 4), Durations.SIXTEENTH);
-		builder.add(sixthElement);
+		builder.add(new NoteBuilder(sixthElement));
 
 		assertTrue(builder.isMonophonic());
 		final Pattern pattern = builder.build();
@@ -58,23 +61,23 @@ class PatternBuilderTest {
 		final PatternBuilder builder = new PatternBuilder();
 
 		final Note firstElement = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
-		builder.add(firstElement);
+		builder.add(new NoteBuilder(firstElement));
 
 		final Note secondElement = Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH);
-		builder.add(secondElement);
+		builder.add(new NoteBuilder(secondElement));
 
 		final Rest thirdElement = Rest.of(Durations.QUARTER);
-		builder.add(thirdElement);
+		builder.add(new RestBuilder(thirdElement));
 
 		final Note fourthElement = Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.SIXTEENTH);
-		builder.add(fourthElement);
+		builder.add(new NoteBuilder(fourthElement));
 
 		final Rest fifthElement = Rest.of(Durations.EIGHTH);
-		builder.add(fifthElement);
+		builder.add(new RestBuilder(fifthElement));
 
 		final Chord sixthElement = Chord.of(Note.of(Pitch.of(Pitch.Base.B, -1, 4), Durations.SIXTEENTH),
 				Note.of(Pitch.of(Pitch.Base.E, -1, 4), Durations.SIXTEENTH));
-		builder.add(sixthElement);
+		builder.add(new ChordBuilder(sixthElement));
 
 		assertFalse(builder.isMonophonic());
 		final Pattern pattern = builder.build();
@@ -97,23 +100,23 @@ class PatternBuilderTest {
 
 		final int voice1number = 1;
 		final Note firstElement = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
-		builder.addToVoice(firstElement, voice1number);
+		builder.addToVoice(new NoteBuilder(firstElement), voice1number);
 
 		final Note secondElement = Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH);
-		builder.addToVoice(secondElement, voice1number);
+		builder.addToVoice(new NoteBuilder(secondElement), voice1number);
 
 		final Rest thirdElement = Rest.of(Durations.QUARTER);
-		builder.addToVoice(thirdElement, voice1number);
+		builder.addToVoice(new RestBuilder(thirdElement), voice1number);
 
 		final int voice2number = 2;
 		final Note fourthElement = Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.SIXTEENTH);
-		builder.addToVoice(fourthElement, voice2number);
+		builder.addToVoice(new NoteBuilder(fourthElement), voice2number);
 
 		final Rest fifthElement = Rest.of(Durations.EIGHTH);
-		builder.addToVoice(fifthElement, voice2number);
+		builder.addToVoice(new RestBuilder(fifthElement), voice2number);
 
 		final Note sixthElement = Note.of(Pitch.of(Pitch.Base.B, -1, 4), Durations.SIXTEENTH);
-		builder.addToVoice(sixthElement, voice2number);
+		builder.addToVoice(new NoteBuilder(sixthElement), voice2number);
 
 		final Pattern patternWithTwoVoices = builder.build();
 		assertFalse(patternWithTwoVoices.isMonophonic());

--- a/src/test/java/org/wmn4j/notation/builders/ChordBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/ChordBuilderTest.java
@@ -32,6 +32,16 @@ class ChordBuilderTest {
 	}
 
 	@Test
+	void testWhenChordBuilderCreatedFromChordThenCorrectValuesAreSet() {
+		final Chord cMajor = Chord.of(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER),
+				Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER),
+				Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER));
+
+		ChordBuilder cMajorBuilder = new ChordBuilder(cMajor);
+		assertEquals(cMajor, cMajorBuilder.build());
+	}
+
+	@Test
 	void testConstructorWithListOfNoteBuilders() {
 		final ChordBuilder builder = new ChordBuilder(getCMajorAsNoteBuilders());
 

--- a/src/test/java/org/wmn4j/notation/builders/NoteBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/NoteBuilderTest.java
@@ -5,6 +5,7 @@ package org.wmn4j.notation.builders;
 
 import org.junit.jupiter.api.Test;
 import org.wmn4j.notation.elements.Articulation;
+import org.wmn4j.notation.elements.Duration;
 import org.wmn4j.notation.elements.Durations;
 import org.wmn4j.notation.elements.Marking;
 import org.wmn4j.notation.elements.Note;
@@ -19,6 +20,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class NoteBuilderTest {
+
+	@Test
+	void testWhenCreatingFromNoteThenCorrectValuesAreSet() {
+		final Note noteWithoutArticulations = Note.of(Pitch.Base.A, -1, 2, Duration.of(1, 12));
+		NoteBuilder builderWithoutArticulations = new NoteBuilder(noteWithoutArticulations);
+
+		assertEquals(noteWithoutArticulations.getPitch(), builderWithoutArticulations.getPitch());
+		assertEquals(noteWithoutArticulations.getDuration(), builderWithoutArticulations.getDuration());
+		assertEquals(noteWithoutArticulations.getArticulations(), builderWithoutArticulations.getArticulations());
+		assertEquals(noteWithoutArticulations, builderWithoutArticulations.build());
+
+		final Note noteWithArticulations = Note.of(Pitch.of(Pitch.Base.A, 1, 3), Duration.of(1, 16),
+				EnumSet.of(Articulation.ACCENT, Articulation.STACCATO));
+		NoteBuilder builderWithArticulations = new NoteBuilder(noteWithArticulations);
+
+		assertEquals(noteWithArticulations.getPitch(), builderWithArticulations.getPitch());
+		assertEquals(noteWithArticulations.getDuration(), builderWithArticulations.getDuration());
+		assertEquals(noteWithArticulations.getArticulations(), builderWithArticulations.getArticulations());
+		assertEquals(noteWithArticulations, builderWithArticulations.build());
+	}
 
 	@Test
 	void testBuildingBasicNote() {

--- a/src/test/java/org/wmn4j/notation/builders/RestBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/RestBuilderTest.java
@@ -1,0 +1,21 @@
+package org.wmn4j.notation.builders;
+
+import org.junit.jupiter.api.Test;
+import org.wmn4j.notation.elements.Duration;
+import org.wmn4j.notation.elements.Rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RestBuilderTest {
+
+	@Test
+	void testWhenCreatingRestBuilderFromRestCorrectValuesAreSet() {
+		final Rest eighthRest = Rest.of(Duration.of(1, 8));
+		RestBuilder eighthBuilder = new RestBuilder(eighthRest);
+		assertEquals(eighthRest, eighthBuilder.build());
+
+		final Rest tripletRest = Rest.of(Duration.of(1, 12));
+		RestBuilder tripletBuilder = new RestBuilder(tripletRest);
+		assertEquals(tripletRest, tripletBuilder.build());
+	}
+}


### PR DESCRIPTION
For consistency with all other builders, use DurationalBuilder instead of Durational in PatternBuilder. Add constructors for DurationalBuilders so they can be created from an existing Durational.