### PR TITLE
Use optionals for missing String values

### DIFF
--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlPatternWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlPatternWriterDom.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -217,11 +218,11 @@ final class MusicXmlPatternWriterDom extends MusicXmlWriterDom {
 	private String createPatternAnnotation(Pattern pattern) {
 		StringBuilder patternAnnotation = new StringBuilder();
 
-		final String patternName = pattern.getName();
+		final Optional<String> patternName = pattern.getName();
 		final Set<String> patternLabels = pattern.getLabels();
 
-		if (!patternName.isEmpty()) {
-			patternAnnotation.append(pattern.getName());
+		if (patternName.isPresent()) {
+			patternAnnotation.append(patternName.get());
 		}
 
 		if (!patternLabels.isEmpty()) {

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlScoreWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlScoreWriterDom.java
@@ -5,6 +5,8 @@ import org.wmn4j.notation.elements.Part;
 import org.wmn4j.notation.elements.Score;
 import org.wmn4j.notation.iterators.PartWiseScoreIterator;
 
+import java.util.Optional;
+
 final class MusicXmlScoreWriterDom extends MusicXmlWriterDom {
 
 	private final Score score;
@@ -82,13 +84,15 @@ final class MusicXmlScoreWriterDom extends MusicXmlWriterDom {
 
 			partElement.setAttribute(MusicXmlTags.PART_ID, partId);
 			final Element partName = getDocument().createElement(MusicXmlTags.PART_NAME);
-			partName.setTextContent(part.getName());
+			partName.setTextContent(part.getName().orElse(""));
 			partElement.appendChild(partName);
 
-			if (!part.getAttribute(Part.Attribute.ABBREVIATED_NAME).isEmpty()) {
-				final Element abbreviatedPartName = getDocument().createElement(MusicXmlTags.PART_NAME_ABBREVIATION);
-				abbreviatedPartName.setTextContent(part.getAttribute(Part.Attribute.ABBREVIATED_NAME));
-				partElement.appendChild(abbreviatedPartName);
+			Optional<String> abbreviatedPartName = part.getAttribute(Part.Attribute.ABBREVIATED_NAME);
+			if (abbreviatedPartName.isPresent()) {
+				final Element abbreviatedPartNameElemen = getDocument()
+						.createElement(MusicXmlTags.PART_NAME_ABBREVIATION);
+				abbreviatedPartNameElemen.setTextContent(abbreviatedPartName.get());
+				partElement.appendChild(abbreviatedPartNameElemen);
 			}
 
 			partList.appendChild(partElement);

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlScoreWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlScoreWriterDom.java
@@ -26,16 +26,17 @@ final class MusicXmlScoreWriterDom extends MusicXmlWriterDom {
 	protected void writeScoreAttributes(Element rootElement) {
 		if (!score.getTitle().isEmpty()) {
 			final Element workTitleElement = getDocument().createElement(MusicXmlTags.SCORE_WORK_TITLE);
-			workTitleElement.setTextContent(score.getTitle());
+			workTitleElement.setTextContent(score.getTitle().get());
 
 			final Element workElement = getDocument().createElement(MusicXmlTags.SCORE_WORK);
 			workElement.appendChild(workTitleElement);
 			rootElement.appendChild(workElement);
 		}
 
-		if (!score.getAttribute(Score.Attribute.MOVEMENT_TITLE).isEmpty()) {
+		Optional<String> movementTitle = score.getAttribute(Score.Attribute.MOVEMENT_TITLE);
+		if (movementTitle.isPresent()) {
 			final Element movementTitleElement = getDocument().createElement(MusicXmlTags.SCORE_MOVEMENT_TITLE);
-			movementTitleElement.setTextContent(score.getAttribute(Score.Attribute.MOVEMENT_TITLE));
+			movementTitleElement.setTextContent(movementTitle.get());
 			rootElement.appendChild(movementTitleElement);
 		}
 
@@ -49,21 +50,23 @@ final class MusicXmlScoreWriterDom extends MusicXmlWriterDom {
 	protected Element createIdentificationElement() {
 		final Element identificationElement = getDocument().createElement(MusicXmlTags.SCORE_IDENTIFICATION);
 
-		if (!score.getAttribute(Score.Attribute.COMPOSER).isEmpty()) {
+		Optional<String> composerName = score.getAttribute(Score.Attribute.COMPOSER);
+		if (composerName.isPresent()) {
 			final Element composerElement = getDocument().createElement(MusicXmlTags.SCORE_IDENTIFICATION_CREATOR);
 			composerElement.setAttribute(MusicXmlTags.SCORE_IDENTIFICATION_CREATOR_TYPE,
 					MusicXmlTags.SCORE_IDENTIFICATION_COMPOSER);
 
-			composerElement.setTextContent(score.getAttribute(Score.Attribute.COMPOSER));
+			composerElement.setTextContent(composerName.get());
 			identificationElement.appendChild(composerElement);
 		}
 
-		if (!score.getAttribute(Score.Attribute.ARRANGER).isEmpty()) {
+		Optional<String> arrangerName = score.getAttribute(Score.Attribute.ARRANGER);
+		if (arrangerName.isPresent()) {
 			final Element arrangerElement = getDocument().createElement(MusicXmlTags.SCORE_IDENTIFICATION_CREATOR);
 			arrangerElement.setAttribute(MusicXmlTags.SCORE_IDENTIFICATION_CREATOR_TYPE,
 					MusicXmlTags.SCORE_IDENTIFICATION_ARRANGER);
 
-			arrangerElement.setTextContent(score.getAttribute(Score.Attribute.ARRANGER));
+			arrangerElement.setTextContent(arrangerName.get());
 			identificationElement.appendChild(arrangerElement);
 		}
 

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -44,7 +45,7 @@ final class MonophonicPattern implements Pattern {
 		if (this.contents.stream().anyMatch((dur) -> (dur instanceof Chord))) {
 			throw new IllegalArgumentException("Contents contain a Chord. Contents must be monophonic");
 		}
-		this.name = Objects.requireNonNull(name);
+		this.name = name;
 		this.labels = Collections.unmodifiableSortedSet(new TreeSet<>(labels));
 	}
 
@@ -53,7 +54,7 @@ final class MonophonicPattern implements Pattern {
 	}
 
 	MonophonicPattern(List<? extends Durational> contents) {
-		this(contents, "", Collections.emptySet());
+		this(contents, null, Collections.emptySet());
 	}
 
 	@Override
@@ -62,8 +63,8 @@ final class MonophonicPattern implements Pattern {
 	}
 
 	@Override
-	public String getName() {
-		return name;
+	public Optional<String> getName() {
+		return Optional.ofNullable(name);
 	}
 
 	@Override

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -9,6 +9,7 @@ import org.wmn4j.notation.elements.Durational;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 
@@ -29,7 +30,7 @@ public interface Pattern {
 	 * @return a pattern with the given contents
 	 */
 	static Pattern of(List<? extends Durational> contents) {
-		return of(contents, "");
+		return of(contents, null);
 	}
 
 	/**
@@ -104,11 +105,11 @@ public interface Pattern {
 	/**
 	 * Returns the name of the pattern.
 	 * <p>
-	 * If the pattern does not have a name, then returns an empty string.
+	 * If the pattern does not have a name, then returns empty.
 	 *
 	 * @return the name of the pattern
 	 */
-	String getName();
+	Optional<String> getName();
 
 	/**
 	 * Returns the labels associated with this pattern in lexicographical order.

--- a/src/main/java/org/wmn4j/mir/PatternBuilder.java
+++ b/src/main/java/org/wmn4j/mir/PatternBuilder.java
@@ -24,7 +24,7 @@ public final class PatternBuilder {
 	private static final int DEFAULT_VOICE_NUMBER = MonophonicPattern.SINGLE_VOICE_NUMBER;
 	private final Map<Integer, List<DurationalBuilder>> voices;
 	private boolean isMonophonic = true;
-	private String name = "";
+	private String name = null;
 	private Set<String> labels = new HashSet<>();
 
 	/**

--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 final class PolyphonicPattern implements Pattern {
 
 	private static final Integer DEFAULT_VOICE_NUMBER = 1;
-	private static final String DEFAULT_NAME = "";
 
 	private final Map<Integer, List<Durational>> voices;
 	private final String name;
@@ -60,7 +59,7 @@ final class PolyphonicPattern implements Pattern {
 			}
 		}
 
-		this.name = Objects.requireNonNull(name);
+		this.name = name;
 		this.labels = Collections.unmodifiableSortedSet(new TreeSet<>(labels));
 	}
 
@@ -69,7 +68,7 @@ final class PolyphonicPattern implements Pattern {
 	}
 
 	PolyphonicPattern(Map<Integer, List<? extends Durational>> voices) {
-		this(voices, DEFAULT_NAME, Collections.emptySet());
+		this(voices, null, Collections.emptySet());
 	}
 
 	PolyphonicPattern(List<? extends Durational> voice, String name, Set<String> labels) {
@@ -82,12 +81,12 @@ final class PolyphonicPattern implements Pattern {
 		voicesCopy.put(DEFAULT_VOICE_NUMBER, voiceCopy);
 		voices = Collections.unmodifiableMap(voicesCopy);
 
-		this.name = Objects.requireNonNull(name);
+		this.name = name;
 		this.labels = Collections.unmodifiableSortedSet(new TreeSet<>(labels));
 	}
 
 	PolyphonicPattern(List<? extends Durational> voice) {
-		this(voice, DEFAULT_NAME, Collections.emptySet());
+		this(voice, null, Collections.emptySet());
 	}
 
 	@Override
@@ -96,8 +95,8 @@ final class PolyphonicPattern implements Pattern {
 	}
 
 	@Override
-	public String getName() {
-		return name;
+	public Optional<String> getName() {
+		return Optional.ofNullable(name);
 	}
 
 	@Override

--- a/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
+++ b/src/main/java/org/wmn4j/notation/builders/PartBuilder.java
@@ -129,8 +129,8 @@ public class PartBuilder {
 	 *
 	 * @return the name set in this builder
 	 */
-	public String getName() {
-		return this.partAttributes.get(Part.Attribute.NAME);
+	public Optional<String> getName() {
+		return Optional.ofNullable(partAttributes.getOrDefault(Part.Attribute.NAME, null));
 	}
 
 	private List<Measure> getBuiltMeasures(List<MeasureBuilder> builders) {

--- a/src/main/java/org/wmn4j/notation/elements/MultiStaffPart.java
+++ b/src/main/java/org/wmn4j/notation/elements/MultiStaffPart.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -62,7 +63,7 @@ public final class MultiStaffPart implements Part {
 	}
 
 	@Override
-	public String getName() {
+	public Optional<String> getName() {
 		return this.getAttribute(Part.Attribute.NAME);
 	}
 
@@ -102,12 +103,8 @@ public final class MultiStaffPart implements Part {
 	}
 
 	@Override
-	public String getAttribute(Attribute attribute) {
-		if (this.partAttributes.containsKey(attribute)) {
-			return this.partAttributes.get(attribute);
-		} else {
-			return "";
-		}
+	public Optional<String> getAttribute(Attribute attribute) {
+		return Optional.ofNullable(partAttributes.getOrDefault(attribute, null));
 	}
 
 	@Override

--- a/src/main/java/org/wmn4j/notation/elements/Part.java
+++ b/src/main/java/org/wmn4j/notation/elements/Part.java
@@ -8,6 +8,7 @@ import org.wmn4j.notation.iterators.PartIterator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 /**
  * Represents a part in a score.
@@ -22,11 +23,12 @@ public interface Part extends Iterable<Measure> {
 	}
 
 	/**
-	 * Returns the name of this part.
+	 * Returns the name of this part or empty if the part has
+	 * no name.
 	 *
 	 * @return name of this part
 	 */
-	String getName();
+	Optional<String> getName();
 
 	/**
 	 * Returns true if this part has multiple staves.
@@ -52,14 +54,14 @@ public interface Part extends Iterable<Measure> {
 	List<Integer> getStaffNumbers();
 
 	/**
-	 * Returns the given attribute. If the attribute is not present, returns an
-	 * empty string.
+	 * Returns the given attribute. If the attribute is not present, returns
+	 * empty.
 	 *
 	 * @param attribute the attribute to return from this part
-	 * @return the value of the attribute, or an empty string if the attribute is
+	 * @return the value of the attribute, or empty if the attribute is
 	 * not set
 	 */
-	String getAttribute(Attribute attribute);
+	Optional<String> getAttribute(Attribute attribute);
 
 	/**
 	 * Returns the number of measures in this part. The count is based on the

--- a/src/main/java/org/wmn4j/notation/elements/Score.java
+++ b/src/main/java/org/wmn4j/notation/elements/Score.java
@@ -259,7 +259,7 @@ public final class Score implements Iterable<Part> {
 
 			StringBuilder partsListBuilder = new StringBuilder();
 			for (Integer partIndex : patternPosition.getPartIndices()) {
-				partsListBuilder.append(getPart(partIndex).getName()).append(" ");
+				partsListBuilder.append(getPart(partIndex).getName().orElse("")).append(" ");
 			}
 
 			String partsList = partsListBuilder.toString().trim();

--- a/src/main/java/org/wmn4j/notation/elements/Score.java
+++ b/src/main/java/org/wmn4j/notation/elements/Score.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -89,10 +90,11 @@ public final class Score implements Iterable<Part> {
 
 	/**
 	 * Returns the main title of this score.
+	 * If no title is set, then returns empty.
 	 *
 	 * @return the main title of this score
 	 */
-	public String getTitle() {
+	public Optional<String> getTitle() {
 		return this.getAttribute(Attribute.TITLE);
 	}
 
@@ -136,17 +138,13 @@ public final class Score implements Iterable<Part> {
 
 	/**
 	 * Returns the value of the given attribute.
+	 * If the attribute is not present, then returns empty.
 	 *
 	 * @param attribute the type of the attribute
-	 * @return the text associated with attribute if the attribute is present. Empty
-	 * string otherwise.
+	 * @return the value of the attribute if the attribute is present
 	 */
-	public String getAttribute(Attribute attribute) {
-		if (this.scoreAttr.containsKey(attribute)) {
-			return this.scoreAttr.get(attribute);
-		}
-
-		return "";
+	public Optional<String> getAttribute(Attribute attribute) {
+		return Optional.ofNullable(scoreAttr.getOrDefault(attribute, null));
 	}
 
 	/**
@@ -196,7 +194,7 @@ public final class Score implements Iterable<Part> {
 	@Override
 	public String toString() {
 		final StringBuilder strBuilder = new StringBuilder();
-		strBuilder.append("Score ").append(getTitle()).append("\n");
+		strBuilder.append("Score ").append(getTitle().get()).append("\n");
 
 		for (int i = 0; i < parts.size(); ++i) {
 			strBuilder.append(parts.get(i).toString());

--- a/src/main/java/org/wmn4j/notation/elements/SingleStaffPart.java
+++ b/src/main/java/org/wmn4j/notation/elements/SingleStaffPart.java
@@ -11,6 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 /**
  * Represents a part with a single staff in a score. This class is immutable.
@@ -61,7 +62,7 @@ public final class SingleStaffPart implements Part {
 	}
 
 	@Override
-	public String getName() {
+	public Optional<String> getName() {
 		return this.getAttribute(Attribute.NAME);
 	}
 
@@ -113,12 +114,8 @@ public final class SingleStaffPart implements Part {
 	}
 
 	@Override
-	public String getAttribute(Attribute attribute) {
-		if (this.partAttributes.containsKey(attribute)) {
-			return this.partAttributes.get(attribute);
-		} else {
-			return "";
-		}
+	public Optional<String> getAttribute(Attribute attribute) {
+		return Optional.ofNullable(partAttributes.getOrDefault(attribute, null));
 	}
 
 	@Override

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
@@ -44,7 +44,7 @@ class MusicXmlFileChecks {
 	 * Expects the contents of the file "singleC.xml"
 	 */
 	static void assertSingleNoteScoreReadCorrectly(Score score) {
-		assertEquals("Single C", score.getAttribute(Score.Attribute.MOVEMENT_TITLE));
+		assertEquals("Single C", score.getAttribute(Score.Attribute.MOVEMENT_TITLE).get());
 		assertEquals(1, score.getParts().size());
 
 		final Part part = score.getParts().get(0);
@@ -130,8 +130,8 @@ class MusicXmlFileChecks {
 	 * Expects the contents of the file "twoPartsAndMeasures.xml"
 	 */
 	static void assertScoreWithMultiplePartsReadCorrectly(Score score) {
-		assertEquals("Multistaff test file", score.getAttribute(Score.Attribute.MOVEMENT_TITLE));
-		assertEquals("TestFile Composer", score.getAttribute(Score.Attribute.COMPOSER));
+		assertEquals("Multistaff test file", score.getAttribute(Score.Attribute.MOVEMENT_TITLE).get());
+		assertEquals("TestFile Composer", score.getAttribute(Score.Attribute.COMPOSER).get());
 		assertEquals(2, score.getParts().size());
 
 		final SingleStaffPart partOne = (SingleStaffPart) score.getParts().get(0);
@@ -501,10 +501,10 @@ class MusicXmlFileChecks {
 	 * Expectes the contents of "attribute_reading_test.xml".
 	 */
 	static void assertScoreHasExpectedAttributes(Score score) {
-		assertEquals("Composition title", score.getTitle());
-		assertEquals("Composer name", score.getAttribute(Score.Attribute.COMPOSER));
-		assertEquals("Movement title", score.getAttribute(Score.Attribute.MOVEMENT_TITLE));
-		assertEquals("Arranger name", score.getAttribute(Score.Attribute.ARRANGER));
+		assertEquals("Composition title", score.getTitle().get());
+		assertEquals("Composer name", score.getAttribute(Score.Attribute.COMPOSER).get());
+		assertEquals("Movement title", score.getAttribute(Score.Attribute.MOVEMENT_TITLE).get());
+		assertEquals("Arranger name", score.getAttribute(Score.Attribute.ARRANGER).get());
 
 		List<Part> parts = score.getParts();
 		assertEquals(2, parts.size());

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
@@ -51,7 +51,7 @@ class MusicXmlFileChecks {
 		assertTrue(part instanceof SingleStaffPart);
 		final SingleStaffPart spart = (SingleStaffPart) part;
 		final Staff staff = spart.getStaff();
-		assertEquals("Part1", part.getName());
+		assertEquals("Part1", part.getName().get());
 		assertEquals(1, staff.getMeasures().size());
 
 		final Measure measure = staff.getMeasures().get(0);
@@ -77,7 +77,7 @@ class MusicXmlFileChecks {
 		assertTrue(part instanceof SingleStaffPart);
 		final SingleStaffPart spart = (SingleStaffPart) part;
 		final Staff staff = spart.getStaff();
-		assertEquals("Part1", part.getName());
+		assertEquals("Part1", part.getName().get());
 		assertEquals(2, staff.getMeasures().size());
 
 		// Verify data of measure one
@@ -136,7 +136,7 @@ class MusicXmlFileChecks {
 
 		final SingleStaffPart partOne = (SingleStaffPart) score.getParts().get(0);
 		final Staff staffOne = partOne.getStaff();
-		assertEquals("Part1", partOne.getName());
+		assertEquals("Part1", partOne.getName().get());
 		assertEquals(2, staffOne.getMeasures().size());
 
 		// Verify data of measure one of staff one
@@ -171,7 +171,7 @@ class MusicXmlFileChecks {
 
 		final SingleStaffPart partTwo = (SingleStaffPart) score.getParts().get(1);
 		final Staff staffTwo = partTwo.getStaff();
-		assertEquals("Part2", partTwo.getName());
+		assertEquals("Part2", partTwo.getName().get());
 		assertEquals(2, staffTwo.getMeasures().size());
 
 		// Verify data of measure one of staff two
@@ -317,10 +317,10 @@ class MusicXmlFileChecks {
 		MultiStaffPart multiStaff = null;
 		SingleStaffPart singleStaff = null;
 		for (Part part : score) {
-			if (part.getName().equals("MultiStaff")) {
+			if (part.getName().get().equals("MultiStaff")) {
 				multiStaff = (MultiStaffPart) part;
 			}
-			if (part.getName().equals("SingleStaff")) {
+			if (part.getName().get().equals("SingleStaff")) {
 				singleStaff = (SingleStaffPart) part;
 			}
 		}
@@ -451,22 +451,29 @@ class MusicXmlFileChecks {
 
 		final Measure topStaffMeasure = topStaff.getMeasure(1);
 
-		assertTrue(((Note) topStaffMeasure.get(1,0)).hasArticulation(Articulation.FERMATA));
-		assertFalse(((Note) topStaffMeasure.get(1,1)).hasArticulations());
-		assertTrue(((Note) topStaffMeasure.get(1,2)).hasArticulation(Articulation.ACCENT));
-		assertTrue(((Note) topStaffMeasure.get(1,2)).hasArticulation(Articulation.TENUTO));
-		assertFalse(((Note) topStaffMeasure.get(1,3)).hasArticulations());
+		assertTrue(((Note) topStaffMeasure.get(1, 0)).hasArticulation(Articulation.FERMATA));
+		assertFalse(((Note) topStaffMeasure.get(1, 1)).hasArticulations());
+		assertTrue(((Note) topStaffMeasure.get(1, 2)).hasArticulation(Articulation.ACCENT));
+		assertTrue(((Note) topStaffMeasure.get(1, 2)).hasArticulation(Articulation.TENUTO));
+		assertFalse(((Note) topStaffMeasure.get(1, 3)).hasArticulations());
 
 		final Measure bottomStaffMeasure = bottomStaff.getMeasure(1);
 		final int bottomStaffSingleVoiceNumber = bottomStaffMeasure.getVoiceNumbers().get(0);
 
-		assertTrue(((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber,0)).hasArticulation(Articulation.STACCATO));
-		assertTrue(((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber,1)).hasArticulation(Articulation.TENUTO));
-		assertTrue(((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber,2)).hasArticulation(Articulation.ACCENT));
-		assertTrue(((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber,3)).hasArticulation(Articulation.STACCATO));
-		assertTrue(((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber,3)).hasArticulation(Articulation.TENUTO));
-		assertTrue(((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber,3)).hasArticulation(Articulation.ACCENT));
-		assertTrue(((Chord) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber,4)).hasArticulation(Articulation.TENUTO));
+		assertTrue(((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber, 0))
+				.hasArticulation(Articulation.STACCATO));
+		assertTrue(
+				((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber, 1)).hasArticulation(Articulation.TENUTO));
+		assertTrue(
+				((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber, 2)).hasArticulation(Articulation.ACCENT));
+		assertTrue(((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber, 3))
+				.hasArticulation(Articulation.STACCATO));
+		assertTrue(
+				((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber, 3)).hasArticulation(Articulation.TENUTO));
+		assertTrue(
+				((Note) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber, 3)).hasArticulation(Articulation.ACCENT));
+		assertTrue(
+				((Chord) bottomStaffMeasure.get(bottomStaffSingleVoiceNumber, 4)).hasArticulation(Articulation.TENUTO));
 	}
 
 	/*
@@ -502,12 +509,12 @@ class MusicXmlFileChecks {
 		List<Part> parts = score.getParts();
 		assertEquals(2, parts.size());
 		Part part1 = parts.get(0);
-		assertEquals("Part name 1", part1.getName());
-		assertEquals("Short part name 1", part1.getAttribute(Part.Attribute.ABBREVIATED_NAME));
+		assertEquals("Part name 1", part1.getName().get());
+		assertEquals("Short part name 1", part1.getAttribute(Part.Attribute.ABBREVIATED_NAME).get());
 
 		Part part2 = parts.get(1);
-		assertEquals("Part name 2", part2.getName());
-		assertEquals("Short part name 2", part2.getAttribute(Part.Attribute.ABBREVIATED_NAME));
+		assertEquals("Part name 2", part2.getName().get());
+		assertEquals("Short part name 2", part2.getAttribute(Part.Attribute.ABBREVIATED_NAME).get());
 	}
 
 	/*

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -304,9 +303,7 @@ class MonophonicPatternTest {
 
 		final String patternName = "A";
 		final Pattern patternWithName = new MonophonicPattern(referenceNotes, patternName);
-		assertEquals(patternName, patternWithName.getName());
-
-		assertThrows(NullPointerException.class, () -> new MonophonicPattern(referenceNotes, null));
+		assertEquals(patternName, patternWithName.getName().get());
 	}
 
 	@Test
@@ -324,7 +321,7 @@ class MonophonicPatternTest {
 
 		final Pattern patternWithLabels = new MonophonicPattern(referenceNotes, patternName, labels);
 
-		assertEquals(patternName, patternWithLabels.getName());
+		assertEquals(patternName, patternWithLabels.getName().get());
 		assertEquals(labels, patternWithLabels.getLabels());
 
 		labels.add("Label not in pattern");
@@ -344,7 +341,7 @@ class MonophonicPatternTest {
 		final Pattern patternWithLabels = new PolyphonicPattern(referenceNotes, patternName,
 				labels);
 
-		assertEquals(patternName, patternWithLabels.getName());
+		assertEquals(patternName, patternWithLabels.getName().get());
 		assertTrue(patternWithLabels.hasLabel(testLabelA));
 		assertTrue(patternWithLabels.hasLabel(testLabelB));
 		assertFalse(patternWithLabels.hasLabel("Label not in pattern"));

--- a/src/test/java/org/wmn4j/mir/PatternBuilderTest.java
+++ b/src/test/java/org/wmn4j/mir/PatternBuilderTest.java
@@ -147,7 +147,7 @@ class PatternBuilderTest {
 		builder.setName(patternName);
 
 		final Pattern pattern = builder.build();
-		assertEquals(patternName, pattern.getName());
+		assertEquals(patternName, pattern.getName().get());
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
@@ -476,9 +476,7 @@ public class PolyphonicPatternTest {
 
 		final String patternName = "A";
 		final Pattern patternWithName = new PolyphonicPattern(createReferencePatternVoices(), patternName);
-		assertEquals(patternName, patternWithName.getName());
-
-		assertThrows(NullPointerException.class, () -> new PolyphonicPattern(createReferencePatternVoices(), null));
+		assertEquals(patternName, patternWithName.getName().get());
 	}
 
 	@Test
@@ -497,7 +495,7 @@ public class PolyphonicPatternTest {
 		final Pattern patternWithLabels = new PolyphonicPattern(createReferencePatternVoices(), patternName,
 				labels);
 
-		assertEquals(patternName, patternWithLabels.getName());
+		assertEquals(patternName, patternWithLabels.getName().get());
 		assertEquals(labels, patternWithLabels.getLabels());
 
 		labels.add("Label not in pattern");
@@ -517,7 +515,7 @@ public class PolyphonicPatternTest {
 		final Pattern patternWithLabels = new PolyphonicPattern(createReferencePatternVoices(), patternName,
 				labels);
 
-		assertEquals(patternName, patternWithLabels.getName());
+		assertEquals(patternName, patternWithLabels.getName().get());
 		assertTrue(patternWithLabels.hasLabel(testLabelA));
 		assertTrue(patternWithLabels.hasLabel(testLabelB));
 		assertFalse(patternWithLabels.hasLabel("Label not in pattern"));

--- a/src/test/java/org/wmn4j/notation/builders/ScoreBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/builders/ScoreBuilderTest.java
@@ -32,8 +32,8 @@ class ScoreBuilderTest {
 		}
 
 		final Score score = builder.build();
-		assertEquals(ScoreTest.SCORE_NAME, score.getTitle());
-		assertEquals(ScoreTest.COMPOSER_NAME, score.getAttribute(Score.Attribute.COMPOSER));
+		assertEquals(ScoreTest.SCORE_NAME, score.getTitle().get());
+		assertEquals(ScoreTest.COMPOSER_NAME, score.getAttribute(Score.Attribute.COMPOSER).get());
 
 		assertEquals(5, score.getPartCount());
 	}

--- a/src/test/java/org/wmn4j/notation/elements/MultiStaffPartTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/MultiStaffPartTest.java
@@ -37,7 +37,8 @@ class MultiStaffPartTest {
 
 		final String partName = "Test staff";
 		final MultiStaffPart part = MultiStaffPart.of(partName, testStavesCopy);
-		assertEquals(partName, part.getName());
+		assertTrue(part.getName().isPresent());
+		assertEquals(partName, part.getName().get());
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/notation/elements/ScoreTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/ScoreTest.java
@@ -72,11 +72,11 @@ public class ScoreTest {
 	@Test
 	void testGetAttribute() {
 		final Score score = Score.of(getTestAttributes(), getTestParts(5, 5));
-		assertEquals(SCORE_NAME, score.getAttribute(Score.Attribute.TITLE));
-		assertEquals(SUBTITLE, score.getAttribute(Score.Attribute.SUBTITLE));
-		assertEquals(COMPOSER_NAME, score.getAttribute(Score.Attribute.COMPOSER));
-		assertEquals(ARRANGER, score.getAttribute(Score.Attribute.ARRANGER));
-		assertEquals(MOVEMENT_NAME, score.getAttribute(Score.Attribute.MOVEMENT_TITLE));
+		assertEquals(SCORE_NAME, score.getAttribute(Score.Attribute.TITLE).get());
+		assertEquals(SUBTITLE, score.getAttribute(Score.Attribute.SUBTITLE).get());
+		assertEquals(COMPOSER_NAME, score.getAttribute(Score.Attribute.COMPOSER).get());
+		assertEquals(ARRANGER, score.getAttribute(Score.Attribute.ARRANGER).get());
+		assertEquals(MOVEMENT_NAME, score.getAttribute(Score.Attribute.MOVEMENT_TITLE).get());
 	}
 
 	@Test
@@ -89,9 +89,10 @@ public class ScoreTest {
 		parts.add(parts.get(0));
 		assertEquals(5, score.getPartCount(), "Adding part to the list used for creating score changed score.");
 
-		assertEquals(SCORE_NAME, score.getTitle(), "Score title was incorrect before trying to modify");
+		assertEquals(SCORE_NAME, score.getTitle().get(), "Score title was incorrect before trying to modify");
 		attributes.put(Score.Attribute.TITLE, "ModifiedName");
-		assertEquals(SCORE_NAME, score.getTitle(), "Score title was changed by modifying map used for creating score");
+		assertEquals(SCORE_NAME, score.getTitle().get(),
+				"Score title was changed by modifying map used for creating score");
 
 		final List<Part> scoreParts = score.getParts();
 		try {

--- a/src/test/java/org/wmn4j/notation/elements/SingleStaffPartTest.java
+++ b/src/test/java/org/wmn4j/notation/elements/SingleStaffPartTest.java
@@ -63,7 +63,8 @@ class SingleStaffPartTest {
 	@Test
 	void testGetName() {
 		final SingleStaffPart part = SingleStaffPart.of("Test part", Staff.of(this.measures));
-		assertEquals("Test part", part.getName());
+		assertTrue(part.getName().isPresent());
+		assertEquals("Test part", part.getName().get());
 	}
 
 	@Test


### PR DESCRIPTION
Use empty optional to denote the absence of a string value instead of using empty strings. This makes the absence of values a bit clearer.