### PR TITLE
Remove methods and improve javadoc

### DIFF
--- a/src/main/java/org/wmn4j/analysis/harmony/Chromagram.java
+++ b/src/main/java/org/wmn4j/analysis/harmony/Chromagram.java
@@ -38,7 +38,7 @@ public final class Chromagram {
 			throw new IllegalArgumentException("All values in a chromagram must be non-negative.");
 		}
 
-		this.profile = new EnumMap(profile);
+		this.profile = new EnumMap<>(profile);
 	}
 
 	/**

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlPatternWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlPatternWriterDom.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 final class MusicXmlPatternWriterDom extends MusicXmlWriterDom {
 
@@ -105,9 +104,10 @@ final class MusicXmlPatternWriterDom extends MusicXmlWriterDom {
 			final int measureNumberBeforeStaffCreation = nextMeasureNumber;
 
 			for (int voiceIndex = 0; voiceIndex < patternVoiceNumbers.size(); ++voiceIndex) {
-				List<Durational> voice = pattern.getVoice(patternVoiceNumbers.get(voiceIndex));
+				final int voiceNumber = patternVoiceNumbers.get(voiceIndex);
+				Iterable<Durational> voice = pattern.getVoice(voiceNumber);
 
-				Duration voiceDuration = getVoiceDuration(voice);
+				Duration voiceDuration = getVoiceDuration(voice, pattern.getVoiceSize(voiceNumber));
 
 				staveContents.get(voiceIndex)
 						.addAll(voiceToMeasureList(voice.iterator(), voiceDuration.equals(longestVoiceDuration)));
@@ -131,12 +131,14 @@ final class MusicXmlPatternWriterDom extends MusicXmlWriterDom {
 		return parts;
 	}
 
-	private Duration getVoiceDuration(List<Durational> voice) {
-		List<Duration> voiceDurations = voice.stream()
-				.map(Durational::getDuration).collect(
-						Collectors.toList());
+	private Duration getVoiceDuration(Iterable<Durational> voice, int voiceSize) {
+		List<Duration> durations = new ArrayList<>(voiceSize);
 
-		return Duration.sumOf(voiceDurations);
+		for (Durational durational : voice) {
+			durations.add(durational.getDuration());
+		}
+
+		return Duration.sumOf(durations);
 	}
 
 	private Duration getLongestVoiceDuration(Pattern pattern) {
@@ -144,7 +146,8 @@ final class MusicXmlPatternWriterDom extends MusicXmlWriterDom {
 		Duration longestVoiceDuration = null;
 
 		for (int voiceIndex = 0; voiceIndex < patternVoiceNumbers.size(); ++voiceIndex) {
-			Duration totalDuration = getVoiceDuration(pattern.getVoice(patternVoiceNumbers.get(voiceIndex)));
+			final int voiceNumber = patternVoiceNumbers.get(voiceIndex);
+			Duration totalDuration = getVoiceDuration(pattern.getVoice(voiceNumber), pattern.getVoiceSize(voiceNumber));
 
 			if (longestVoiceDuration == null) {
 				longestVoiceDuration = totalDuration;

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlPatternWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlPatternWriterDom.java
@@ -68,7 +68,7 @@ final class MusicXmlPatternWriterDom extends MusicXmlWriterDom {
 
 	private List<Part> fromPatterns(Collection<Pattern> patterns) {
 
-		int maxNumberOfVoices = patterns.stream().map(Pattern::getNumberOfVoices).max(Integer::compareTo).orElseThrow();
+		int maxNumberOfVoices = patterns.stream().map(Pattern::getVoiceCount).max(Integer::compareTo).orElseThrow();
 
 		if (maxNumberOfVoices == 1) {
 			return Collections.singletonList(singleVoicePatternsToPart(patterns));

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlPatternWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlPatternWriterDom.java
@@ -52,7 +52,9 @@ final class MusicXmlPatternWriterDom extends MusicXmlWriterDom {
 	MusicXmlPatternWriterDom(Collection<Pattern> patterns) {
 		Collection<Durational> allDurationals = new ArrayList<>();
 		patterns.forEach(pattern -> {
-			allDurationals.addAll(pattern.getContents());
+			for (Durational dur : pattern) {
+				allDurationals.add(dur);
+			}
 		});
 
 		this.divisions = computeDivisions(allDurationals.iterator());
@@ -79,7 +81,7 @@ final class MusicXmlPatternWriterDom extends MusicXmlWriterDom {
 	private Part singleVoicePatternsToPart(Collection<Pattern> patterns) {
 		final List<Measure> allMeasures = new ArrayList<>();
 		for (Pattern pattern : patterns) {
-			List<Measure> measures = voiceToMeasureList(pattern.getContents().iterator(), true);
+			List<Measure> measures = voiceToMeasureList(pattern.iterator(), true);
 			allMeasures.addAll(measures);
 			final Integer firstMeasureNumber = measures.get(0).getNumber();
 			newSystemBeginningMeasureNumbers.add(firstMeasureNumber);

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
@@ -242,7 +242,7 @@ final class MusicXmlReaderDom implements MusicXmlReader {
 	 */
 	private void readMeasuresIntoPartBuilder(PartBuilder partBuilder, Node partNode) {
 
-		final int staves = getNumberOfStaves(partNode);
+		final int staves = getStaffCount(partNode);
 		final Map<Integer, Context> contexts = new HashMap<>();
 
 		// Create the context containers for the staves.
@@ -269,7 +269,7 @@ final class MusicXmlReaderDom implements MusicXmlReader {
 	/**
 	 * Find the number of staves in the part.
 	 */
-	private int getNumberOfStaves(Node partNode) {
+	private int getStaffCount(Node partNode) {
 
 		// If the number of staves is not defined in the first attributes node,
 		// then use default.

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
@@ -343,7 +343,8 @@ abstract class MusicXmlWriterDom implements MusicXmlWriter {
 		for (Integer voiceNumber : voiceNumbers) {
 
 			Duration cumulatedDuration = null;
-			for (Durational dur : measure.getVoice(voiceNumber)) {
+			for (int indexInVoice = 0; indexInVoice < measure.getVoiceSize(voiceNumber); ++indexInVoice) {
+				Durational dur = measure.get(voiceNumber, indexInVoice);
 				if (cumulatedDuration == null) {
 					cumulatedDuration = dur.getDuration();
 				} else {

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
@@ -544,9 +544,9 @@ abstract class MusicXmlWriterDom implements MusicXmlWriter {
 		Element keySigElement = getDocument().createElement(MusicXmlTags.MEAS_ATTR_KEY);
 		Element fifthsElement = getDocument().createElement(MusicXmlTags.MEAS_ATTR_KEY_FIFTHS);
 
-		int fifths = keySignature.getNumberOfSharps();
+		int fifths = keySignature.getSharpCount();
 		if (fifths == 0) {
-			fifths = keySignature.getNumberOfFlats() * -1;
+			fifths = keySignature.getFlatCount() * -1;
 		}
 		fifthsElement.setTextContent(Integer.toString(fifths));
 

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -88,7 +88,7 @@ final class MonophonicPattern implements Pattern {
 	}
 
 	@Override
-	public int getNumberOfVoices() {
+	public int getVoiceCount() {
 		return 1;
 	}
 

--- a/src/main/java/org/wmn4j/mir/MonophonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/MonophonicPattern.java
@@ -11,6 +11,7 @@ import org.wmn4j.notation.Pitched;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -107,6 +108,21 @@ final class MonophonicPattern implements Pattern {
 	}
 
 	@Override
+	public Durational get(int voiceNumber, int index) {
+		if (voiceNumber != SINGLE_VOICE_NUMBER) {
+			throw new NoSuchElementException("No voice with number " + voiceNumber + " in pattern");
+		}
+		return contents.get(index);
+
+	}
+
+	@Override
+	public int getVoiceSize(int voiceNumber) {
+		return contents.size();
+
+	}
+
+	@Override
 	public boolean hasLabel(String label) {
 		return labels.contains(label);
 	}
@@ -191,30 +207,30 @@ final class MonophonicPattern implements Pattern {
 		return false;
 	}
 
-	static boolean areVoicesEqualInDurations(List<Durational> voiceA, List<Durational> voiceB) {
-		if (voiceA.size() == voiceB.size()) {
-			for (int i = 0; i < voiceA.size(); ++i) {
+	static boolean areVoicesEqualInDurations(Iterable<Durational> voiceA, Iterable<Durational> voiceB) {
+		Iterator<Durational> iterA = voiceA.iterator();
+		Iterator<Durational> iterB = voiceB.iterator();
 
-				final Durational durationalInThis = voiceA.get(i);
-				final Durational durationalInOther = voiceB.get(i);
+		while (iterA.hasNext() && iterB.hasNext()) {
 
-				final boolean bothAreOfSameType =
-						(durationalInThis.isRest() && durationalInOther.isRest()) || (!durationalInThis.isRest()
-								&& !durationalInOther.isRest());
+			final Durational durationalInThis = iterA.next();
+			final Durational durationalInOther = iterB.next();
 
-				if (!bothAreOfSameType) {
-					return false;
-				}
+			final boolean bothAreOfSameType =
+					(durationalInThis.isRest() && durationalInOther.isRest()) || (!durationalInThis.isRest()
+							&& !durationalInOther.isRest());
 
-				if (!voiceA.get(i).getDuration().equals(voiceB.get(i).getDuration())) {
-					return false;
-				}
+			if (!bothAreOfSameType) {
+				return false;
 			}
 
-			return true;
+			if (!durationalInThis.getDuration().equals(durationalInOther.getDuration())) {
+				return false;
+			}
 		}
 
-		return false;
+		// Check that both iterators are finished, otherwise the number of elements is not equal.
+		return iterA.hasNext() == iterB.hasNext();
 	}
 
 	@Override

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -137,9 +137,9 @@ public interface Pattern {
 	int getVoiceCount();
 
 	/**
-	 * Returns the voice numbers in this pattern from smallest to greatest.
+	 * Returns the voice numbers in this pattern in ascending order.
 	 *
-	 * @return the voice numbers in this pattern from smallest to greatest
+	 * @return the voice numbers in this pattern in ascending order
 	 */
 	List<Integer> getVoiceNumbers();
 

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -145,11 +145,32 @@ public interface Pattern {
 
 	/**
 	 * Returns the contents of the voice with the given number.
+	 * The contents of the voice are iterated in their temporal order, i.e.,
+	 * from left to right int notation.
 	 *
 	 * @param voiceNumber the number of the voice whose contents are returned
 	 * @return the contents of the voice with the given number
 	 */
-	List<Durational> getVoice(int voiceNumber);
+	Iterable<Durational> getVoice(int voiceNumber);
+
+	/**
+	 * Returns the notation element at the given index in the voice
+	 * with the given number.
+	 *
+	 * @param voiceNumber the number of the voice from which to retrieve the notation element
+	 * @param index       the index of the notation element in the voice
+	 * @return the notation element at the given index in the voice
+	 * with the given number
+	 */
+	Durational get(int voiceNumber, int index);
+
+	/**
+	 * Returns the number of notation elements in the voice with the given number.
+	 *
+	 * @param voiceNumber the number of the voice for which the size is returned
+	 * @return the number of notation elements in the voice with the given number
+	 */
+	int getVoiceSize(int voiceNumber);
 
 	/**
 	 * Returns true if this pattern has the given labels.

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -21,9 +21,14 @@ import java.util.SortedSet;
  * pattern there can be multiple notes occurring at the same time in chords or
  * in multiple voices.
  * <p>
+ * The notation elements in monophonic pattern are iterated in temporal orders.
+ * For polyphonic patterns the elements are iterated first by iterating through the
+ * voice with the smallest number and then moving on the voice with the next greatest
+ * number and so on.
+ * <p>
  * Implementations of this interface are required to be thread-safe.
  */
-public interface Pattern {
+public interface Pattern extends Iterable<Durational> {
 
 	/**
 	 * Returns a pattern with the given contents.
@@ -95,14 +100,6 @@ public interface Pattern {
 	static Pattern of(Map<Integer, List<? extends Durational>> voices) {
 		return new PolyphonicPattern(voices);
 	}
-
-	/**
-	 * Returns the contents of this pattern. For monophonic patterns the contents are returned in temporal order. For
-	 * polyphonic patterns the order is not specified.
-	 *
-	 * @return the contents of this pattern
-	 */
-	List<Durational> getContents();
 
 	/**
 	 * Returns the name of the pattern.
@@ -229,4 +226,11 @@ public interface Pattern {
 	 * @return true if this pattern has the same durations as the other pattern
 	 */
 	boolean equalsInDurations(Pattern other);
+
+	/**
+	 * Returns the number of durational notation elements in this pattern.
+	 *
+	 * @return the number of durational notation elements in this pattern
+	 */
+	int size();
 }

--- a/src/main/java/org/wmn4j/mir/Pattern.java
+++ b/src/main/java/org/wmn4j/mir/Pattern.java
@@ -134,7 +134,7 @@ public interface Pattern {
 	 *
 	 * @return the number of voices in this pattern
 	 */
-	int getNumberOfVoices();
+	int getVoiceCount();
 
 	/**
 	 * Returns the voice numbers in this pattern from smallest to greatest.

--- a/src/main/java/org/wmn4j/mir/PatternBuilder.java
+++ b/src/main/java/org/wmn4j/mir/PatternBuilder.java
@@ -44,7 +44,7 @@ public final class PatternBuilder {
 	 * @param builder the durational builder that is added to the default voice in this builder
 	 */
 	public void add(DurationalBuilder builder) {
-		addToVoice(builder, DEFAULT_VOICE_NUMBER);
+		addToVoice(DEFAULT_VOICE_NUMBER, builder);
 	}
 
 	/**
@@ -52,10 +52,10 @@ public final class PatternBuilder {
 	 * polyphonic patterns, the {@link PatternBuilder#add add} method can be used for constructing
 	 * monophonic patterns.
 	 *
-	 * @param durationalBuilder the durational builder that is added to the given voice in this builder
 	 * @param voice             the number of the voice to which the durational builder is added
+	 * @param durationalBuilder the durational builder that is added to the given voice in this builder
 	 */
-	public void addToVoice(DurationalBuilder durationalBuilder, int voice) {
+	public void addToVoice(int voice, DurationalBuilder durationalBuilder) {
 		if (!voices.containsKey(voice)) {
 			voices.put(voice, new ArrayList<>());
 		}

--- a/src/main/java/org/wmn4j/mir/PatternPosition.java
+++ b/src/main/java/org/wmn4j/mir/PatternPosition.java
@@ -53,7 +53,7 @@ public final class PatternPosition {
 	 *
 	 * @return the number of notation elements the referred pattern contains
 	 */
-	public int getSize() {
+	public int size() {
 		return (int) positionsPerPart.values().stream().flatMap(Set::stream).count();
 	}
 

--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -110,7 +110,7 @@ final class PolyphonicPattern implements Pattern {
 	}
 
 	@Override
-	public int getNumberOfVoices() {
+	public int getVoiceCount() {
 		return voices.size();
 	}
 
@@ -146,7 +146,7 @@ final class PolyphonicPattern implements Pattern {
 
 	private boolean containsEqualVoices(Pattern other,
 			BiFunction<List<Durational>, List<Durational>, Boolean> voiceEquality) {
-		if (other.getNumberOfVoices() != getNumberOfVoices()) {
+		if (other.getVoiceCount() != getVoiceCount()) {
 			return false;
 		}
 

--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -91,11 +91,6 @@ final class PolyphonicPattern implements Pattern {
 	}
 
 	@Override
-	public List<Durational> getContents() {
-		return voices.values().stream().flatMap(voice -> voice.stream()).collect(Collectors.toList());
-	}
-
-	@Override
 	public Optional<String> getName() {
 		return Optional.ofNullable(name);
 	}
@@ -145,7 +140,7 @@ final class PolyphonicPattern implements Pattern {
 		return containsEqualVoices((Pattern) o, PolyphonicPattern::iterablesEquals);
 	}
 
-	private static boolean iterablesEquals(Iterable<Durational> a, Iterable<Durational> b) {
+	static boolean iterablesEquals(Iterable<Durational> a, Iterable<Durational> b) {
 		Iterator<Durational> iterA = a.iterator();
 		Iterator<Durational> iterB = b.iterator();
 
@@ -340,7 +335,23 @@ final class PolyphonicPattern implements Pattern {
 	}
 
 	@Override
+	public int size() {
+		return voices.values().stream().map(List::size).reduce(0, Integer::sum);
+	}
+
+	@Override
 	public int hashCode() {
 		return Objects.hash(voices);
+	}
+
+	@Override
+	public Iterator<Durational> iterator() {
+		List<Durational> iterable = new ArrayList<>();
+
+		for (Integer voiceNumber : getVoiceNumbers()) {
+			iterable.addAll(voices.get(voiceNumber));
+		}
+
+		return iterable.iterator();
 	}
 }

--- a/src/main/java/org/wmn4j/notation/KeySignature.java
+++ b/src/main/java/org/wmn4j/notation/KeySignature.java
@@ -19,8 +19,8 @@ public final class KeySignature {
 
 	/**
 	 * Returns a key signature with the given sharps and flats. For common key
-	 * signatures use the ones defined in {@link KeySignatures}. This is mostly
-	 * intended for creating custom key signatures.
+	 * signatures using the ones defined in {@link KeySignatures} is recommended.
+	 * This is method is intended for creating non-standard key signatures.
 	 *
 	 * @param sharps the Pitch.Base names that should be raised. For example, for
 	 *               G-major this list consists only of Pitch.Base.F.
@@ -91,18 +91,18 @@ public final class KeySignature {
 	}
 
 	/**
-	 * Returns the sharps in this key signature.
+	 * Returns the sharps in this key signature from left to right.
 	 *
-	 * @return the sharps in this key signature.
+	 * @return the sharps in this key signature from left to right
 	 */
 	public List<Pitch.Base> getSharps() {
 		return new ArrayList<>(this.sharps);
 	}
 
 	/**
-	 * Returns the flats in this key signature.
+	 * Returns the flats in this key signature from left to right.
 	 *
-	 * @return the flats in this key signature
+	 * @return the flats in this key signature from left to right
 	 */
 	public List<Pitch.Base> getFlats() {
 		return new ArrayList<>(this.flats);

--- a/src/main/java/org/wmn4j/notation/KeySignature.java
+++ b/src/main/java/org/wmn4j/notation/KeySignature.java
@@ -77,7 +77,7 @@ public final class KeySignature {
 	 *
 	 * @return the number of sharps in this key signature
 	 */
-	public int getNumberOfSharps() {
+	public int getSharpCount() {
 		return this.sharps.size();
 	}
 
@@ -86,7 +86,7 @@ public final class KeySignature {
 	 *
 	 * @return the number of flats in this key signature
 	 */
-	public int getNumberOfFlats() {
+	public int getFlatCount() {
 		return this.flats.size();
 	}
 

--- a/src/main/java/org/wmn4j/notation/Measure.java
+++ b/src/main/java/org/wmn4j/notation/Measure.java
@@ -124,8 +124,8 @@ public final class Measure implements Iterable<Durational> {
 	}
 
 	/**
-	 * Returns the voice numbers in this measure. Voice numbers are not necessarily
-	 * consecutive and do not begin from 0.
+	 * Returns the voice numbers in this measure in ascending order.
+	 * Voice numbers are not necessarily consecutive and do not need begin from 0.
 	 *
 	 * @return list of the voice numbers used in this measure.
 	 */

--- a/src/main/java/org/wmn4j/notation/Measure.java
+++ b/src/main/java/org/wmn4j/notation/Measure.java
@@ -134,16 +134,6 @@ public final class Measure implements Iterable<Durational> {
 	}
 
 	/**
-	 * Returns the voice with the given measure.
-	 *
-	 * @param voiceNumber the number of the voice
-	 * @return the voice at the given index voiceNumber
-	 */
-	public List<Durational> getVoice(int voiceNumber) {
-		return this.voices.get(voiceNumber);
-	}
-
-	/**
 	 * Returns the number of durational notation elements in the voice with the
 	 * given number.
 	 *
@@ -356,7 +346,7 @@ public final class Measure implements Iterable<Durational> {
 			}
 
 			final int voiceNumber = this.voiceNumbers.get(this.voiceNumberIndex);
-			return !this.measure.getVoice(voiceNumber).isEmpty();
+			return this.measure.getVoiceSize(voiceNumber) > 0;
 		}
 
 		@Override
@@ -366,12 +356,11 @@ public final class Measure implements Iterable<Durational> {
 			}
 
 			this.prevVoiceNumber = this.voiceNumbers.get(this.voiceNumberIndex);
-			final List<Durational> currentVoice = this.measure.getVoice(this.prevVoiceNumber);
 			this.prevPositionInVoice = this.positionInVoice;
-			final Durational next = currentVoice.get(this.prevPositionInVoice);
+			final Durational next = measure.get(prevVoiceNumber, prevPositionInVoice);
 
 			++this.positionInVoice;
-			if (this.positionInVoice == currentVoice.size()) {
+			if (this.positionInVoice == measure.getVoiceSize(prevVoiceNumber)) {
 				++this.voiceNumberIndex;
 				this.positionInVoice = 0;
 			}

--- a/src/main/java/org/wmn4j/notation/MeasureBuilder.java
+++ b/src/main/java/org/wmn4j/notation/MeasureBuilder.java
@@ -248,7 +248,7 @@ public class MeasureBuilder {
 	 *
 	 * @return number or voices in this builder
 	 */
-	public int getNumberOfVoices() {
+	public int getVoiceCount() {
 		return this.voices.size();
 	}
 

--- a/src/main/java/org/wmn4j/notation/MeasureBuilder.java
+++ b/src/main/java/org/wmn4j/notation/MeasureBuilder.java
@@ -205,27 +205,6 @@ public class MeasureBuilder {
 	}
 
 	/**
-	 * Add new empty voice to this builder.
-	 *
-	 * @return reference to this builder.
-	 */
-	public MeasureBuilder addVoice() {
-		this.voices.put(this.voices.keySet().size(), new ArrayList<>());
-		return this;
-	}
-
-	/**
-	 * Add possibly voice to this builder.
-	 *
-	 * @param voice new voice to be added to this
-	 * @return reference to this builder
-	 */
-	public MeasureBuilder addVoice(List<DurationalBuilder> voice) {
-		this.voices.put(this.voices.keySet().size(), voice);
-		return this;
-	}
-
-	/**
 	 * Append a {@link DurationalBuilder} to the voice with the given number. If
 	 * voice does not exist it is created.
 	 *

--- a/src/main/java/org/wmn4j/notation/MeasureBuilder.java
+++ b/src/main/java/org/wmn4j/notation/MeasureBuilder.java
@@ -4,11 +4,9 @@
 package org.wmn4j.notation;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -237,8 +235,8 @@ public class MeasureBuilder {
 	 *
 	 * @return the set of voice numbers in this builder
 	 */
-	public Set<Integer> getVoiceNumbers() {
-		return Collections.unmodifiableSet(this.voices.keySet());
+	public List<Integer> getVoiceNumbers() {
+		return new ArrayList<>(this.voices.keySet());
 	}
 
 	/**

--- a/src/main/java/org/wmn4j/notation/Note.java
+++ b/src/main/java/org/wmn4j/notation/Note.java
@@ -148,22 +148,22 @@ public final class Note implements Durational, Pitched {
 	}
 
 	/**
-	 * Returns an unmodifiable view of all articulations defined for this note.
+	 * Returns all articulations defined for this note.
 	 *
 	 * @return the articulations defined for this note
 	 */
-	public Collection<Articulation> getArticulations() {
+	public Set<Articulation> getArticulations() {
 		return this.articulations;
 	}
 
 	/**
-	 * Returns an unmodifiable view of all marking connections that affect this note.
+	 * Returns all markings that affect this note.
 	 *
-	 * @return all marking connections that affect this note
+	 * @return all markings that affect this note
 	 */
-	public Collection<Marking> getMarkings() {
+	public Set<Marking> getMarkings() {
 		return markingConnections.stream().map(connection -> connection.getMarking())
-				.collect(Collectors.toUnmodifiableList());
+				.collect(Collectors.toUnmodifiableSet());
 	}
 
 	/**

--- a/src/main/java/org/wmn4j/notation/Part.java
+++ b/src/main/java/org/wmn4j/notation/Part.java
@@ -47,11 +47,9 @@ public interface Part extends Iterable<Measure> {
 	int getStaffCount();
 
 	/**
-	 * Returns the numbers of the staves in this part.
-	 * <p>
-	 * The staff numbers are ordered from smallest to greatest.
+	 * Returns the numbers of the staves in this part in ascending order.
 	 *
-	 * @return the numbers of the staves in this part
+	 * @return the numbers of the staves in this part in ascending order
 	 */
 	List<Integer> getStaffNumbers();
 

--- a/src/main/java/org/wmn4j/notation/PartBuilder.java
+++ b/src/main/java/org/wmn4j/notation/PartBuilder.java
@@ -11,7 +11,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 /**
@@ -21,7 +22,7 @@ import java.util.stream.Collectors;
  */
 public class PartBuilder {
 
-	private final Map<Integer, List<MeasureBuilder>> staveContents = new HashMap<>();
+	private final SortedMap<Integer, List<MeasureBuilder>> staveContents = new TreeMap<>();
 	private final Map<Part.Attribute, String> partAttributes = new HashMap<>();
 	private static final int SINGLE_STAFF_NUMBER = SingleStaffPart.STAFF_NUMBER;
 
@@ -112,12 +113,12 @@ public class PartBuilder {
 	}
 
 	/**
-	 * Returns the staff numbers set in this builder.
+	 * Returns the staff numbers set in this builder in ascending order.
 	 *
-	 * @return the staff numbers set in this builder
+	 * @return the staff numbers set in this builder in ascending order
 	 */
-	public Set<Integer> getStaffNumbers() {
-		return staveContents.keySet();
+	public List<Integer> getStaffNumbers() {
+		return new ArrayList<>(staveContents.keySet());
 	}
 
 	/**

--- a/src/main/java/org/wmn4j/notation/Score.java
+++ b/src/main/java/org/wmn4j/notation/Score.java
@@ -110,15 +110,6 @@ public final class Score implements Iterable<Part> {
 	}
 
 	/**
-	 * Returns the parts in this score.
-	 *
-	 * @return the parts in this score
-	 */
-	public List<Part> getParts() {
-		return this.parts;
-	}
-
-	/**
 	 * Returns the part at the index.
 	 *
 	 * @param index the number of the part in this score

--- a/src/main/java/org/wmn4j/notation/Staff.java
+++ b/src/main/java/org/wmn4j/notation/Staff.java
@@ -105,20 +105,6 @@ public final class Staff implements Iterable<Measure> {
 	}
 
 	/**
-	 * Returns the measures in this staff as a list from smallest measure number to
-	 * greatest.
-	 *
-	 * @return the measures in this staff
-	 */
-	public List<Measure> getMeasures() {
-		if (!this.hasPickupMeasure()) {
-			return this.measures.subList(1, this.measures.size());
-		}
-
-		return this.measures;
-	}
-
-	/**
 	 * Returns true if this staff contains a pickup measure.
 	 *
 	 * @return true if this staff begins with a pickup measure, false otherwise

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
@@ -45,9 +45,9 @@ class MusicXmlFileChecks {
 	 */
 	static void assertSingleNoteScoreReadCorrectly(Score score) {
 		assertEquals("Single C", score.getAttribute(Score.Attribute.MOVEMENT_TITLE).get());
-		assertEquals(1, score.getParts().size());
+		assertEquals(1, score.getPartCount());
 
-		final Part part = score.getParts().get(0);
+		final Part part = score.getPart(0);
 		assertTrue(part instanceof SingleStaffPart);
 		final SingleStaffPart spart = (SingleStaffPart) part;
 		final Staff staff = spart.getStaff();
@@ -70,9 +70,9 @@ class MusicXmlFileChecks {
 	 * Expects the contents of the file "twoMeasures.xml"
 	 */
 	static void assertChordsAndMultipleVoicesReadCorrectly(Score score) {
-		assertEquals(1, score.getParts().size());
+		assertEquals(1, score.getPartCount());
 
-		final Part part = score.getParts().get(0);
+		final Part part = score.getPart(0);
 		assertTrue(part instanceof SingleStaffPart);
 		final SingleStaffPart spart = (SingleStaffPart) part;
 		final Staff staff = spart.getStaff();
@@ -128,9 +128,9 @@ class MusicXmlFileChecks {
 	static void assertScoreWithMultiplePartsReadCorrectly(Score score) {
 		assertEquals("Multistaff test file", score.getAttribute(Score.Attribute.MOVEMENT_TITLE).get());
 		assertEquals("TestFile Composer", score.getAttribute(Score.Attribute.COMPOSER).get());
-		assertEquals(2, score.getParts().size());
+		assertEquals(2, score.getPartCount());
 
-		final SingleStaffPart partOne = (SingleStaffPart) score.getParts().get(0);
+		final SingleStaffPart partOne = (SingleStaffPart) score.getPart(0);
 		final Staff staffOne = partOne.getStaff();
 		assertEquals("Part1", partOne.getName().get());
 		assertEquals(2, staffOne.getMeasureCount());
@@ -163,7 +163,7 @@ class MusicXmlFileChecks {
 		assertEquals(Rest.of(Durations.QUARTER), staffOneMeasureTwo.get(1, 0));
 		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF), staffOneMeasureTwo.get(1, 1));
 
-		final SingleStaffPart partTwo = (SingleStaffPart) score.getParts().get(1);
+		final SingleStaffPart partTwo = (SingleStaffPart) score.getPart(1);
 		final Staff staffTwo = partTwo.getStaff();
 		assertEquals("Part2", partTwo.getName().get());
 		assertEquals(2, staffTwo.getMeasureCount());
@@ -200,8 +200,8 @@ class MusicXmlFileChecks {
 	 */
 	static void assertBarlinesReadCorrectly(Score score) {
 
-		assertEquals(1, score.getParts().size());
-		final SingleStaffPart part = (SingleStaffPart) score.getParts().get(0);
+		assertEquals(1, score.getPartCount());
+		final SingleStaffPart part = (SingleStaffPart) score.getPart(0);
 
 		assertEquals(Barline.SINGLE, part.getMeasure(1).getRightBarline());
 		assertEquals(Barline.NONE, part.getMeasure(1).getLeftBarline());
@@ -235,7 +235,7 @@ class MusicXmlFileChecks {
 	 * Expects the contents of the file "clefs.xml"
 	 */
 	static void assertClefsReadCorrectly(Score score) {
-		final SingleStaffPart part = (SingleStaffPart) score.getParts().get(0);
+		final SingleStaffPart part = (SingleStaffPart) score.getPart(0);
 
 		assertEquals(Clefs.G, part.getMeasure(1).getClef());
 		assertFalse(part.getMeasure(1).containsClefChanges());
@@ -264,7 +264,7 @@ class MusicXmlFileChecks {
 	 * Expects the contents of the file "multiStaffClefs.xml"
 	 */
 	static void assertMultiStaffClefsReadCorrectlyToScore(Score score) {
-		final MultiStaffPart part = (MultiStaffPart) score.getParts().get(0);
+		final MultiStaffPart part = (MultiStaffPart) score.getPart(0);
 		final Staff upper = part.getStaff(1);
 		final Staff lower = part.getStaff(2);
 
@@ -294,7 +294,7 @@ class MusicXmlFileChecks {
 	 * Expects the contents of the file "keysigs.xml"
 	 */
 	static void assertKeySignaturesReadToScoreCorrectly(Score score) {
-		final SingleStaffPart part = (SingleStaffPart) score.getParts().get(0);
+		final SingleStaffPart part = (SingleStaffPart) score.getPart(0);
 
 		assertEquals(KeySignatures.CMAJ_AMIN, part.getMeasure(1).getKeySignature());
 		assertEquals(KeySignatures.GMAJ_EMIN, part.getMeasure(2).getKeySignature());
@@ -344,7 +344,7 @@ class MusicXmlFileChecks {
 	 */
 	static void assertTimeSignaturesReadCorrectly(Score score) {
 		assertEquals(1, score.getPartCount());
-		final SingleStaffPart part = (SingleStaffPart) score.getParts().get(0);
+		final SingleStaffPart part = (SingleStaffPart) score.getPart(0);
 		assertEquals(TimeSignature.of(2, 2), part.getMeasure(1).getTimeSignature());
 		assertEquals(TimeSignature.of(3, 4), part.getMeasure(2).getTimeSignature());
 		assertEquals(TimeSignature.of(6, 8), part.getMeasure(3).getTimeSignature());
@@ -355,7 +355,7 @@ class MusicXmlFileChecks {
 	 * Expects the contents of the file "scoreIteratorTesting.xml"
 	 */
 	static void assertTimeSignatureChangeReadCorrectly(Score score) {
-		final SingleStaffPart part = (SingleStaffPart) score.getParts().get(0);
+		final SingleStaffPart part = (SingleStaffPart) score.getPart(0);
 		final Durational n = part.getMeasure(2).get(1, 0);
 		assertEquals(Durations.EIGHTH, n.getDuration());
 	}
@@ -364,7 +364,7 @@ class MusicXmlFileChecks {
 	 * Expects the contents of the file "tieTesting.xml"
 	 */
 	static void assertTiedNotesReadCorrectly(Score score) {
-		final SingleStaffPart part = (SingleStaffPart) score.getParts().get(0);
+		final SingleStaffPart part = (SingleStaffPart) score.getPart(0);
 
 		final Measure firstMeasure = part.getMeasure(1);
 		final Note first = (Note) firstMeasure.get(1, 0);
@@ -473,7 +473,7 @@ class MusicXmlFileChecks {
 	 */
 	static void assertPickupMeasureReadCorrectly(Score score) {
 		assertEquals(1, score.getPartCount());
-		Part part = score.getParts().get(0);
+		Part part = score.getPart(0);
 		assertFalse(part.isMultiStaff());
 		assertEquals(4, part.getMeasureCount());
 		assertEquals(3, part.getFullMeasureCount());
@@ -498,13 +498,12 @@ class MusicXmlFileChecks {
 		assertEquals("Movement title", score.getAttribute(Score.Attribute.MOVEMENT_TITLE).get());
 		assertEquals("Arranger name", score.getAttribute(Score.Attribute.ARRANGER).get());
 
-		List<Part> parts = score.getParts();
-		assertEquals(2, parts.size());
-		Part part1 = parts.get(0);
+		assertEquals(2, score.getPartCount());
+		Part part1 = score.getPart(0);
 		assertEquals("Part name 1", part1.getName().get());
 		assertEquals("Short part name 1", part1.getAttribute(Part.Attribute.ABBREVIATED_NAME).get());
 
-		Part part2 = parts.get(1);
+		Part part2 = score.getPart(1);
 		assertEquals("Part name 2", part2.getName().get());
 		assertEquals("Short part name 2", part2.getAttribute(Part.Attribute.ABBREVIATED_NAME).get());
 	}

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
@@ -52,9 +52,9 @@ class MusicXmlFileChecks {
 		final SingleStaffPart spart = (SingleStaffPart) part;
 		final Staff staff = spart.getStaff();
 		assertEquals("Part1", part.getName().get());
-		assertEquals(1, staff.getMeasures().size());
+		assertEquals(1, staff.getMeasureCount());
 
-		final Measure measure = staff.getMeasures().get(0);
+		final Measure measure = staff.getMeasure(1);
 		assertEquals(1, measure.getNumber());
 		assertEquals(1, measure.getVoiceCount());
 		assertEquals(TimeSignatures.FOUR_FOUR, measure.getTimeSignature());
@@ -77,10 +77,10 @@ class MusicXmlFileChecks {
 		final SingleStaffPart spart = (SingleStaffPart) part;
 		final Staff staff = spart.getStaff();
 		assertEquals("Part1", part.getName().get());
-		assertEquals(2, staff.getMeasures().size());
+		assertEquals(2, staff.getMeasureCount());
 
 		// Verify data of measure one
-		final Measure measureOne = staff.getMeasures().get(0);
+		final Measure measureOne = staff.getMeasure(1);
 		assertEquals(1, measureOne.getNumber());
 		assertEquals(1, measureOne.getVoiceCount());
 		assertEquals(TimeSignatures.FOUR_FOUR, measureOne.getTimeSignature());
@@ -103,7 +103,7 @@ class MusicXmlFileChecks {
 		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHTH_TRIPLET), measureOne.get(1, 7));
 
 		// Verify data of measure two
-		final Measure measureTwo = staff.getMeasures().get(1);
+		final Measure measureTwo = staff.getMeasure(2);
 		assertEquals(2, measureTwo.getNumber());
 		assertEquals(2, measureTwo.getVoiceCount());
 		assertEquals(TimeSignatures.FOUR_FOUR, measureTwo.getTimeSignature());
@@ -133,10 +133,10 @@ class MusicXmlFileChecks {
 		final SingleStaffPart partOne = (SingleStaffPart) score.getParts().get(0);
 		final Staff staffOne = partOne.getStaff();
 		assertEquals("Part1", partOne.getName().get());
-		assertEquals(2, staffOne.getMeasures().size());
+		assertEquals(2, staffOne.getMeasureCount());
 
 		// Verify data of measure one of staff one
-		final Measure staffOneMeasureOne = staffOne.getMeasures().get(0);
+		final Measure staffOneMeasureOne = staffOne.getMeasure(1);
 		assertEquals(1, staffOneMeasureOne.getNumber());
 		assertEquals(1, staffOneMeasureOne.getVoiceCount());
 		assertEquals(TimeSignatures.THREE_FOUR, staffOneMeasureOne.getTimeSignature());
@@ -150,7 +150,7 @@ class MusicXmlFileChecks {
 		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER), staffOneMeasureOne.get(1, 1));
 
 		// Verify data of measure two of staff one
-		final Measure staffOneMeasureTwo = staffOne.getMeasures().get(1);
+		final Measure staffOneMeasureTwo = staffOne.getMeasure(2);
 		assertEquals(2, staffOneMeasureTwo.getNumber());
 		assertEquals(1, staffOneMeasureTwo.getVoiceCount());
 		assertEquals(TimeSignatures.THREE_FOUR, staffOneMeasureTwo.getTimeSignature());
@@ -166,10 +166,10 @@ class MusicXmlFileChecks {
 		final SingleStaffPart partTwo = (SingleStaffPart) score.getParts().get(1);
 		final Staff staffTwo = partTwo.getStaff();
 		assertEquals("Part2", partTwo.getName().get());
-		assertEquals(2, staffTwo.getMeasures().size());
+		assertEquals(2, staffTwo.getMeasureCount());
 
 		// Verify data of measure one of staff two
-		final Measure staffTwoMeasureOne = staffTwo.getMeasures().get(0);
+		final Measure staffTwoMeasureOne = staffTwo.getMeasure(1);
 		assertEquals(1, staffTwoMeasureOne.getNumber());
 		assertEquals(1, staffTwoMeasureOne.getVoiceCount());
 		assertEquals(TimeSignatures.THREE_FOUR, staffTwoMeasureOne.getTimeSignature());
@@ -182,7 +182,7 @@ class MusicXmlFileChecks {
 		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 3), Durations.HALF.addDot()), staffTwoMeasureOne.get(1, 0));
 
 		// Verify data of measure two of staff two
-		final Measure staffTwoMeasureTwo = staffTwo.getMeasures().get(1);
+		final Measure staffTwoMeasureTwo = staffTwo.getMeasure(2);
 		assertEquals(2, staffTwoMeasureTwo.getNumber());
 		assertEquals(1, staffTwoMeasureTwo.getVoiceCount());
 		assertEquals(TimeSignatures.THREE_FOUR, staffTwoMeasureTwo.getTimeSignature());

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
@@ -62,9 +62,8 @@ class MusicXmlFileChecks {
 		assertEquals(Barline.SINGLE, measure.getRightBarline());
 		assertEquals(Clefs.G, measure.getClef());
 
-		final List<Durational> voice = measure.getVoice(1);
-		assertEquals(1, voice.size());
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.WHOLE), voice.get(0));
+		assertEquals(1, measure.getVoiceSize(1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.WHOLE), measure.get(1, 0));
 	}
 
 	/*
@@ -90,19 +89,18 @@ class MusicXmlFileChecks {
 		assertEquals(Clefs.G, measureOne.getClef());
 
 		// Verify notes of measure one
-		List<Durational> voiceOne = measureOne.getVoice(1);
-		assertEquals(8, voiceOne.size());
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceOne.get(0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH), voiceOne.get(1));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH), voiceOne.get(2));
-		assertEquals(Rest.of(Durations.EIGHTH), voiceOne.get(3));
+		assertEquals(8, measureOne.getVoiceSize(1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), measureOne.get(1, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH), measureOne.get(1, 1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH), measureOne.get(1, 2));
+		assertEquals(Rest.of(Durations.EIGHTH), measureOne.get(1, 3));
 		final Chord cMajor = Chord.of(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH),
 				Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH),
 				Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH));
-		assertEquals(cMajor, voiceOne.get(4));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHTH_TRIPLET), voiceOne.get(5));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHTH_TRIPLET), voiceOne.get(6));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHTH_TRIPLET), voiceOne.get(7));
+		assertEquals(cMajor, measureOne.get(1, 4));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHTH_TRIPLET), measureOne.get(1, 5));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHTH_TRIPLET), measureOne.get(1, 6));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHTH_TRIPLET), measureOne.get(1, 7));
 
 		// Verify data of measure two
 		final Measure measureTwo = staff.getMeasures().get(1);
@@ -114,16 +112,14 @@ class MusicXmlFileChecks {
 		assertEquals(Clefs.G, measureTwo.getClef());
 
 		// Verify notes of measure two
-		voiceOne = measureTwo.getVoice(1);
-		assertEquals(2, voiceOne.size());
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.HALF), voiceOne.get(0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.HALF), voiceOne.get(1));
+		assertEquals(2, measureTwo.getVoiceSize(1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.HALF), measureTwo.get(1, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.HALF), measureTwo.get(1, 1));
 
-		final List<Durational> voiceTwo = measureTwo.getVoice(2);
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(1));
-		assertEquals(Rest.of(Durations.QUARTER), voiceTwo.get(2));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), voiceTwo.get(3));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), measureTwo.get(2, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), measureTwo.get(2, 1));
+		assertEquals(Rest.of(Durations.QUARTER), measureTwo.get(2, 2));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), measureTwo.get(2, 3));
 	}
 
 	/*
@@ -150,9 +146,8 @@ class MusicXmlFileChecks {
 
 		// Verify contents of measure one of staff one
 		assertEquals(1, staffOneMeasureOne.getVoiceCount());
-		final List<Durational> voiceMOne = staffOneMeasureOne.getVoice(1);
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF), voiceMOne.get(0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER), voiceMOne.get(1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF), staffOneMeasureOne.get(1, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER), staffOneMeasureOne.get(1, 1));
 
 		// Verify data of measure two of staff one
 		final Measure staffOneMeasureTwo = staffOne.getMeasures().get(1);
@@ -165,9 +160,8 @@ class MusicXmlFileChecks {
 
 		// Verify contents of measure one of staff one
 		assertEquals(1, staffOneMeasureTwo.getVoiceCount());
-		final List<Durational> voiceM2 = staffOneMeasureTwo.getVoice(1);
-		assertEquals(Rest.of(Durations.QUARTER), voiceM2.get(0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF), voiceM2.get(1));
+		assertEquals(Rest.of(Durations.QUARTER), staffOneMeasureTwo.get(1, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF), staffOneMeasureTwo.get(1, 1));
 
 		final SingleStaffPart partTwo = (SingleStaffPart) score.getParts().get(1);
 		final Staff staffTwo = partTwo.getStaff();
@@ -185,8 +179,7 @@ class MusicXmlFileChecks {
 
 		// Verify contents of measure one of staff two
 		assertEquals(1, staffTwoMeasureOne.getVoiceCount());
-		final List<Durational> voiceMOneS2 = staffTwoMeasureOne.getVoice(1);
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 3), Durations.HALF.addDot()), voiceMOneS2.get(0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 3), Durations.HALF.addDot()), staffTwoMeasureOne.get(1, 0));
 
 		// Verify data of measure two of staff two
 		final Measure staffTwoMeasureTwo = staffTwo.getMeasures().get(1);
@@ -199,8 +192,7 @@ class MusicXmlFileChecks {
 
 		// Verify contents of measure two of staff two
 		assertEquals(1, staffTwoMeasureTwo.getVoiceCount());
-		final List<Durational> voiceM2S2 = staffTwoMeasureTwo.getVoice(1);
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 3), Durations.HALF.addDot()), voiceM2S2.get(0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 3), Durations.HALF.addDot()), staffTwoMeasureTwo.get(1, 0));
 	}
 
 	/*
@@ -338,9 +330,9 @@ class MusicXmlFileChecks {
 
 		for (Measure measure : multiStaff) {
 			assertTrue(measure.isSingleVoice());
-			final List<Durational> voice = measure.getVoice(measure.getVoiceNumbers().get(0));
-			assertEquals(1, voice.size());
-			assertTrue(voice.get(0).equals(expectedNote));
+			final int voiceNumber = measure.getVoiceNumbers().get(0);
+			assertEquals(1, measure.getVoiceSize(voiceNumber));
+			assertTrue(measure.get(voiceNumber, 0).equals(expectedNote));
 			++measureCount;
 		}
 
@@ -364,7 +356,7 @@ class MusicXmlFileChecks {
 	 */
 	static void assertTimeSignatureChangeReadCorrectly(Score score) {
 		final SingleStaffPart part = (SingleStaffPart) score.getParts().get(0);
-		final Durational n = part.getMeasure(2).getVoice(1).get(0);
+		final Durational n = part.getMeasure(2).get(1, 0);
 		assertEquals(Durations.EIGHTH, n.getDuration());
 	}
 

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlPatternWriterDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlPatternWriterDomTest.java
@@ -111,7 +111,7 @@ class MusicXmlPatternWriterDomTest {
 			Clef expectedClef) {
 		assertEquals(1, patternsAsScore.getPartCount());
 
-		final Part part = patternsAsScore.getParts().get(0);
+		final Part part = patternsAsScore.getPart(0);
 		assertPartHasCorrectContents(expectedContents, part, expectedClef);
 	}
 
@@ -153,7 +153,7 @@ class MusicXmlPatternWriterDomTest {
 
 		assertEquals(1, patternsAsScore.getPartCount());
 
-		final Part part = patternsAsScore.getParts().get(0);
+		final Part part = patternsAsScore.getPart(0);
 		assertFalse(part.isMultiStaff());
 
 		List<Durational> partContents = new ArrayList<>();

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlPatternWriterDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlPatternWriterDomTest.java
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.wmn4j.TestHelper;
 import org.wmn4j.io.ParsingFailureException;
 import org.wmn4j.mir.Pattern;
-import org.wmn4j.TestHelper;
 import org.wmn4j.notation.Chord;
 import org.wmn4j.notation.Clef;
 import org.wmn4j.notation.Clefs;
@@ -124,7 +124,10 @@ class MusicXmlPatternWriterDomTest {
 		List<Durational> partContents = new ArrayList<>();
 		for (Measure measure : part) {
 			assertEquals(1, measure.getVoiceCount());
-			partContents.addAll(measure.getVoice(measure.getVoiceNumbers().get(0)));
+			final int voiceNumber = measure.getVoiceNumbers().get(0);
+			for (int i = 0; i < measure.getVoiceSize(voiceNumber); ++i) {
+				partContents.add(measure.get(voiceNumber, i));
+			}
 
 			// Check the clef only if it has been specified
 			if (expectedClef != null) {
@@ -158,7 +161,10 @@ class MusicXmlPatternWriterDomTest {
 			assertEquals(1, measure.getVoiceCount());
 			// Full measure rests are used for padding, so they should be ignored.
 			if (!measure.isFullMeasureRest()) {
-				partContents.addAll(measure.getVoice(measure.getVoiceNumbers().get(0)));
+				final int voiceNumber = measure.getVoiceNumbers().get(0);
+				for (int i = 0; i < measure.getVoiceSize(voiceNumber); ++i) {
+					partContents.add(measure.get(voiceNumber, i));
+				}
 			}
 		}
 

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -89,7 +89,7 @@ class MonophonicPatternTest {
 	@Test
 	void testGetNumberOfVoicesReturnsOne() {
 		final Pattern pattern = new MonophonicPattern(this.referenceNotes);
-		assertEquals(1, pattern.getNumberOfVoices());
+		assertEquals(1, pattern.getVoiceCount());
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -101,8 +101,13 @@ class MonophonicPatternTest {
 	@Test
 	void testGetVoiceReturnsContents() {
 		final Pattern pattern = new MonophonicPattern(this.referenceNotes);
-		List<Durational> voiceContents = pattern.getVoice(pattern.getVoiceNumbers().get(0));
-		assertEquals(this.referenceNotes, voiceContents);
+		Iterable<Durational> voiceContents = pattern.getVoice(pattern.getVoiceNumbers().get(0));
+		List<Durational> voiceContentsAsList = new ArrayList<>();
+		for (Durational durational : voiceContents) {
+			voiceContentsAsList.add(durational);
+		}
+
+		assertEquals(this.referenceNotes, voiceContentsAsList);
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -73,17 +73,9 @@ class MonophonicPatternTest {
 		List<Durational> contents = new ArrayList<>(referenceNotes);
 
 		final Pattern pattern = new MonophonicPattern(contents);
-		assertEquals(contents, pattern.getContents());
 
 		contents.add(Rest.of(Durations.QUARTER));
-		assertNotEquals(pattern.getContents().size(), contents.size());
-
-		try {
-			pattern.getContents().add(Rest.of(Durations.QUARTER));
-			fail("Was able to add to contents of pattern");
-		} catch (Exception e) {
-			// Pass, exception is expected.
-		}
+		assertNotEquals(pattern.size(), contents.size());
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/mir/PatternBuilderTest.java
+++ b/src/test/java/org/wmn4j/mir/PatternBuilderTest.java
@@ -3,15 +3,12 @@ package org.wmn4j.mir;
 import org.junit.jupiter.api.Test;
 import org.wmn4j.notation.Chord;
 import org.wmn4j.notation.ChordBuilder;
-import org.wmn4j.notation.Durational;
 import org.wmn4j.notation.Durations;
 import org.wmn4j.notation.Note;
 import org.wmn4j.notation.NoteBuilder;
 import org.wmn4j.notation.Pitch;
 import org.wmn4j.notation.Rest;
 import org.wmn4j.notation.RestBuilder;
-
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -44,14 +41,14 @@ class PatternBuilderTest {
 		assertTrue(builder.isMonophonic());
 		final Pattern pattern = builder.build();
 
-		final List<Durational> patternContents = pattern.getContents();
+		final int voiceNumber = pattern.getVoiceNumbers().get(0);
 
-		assertEquals(firstElement, patternContents.get(0));
-		assertEquals(secondElement, patternContents.get(1));
-		assertEquals(thirdElement, patternContents.get(2));
-		assertEquals(fourthElement, patternContents.get(3));
-		assertEquals(fifthElement, patternContents.get(4));
-		assertEquals(sixthElement, patternContents.get(5));
+		assertEquals(firstElement, pattern.get(voiceNumber, 0));
+		assertEquals(secondElement, pattern.get(voiceNumber, 1));
+		assertEquals(thirdElement, pattern.get(voiceNumber, 2));
+		assertEquals(fourthElement, pattern.get(voiceNumber, 3));
+		assertEquals(fifthElement, pattern.get(voiceNumber, 4));
+		assertEquals(sixthElement, pattern.get(voiceNumber, 5));
 
 		assertTrue(pattern.isMonophonic());
 	}
@@ -82,14 +79,16 @@ class PatternBuilderTest {
 		assertFalse(builder.isMonophonic());
 		final Pattern pattern = builder.build();
 
-		final List<Durational> patternContents = pattern.getContents();
+		assertEquals(1, pattern.getVoiceCount());
 
-		assertEquals(firstElement, patternContents.get(0));
-		assertEquals(secondElement, patternContents.get(1));
-		assertEquals(thirdElement, patternContents.get(2));
-		assertEquals(fourthElement, patternContents.get(3));
-		assertEquals(fifthElement, patternContents.get(4));
-		assertEquals(sixthElement, patternContents.get(5));
+		final int voiceNumber = pattern.getVoiceNumbers().get(0);
+
+		assertEquals(firstElement, pattern.get(voiceNumber, 0));
+		assertEquals(secondElement, pattern.get(voiceNumber, 1));
+		assertEquals(thirdElement, pattern.get(voiceNumber, 2));
+		assertEquals(fourthElement, pattern.get(voiceNumber, 3));
+		assertEquals(fifthElement, pattern.get(voiceNumber, 4));
+		assertEquals(sixthElement, pattern.get(voiceNumber, 5));
 
 		assertFalse(pattern.isMonophonic());
 	}

--- a/src/test/java/org/wmn4j/mir/PatternBuilderTest.java
+++ b/src/test/java/org/wmn4j/mir/PatternBuilderTest.java
@@ -1,15 +1,15 @@
 package org.wmn4j.mir;
 
 import org.junit.jupiter.api.Test;
-import org.wmn4j.notation.ChordBuilder;
-import org.wmn4j.notation.NoteBuilder;
-import org.wmn4j.notation.RestBuilder;
 import org.wmn4j.notation.Chord;
+import org.wmn4j.notation.ChordBuilder;
 import org.wmn4j.notation.Durational;
 import org.wmn4j.notation.Durations;
 import org.wmn4j.notation.Note;
+import org.wmn4j.notation.NoteBuilder;
 import org.wmn4j.notation.Pitch;
 import org.wmn4j.notation.Rest;
+import org.wmn4j.notation.RestBuilder;
 
 import java.util.List;
 
@@ -100,23 +100,23 @@ class PatternBuilderTest {
 
 		final int voice1number = 1;
 		final Note firstElement = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
-		builder.addToVoice(new NoteBuilder(firstElement), voice1number);
+		builder.addToVoice(voice1number, new NoteBuilder(firstElement));
 
 		final Note secondElement = Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH);
-		builder.addToVoice(new NoteBuilder(secondElement), voice1number);
+		builder.addToVoice(voice1number, new NoteBuilder(secondElement));
 
 		final Rest thirdElement = Rest.of(Durations.QUARTER);
-		builder.addToVoice(new RestBuilder(thirdElement), voice1number);
+		builder.addToVoice(voice1number, new RestBuilder(thirdElement));
 
 		final int voice2number = 2;
 		final Note fourthElement = Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.SIXTEENTH);
-		builder.addToVoice(new NoteBuilder(fourthElement), voice2number);
+		builder.addToVoice(voice2number, new NoteBuilder(fourthElement));
 
 		final Rest fifthElement = Rest.of(Durations.EIGHTH);
-		builder.addToVoice(new RestBuilder(fifthElement), voice2number);
+		builder.addToVoice(voice2number, new RestBuilder(fifthElement));
 
 		final Note sixthElement = Note.of(Pitch.of(Pitch.Base.B, -1, 4), Durations.SIXTEENTH);
-		builder.addToVoice(new NoteBuilder(sixthElement), voice2number);
+		builder.addToVoice(voice2number, new NoteBuilder(sixthElement));
 
 		final Pattern patternWithTwoVoices = builder.build();
 		assertFalse(patternWithTwoVoices.isMonophonic());

--- a/src/test/java/org/wmn4j/mir/PatternBuilderTest.java
+++ b/src/test/java/org/wmn4j/mir/PatternBuilderTest.java
@@ -123,17 +123,15 @@ class PatternBuilderTest {
 
 		assertEquals(2, patternWithTwoVoices.getVoiceCount());
 
-		List<Durational> voice1 = patternWithTwoVoices.getVoice(voice1number);
-		assertEquals(3, voice1.size());
-		assertEquals(firstElement, voice1.get(0));
-		assertEquals(secondElement, voice1.get(1));
-		assertEquals(thirdElement, voice1.get(2));
+		assertEquals(3, patternWithTwoVoices.getVoiceSize(voice1number));
+		assertEquals(firstElement, patternWithTwoVoices.get(voice1number, 0));
+		assertEquals(secondElement, patternWithTwoVoices.get(voice1number, 1));
+		assertEquals(thirdElement, patternWithTwoVoices.get(voice1number, 2));
 
-		List<Durational> voice2 = patternWithTwoVoices.getVoice(voice2number);
-		assertEquals(3, voice2.size());
-		assertEquals(fourthElement, voice2.get(0));
-		assertEquals(fifthElement, voice2.get(1));
-		assertEquals(sixthElement, voice2.get(2));
+		assertEquals(3, patternWithTwoVoices.getVoiceSize(voice2number));
+		assertEquals(fourthElement, patternWithTwoVoices.get(voice2number, 0));
+		assertEquals(fifthElement, patternWithTwoVoices.get(voice2number, 1));
+		assertEquals(sixthElement, patternWithTwoVoices.get(voice2number, 2));
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/mir/PatternBuilderTest.java
+++ b/src/test/java/org/wmn4j/mir/PatternBuilderTest.java
@@ -121,7 +121,7 @@ class PatternBuilderTest {
 		final Pattern patternWithTwoVoices = builder.build();
 		assertFalse(patternWithTwoVoices.isMonophonic());
 
-		assertEquals(2, patternWithTwoVoices.getNumberOfVoices());
+		assertEquals(2, patternWithTwoVoices.getVoiceCount());
 
 		List<Durational> voice1 = patternWithTwoVoices.getVoice(voice1number);
 		assertEquals(3, voice1.size());

--- a/src/test/java/org/wmn4j/mir/PatternPositionTest.java
+++ b/src/test/java/org/wmn4j/mir/PatternPositionTest.java
@@ -25,7 +25,7 @@ class PatternPositionTest {
 		positions.add(new Position(partIndex, 1, 5, 2, 1, 0));
 
 		final PatternPosition position = new PatternPosition(positions);
-		assertEquals(3, position.getSize());
+		assertEquals(3, position.size());
 		assertEquals(3, position.getPositions(partIndex).size());
 
 		assertEquals(1, position.getStaffNumbers(partIndex).size());
@@ -64,7 +64,7 @@ class PatternPositionTest {
 		positions.add(new Position(3, 1, 6, 2, 1, 0));
 
 		final PatternPosition position = new PatternPosition(positions);
-		assertEquals(6, position.getSize());
+		assertEquals(6, position.size());
 
 		assertEquals(1, position.getStaffNumbers(1).size());
 		assertTrue(position.getStaffNumbers(1).contains(1));

--- a/src/test/java/org/wmn4j/mir/PatternTest.java
+++ b/src/test/java/org/wmn4j/mir/PatternTest.java
@@ -35,10 +35,15 @@ public class PatternTest {
 		final Pattern monophonicPattern = Pattern.of(notes);
 		assertTrue(monophonicPattern.isMonophonic());
 
-		final List<Durational> contentsOfMonophonicPattern = monophonicPattern
+		final Iterable<Durational> contentsOfMonophonicPattern = monophonicPattern
 				.getVoice(monophonicPattern.getVoiceNumbers().get(0));
 
-		assertEquals(notes, contentsOfMonophonicPattern);
+		List<Durational> monophonicPatternVoiceContentsAsList = new ArrayList<>();
+		for (Durational durational : contentsOfMonophonicPattern) {
+			monophonicPatternVoiceContentsAsList.add(durational);
+		}
+
+		assertEquals(notes, monophonicPatternVoiceContentsAsList);
 
 		final List<Durational> contentsOfPolyphonicPattern = new ArrayList<>(notes);
 		final Chord chord = Chord.of(notes.subList(0, 2));

--- a/src/test/java/org/wmn4j/mir/PatternTest.java
+++ b/src/test/java/org/wmn4j/mir/PatternTest.java
@@ -46,7 +46,7 @@ public class PatternTest {
 
 		final Pattern polyphonicPatternWithOneVoice = Pattern.of(contentsOfPolyphonicPattern);
 		assertFalse(polyphonicPatternWithOneVoice.isMonophonic());
-		assertEquals(1, polyphonicPatternWithOneVoice.getNumberOfVoices());
+		assertEquals(1, polyphonicPatternWithOneVoice.getVoiceCount());
 		assertEquals(contentsOfPolyphonicPattern,
 				polyphonicPatternWithOneVoice.getVoice(polyphonicPatternWithOneVoice.getVoiceNumbers().get(0)));
 	}
@@ -71,7 +71,7 @@ public class PatternTest {
 		final Pattern patternWithMultipleVoices = Pattern.of(voices);
 		assertFalse(patternWithMultipleVoices.isMonophonic());
 
-		assertEquals(2, patternWithMultipleVoices.getNumberOfVoices());
+		assertEquals(2, patternWithMultipleVoices.getVoiceCount());
 		final List<Integer> voiceNumbers = patternWithMultipleVoices.getVoiceNumbers();
 		assertEquals(voice1, patternWithMultipleVoices.getVoice(voiceNumbers.get(0)));
 		assertEquals(voice2, patternWithMultipleVoices.getVoice(voiceNumbers.get(1)));

--- a/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
@@ -15,7 +15,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -93,18 +92,12 @@ public class PolyphonicPatternTest {
 	}
 
 	@Test
-	void testGetContentsReturnsAllContentsOfPattern() {
+	void testGetSizeReturnsCorrectSize() {
 		final Map<Integer, List<? extends Durational>> voiceContents = createReferencePatternVoices();
 
 		final Pattern pattern = new PolyphonicPattern(voiceContents);
-		final List<Durational> contents = pattern.getContents();
 
-		assertEquals(6, contents.size());
-
-		List<? extends Durational> expectedContents = voiceContents.values().stream().flatMap(voice -> voice.stream())
-				.collect(Collectors.toList());
-
-		expectedContents.forEach(notationElement -> assertTrue(contents.contains(notationElement)));
+		assertEquals(6, pattern.size());
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
@@ -110,7 +110,7 @@ public class PolyphonicPatternTest {
 	@Test
 	void testGetNumberOfVoicesReturnsCorrectNumber() {
 		final Pattern pattern = new PolyphonicPattern(createReferencePatternVoices());
-		assertEquals(2, pattern.getNumberOfVoices());
+		assertEquals(2, pattern.getVoiceCount());
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/notation/KeySignatureTest.java
+++ b/src/test/java/org/wmn4j/notation/KeySignatureTest.java
@@ -4,9 +4,6 @@
 package org.wmn4j.notation;
 
 import org.junit.jupiter.api.Test;
-import org.wmn4j.notation.KeySignature;
-import org.wmn4j.notation.KeySignatures;
-import org.wmn4j.notation.Pitch;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,15 +31,15 @@ class KeySignatureTest {
 
 	@Test
 	void testGetNumSharps() {
-		assertEquals(0, KeySignatures.CMAJ_AMIN.getNumberOfSharps());
-		assertEquals(1, KeySignatures.GMAJ_EMIN.getNumberOfSharps());
-		assertEquals(2, KeySignatures.DMAJ_BMIN.getNumberOfSharps());
+		assertEquals(0, KeySignatures.CMAJ_AMIN.getSharpCount());
+		assertEquals(1, KeySignatures.GMAJ_EMIN.getSharpCount());
+		assertEquals(2, KeySignatures.DMAJ_BMIN.getSharpCount());
 	}
 
 	@Test
 	void testGetNumFlats() {
-		assertEquals(0, KeySignatures.CMAJ_AMIN.getNumberOfFlats());
-		assertEquals(4, KeySignatures.AFLATMAJ_FMIN.getNumberOfFlats());
+		assertEquals(0, KeySignatures.CMAJ_AMIN.getFlatCount());
+		assertEquals(4, KeySignatures.AFLATMAJ_FMIN.getFlatCount());
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/notation/MeasureBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/MeasureBuilderTest.java
@@ -18,11 +18,11 @@ class MeasureBuilderTest {
 		builder.setTimeSignature(TimeSignatures.SIX_EIGHT).setKeySignature(KeySignatures.DFLATMAJ_BFLATMIN);
 		builder.setRightBarline(Barline.DOUBLE).setClef(Clefs.F);
 
-		builder.addVoice();
-		assertEquals(1, builder.getVoiceCount());
 		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH))
 				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH))
 				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH));
+
+		assertEquals(1, builder.getVoiceCount());
 
 		final Measure measure = builder.build();
 		assertNotNull(measure);
@@ -44,11 +44,11 @@ class MeasureBuilderTest {
 				KeySignatures.DFLATMAJ_BFLATMIN, Barline.DOUBLE, Clefs.F);
 		final MeasureBuilder builder = new MeasureBuilder(1, measureAttr);
 
-		builder.addVoice();
-		assertEquals(1, builder.getVoiceCount());
 		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH))
 				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH))
 				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH));
+
+		assertEquals(1, builder.getVoiceCount());
 
 		final Measure measure = builder.build();
 		assertNotNull(measure);
@@ -74,11 +74,11 @@ class MeasureBuilderTest {
 		builder.setTimeSignature(TimeSignatures.SIX_EIGHT).setKeySignature(KeySignatures.DFLATMAJ_BFLATMIN);
 		builder.setRightBarline(Barline.DOUBLE).setClef(Clefs.F);
 
-		builder.addVoice();
-		assertEquals(1, builder.getVoiceCount());
 		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH))
 				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH))
 				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH));
+
+		assertEquals(1, builder.getVoiceCount());
 
 		final Measure measure = builder.build();
 		assertNotNull(measure);

--- a/src/test/java/org/wmn4j/notation/MeasureBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/MeasureBuilderTest.java
@@ -19,7 +19,7 @@ class MeasureBuilderTest {
 		builder.setRightBarline(Barline.DOUBLE).setClef(Clefs.F);
 
 		builder.addVoice();
-		assertEquals(1, builder.getNumberOfVoices());
+		assertEquals(1, builder.getVoiceCount());
 		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH))
 				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH))
 				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH));
@@ -45,7 +45,7 @@ class MeasureBuilderTest {
 		final MeasureBuilder builder = new MeasureBuilder(1, measureAttr);
 
 		builder.addVoice();
-		assertEquals(1, builder.getNumberOfVoices());
+		assertEquals(1, builder.getVoiceCount());
 		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH))
 				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH))
 				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH));
@@ -75,7 +75,7 @@ class MeasureBuilderTest {
 		builder.setRightBarline(Barline.DOUBLE).setClef(Clefs.F);
 
 		builder.addVoice();
-		assertEquals(1, builder.getNumberOfVoices());
+		assertEquals(1, builder.getVoiceCount());
 		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH))
 				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH))
 				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH));
@@ -103,9 +103,9 @@ class MeasureBuilderTest {
 		final Duration measureFillingDuration = TimeSignatures.SIX_EIGHT.getTotalDuration();
 
 		builder.addToVoice(1, new RestBuilder(measureFillingDuration));
-		assertEquals(1, builder.getNumberOfVoices());
+		assertEquals(1, builder.getVoiceCount());
 		builder.addToVoice(3, new RestBuilder(measureFillingDuration));
-		assertEquals(2, builder.getNumberOfVoices());
+		assertEquals(2, builder.getVoiceCount());
 
 		final Measure measure = builder.build();
 		assertEquals(2, measure.getVoiceCount());

--- a/src/test/java/org/wmn4j/notation/MeasureBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/MeasureBuilderTest.java
@@ -4,23 +4,6 @@
 package org.wmn4j.notation;
 
 import org.junit.jupiter.api.Test;
-import org.wmn4j.notation.MeasureBuilder;
-import org.wmn4j.notation.NoteBuilder;
-import org.wmn4j.notation.RestBuilder;
-import org.wmn4j.notation.Barline;
-import org.wmn4j.notation.Clefs;
-import org.wmn4j.notation.Duration;
-import org.wmn4j.notation.Durational;
-import org.wmn4j.notation.Durations;
-import org.wmn4j.notation.KeySignatures;
-import org.wmn4j.notation.Measure;
-import org.wmn4j.notation.MeasureAttributes;
-import org.wmn4j.notation.Note;
-import org.wmn4j.notation.Pitch;
-import org.wmn4j.notation.Rest;
-import org.wmn4j.notation.TimeSignatures;
-
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -50,10 +33,9 @@ class MeasureBuilderTest {
 		assertEquals(1, measure.getNumber());
 
 		assertEquals(1, measure.getVoiceCount());
-		final List<Durational> voice = measure.getVoice(0);
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH), voice.get(0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH), voice.get(1));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH), voice.get(2));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH), measure.get(0, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH), measure.get(0, 1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH), measure.get(0, 2));
 	}
 
 	@Test
@@ -77,10 +59,10 @@ class MeasureBuilderTest {
 		assertEquals(1, measure.getNumber());
 
 		assertEquals(1, measure.getVoiceCount());
-		final List<Durational> voice = measure.getVoice(0);
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH), voice.get(0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH), voice.get(1));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH), voice.get(2));
+
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH), measure.get(0, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH), measure.get(0, 1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH), measure.get(0, 2));
 	}
 
 	@Test
@@ -107,10 +89,9 @@ class MeasureBuilderTest {
 		assertEquals(1, measure.getNumber());
 
 		assertEquals(1, measure.getVoiceCount());
-		final List<Durational> voice = measure.getVoice(0);
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH), voice.get(0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH), voice.get(1));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH), voice.get(2));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH), measure.get(0, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH), measure.get(0, 1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH), measure.get(0, 2));
 	}
 
 	@Test
@@ -128,10 +109,10 @@ class MeasureBuilderTest {
 
 		final Measure measure = builder.build();
 		assertEquals(2, measure.getVoiceCount());
-		assertEquals(1, measure.getVoice(1).size());
-		assertTrue(measure.getVoice(1).contains(Rest.of(measureFillingDuration)));
-		assertEquals(1, measure.getVoice(3).size());
-		assertTrue(measure.getVoice(3).contains(Rest.of(measureFillingDuration)));
+		assertEquals(1, measure.getVoiceSize(1));
+		assertEquals(Rest.of(measureFillingDuration), measure.get(1, 0));
+		assertEquals(1, measure.getVoiceSize(3));
+		assertEquals(Rest.of(measureFillingDuration), measure.get(3, 0));
 	}
 
 	@Test
@@ -316,10 +297,10 @@ class MeasureBuilderTest {
 
 		final Measure incompleteMeasure = builder.build(false, false);
 
-		assertEquals(1, incompleteMeasure.getVoice(0).size());
+		assertEquals(1, incompleteMeasure.getVoiceSize(0));
 		assertEquals(expectedVoice0Note, incompleteMeasure.get(0, 0));
 
-		assertEquals(1, incompleteMeasure.getVoice(1).size());
+		assertEquals(1, incompleteMeasure.getVoiceSize(1));
 		assertEquals(expectedVoice1Note, incompleteMeasure.get(1, 0));
 	}
 

--- a/src/test/java/org/wmn4j/notation/MeasureTest.java
+++ b/src/test/java/org/wmn4j/notation/MeasureTest.java
@@ -4,19 +4,6 @@
 package org.wmn4j.notation;
 
 import org.junit.jupiter.api.Test;
-import org.wmn4j.notation.Barline;
-import org.wmn4j.notation.Chord;
-import org.wmn4j.notation.Clefs;
-import org.wmn4j.notation.Durational;
-import org.wmn4j.notation.Durations;
-import org.wmn4j.notation.KeySignature;
-import org.wmn4j.notation.KeySignatures;
-import org.wmn4j.notation.Measure;
-import org.wmn4j.notation.MeasureAttributes;
-import org.wmn4j.notation.Note;
-import org.wmn4j.notation.Pitch;
-import org.wmn4j.notation.Rest;
-import org.wmn4j.notation.TimeSignatures;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class MeasureTest {
 
 	private Map<Integer, List<Durational>> singleNoteVoice = new HashMap<>();
-	private Map<Integer, List<Durational>> multipleNoteVoices = new HashMap<>();
+	private Map<Integer, List<Durational>> multipleNoteVoices;
 
 	private KeySignature keySig = KeySignatures.CMAJ_AMIN;
 
@@ -87,22 +74,7 @@ class MeasureTest {
 		// Test that modifying the original voices list does no affect measure created
 		// using it.
 		voices.get(0).add(C4);
-		assertEquals(1, measure.getVoice(0).size(), "Modifying list from which measure is created changes measure");
-	}
-
-	@Test
-	void testGetVoice() {
-		final Measure m = Measure.of(1, multipleNoteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
-		assertTrue(m.getVoice(1).contains(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.HALF)));
-		assertTrue(m.getVoice(0).contains(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER)));
-
-		final List<Durational> voice = m.getVoice(0);
-		try {
-			voice.add(Rest.of(Durations.QUARTER));
-			fail("Failed to throw exception for disabled adding");
-		} catch (final Exception e) {
-			/* Do nothing */
-		}
+		assertEquals(1, measure.getVoiceSize(0), "Modifying list from which measure is created changes measure");
 	}
 
 	@Test
@@ -114,7 +86,6 @@ class MeasureTest {
 	@Test
 	void testIteratorWithSingleVoiceMeasure() {
 		final Measure singleVoiceMeasure = Measure.of(1, singleNoteVoice, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
-		final int noteCount = 0;
 
 		final List<Durational> expected = singleNoteVoice.get(0);
 		final List<Durational> found = new ArrayList<>();
@@ -133,7 +104,6 @@ class MeasureTest {
 	@Test
 	void testIteratorWithMultiVoiceMeasure() {
 		final Measure multiVoiceMeasure = Measure.of(1, multipleNoteVoices, TimeSignatures.FOUR_FOUR, keySig, Clefs.G);
-		final int noteCount = 0;
 
 		final List<Durational> expected = new ArrayList<>();
 		expected.addAll(multipleNoteVoices.get(0));

--- a/src/test/java/org/wmn4j/notation/PartBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/PartBuilderTest.java
@@ -4,25 +4,6 @@
 package org.wmn4j.notation;
 
 import org.junit.jupiter.api.Test;
-import org.wmn4j.notation.ChordBuilder;
-import org.wmn4j.notation.DurationalBuilder;
-import org.wmn4j.notation.MeasureBuilder;
-import org.wmn4j.notation.NoteBuilder;
-import org.wmn4j.notation.PartBuilder;
-import org.wmn4j.notation.RestBuilder;
-import org.wmn4j.notation.Barline;
-import org.wmn4j.notation.Clefs;
-import org.wmn4j.notation.Durations;
-import org.wmn4j.notation.KeySignatures;
-import org.wmn4j.notation.Measure;
-import org.wmn4j.notation.MeasureAttributes;
-import org.wmn4j.notation.MultiStaffPart;
-import org.wmn4j.notation.Note;
-import org.wmn4j.notation.Part;
-import org.wmn4j.notation.Pitch;
-import org.wmn4j.notation.SingleStaffPart;
-import org.wmn4j.notation.Staff;
-import org.wmn4j.notation.TimeSignatures;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -71,7 +52,10 @@ class PartBuilderTest {
 	private MeasureBuilder getMeasureBuilder(int number) {
 		final MeasureBuilder builder = new MeasureBuilder(number, this.measureAttr);
 		for (Integer voiceNum : this.measureContents.keySet()) {
-			builder.addVoice(this.measureContents.get(voiceNum));
+			List<DurationalBuilder> voiceContents = this.measureContents.get(voiceNum);
+			for (DurationalBuilder dur : voiceContents) {
+				builder.addToVoice(voiceNum, dur);
+			}
 		}
 
 		return builder;

--- a/src/test/java/org/wmn4j/notation/ScoreTest.java
+++ b/src/test/java/org/wmn4j/notation/ScoreTest.java
@@ -172,11 +172,13 @@ public class ScoreTest {
 		simplePositions.add(new Position(0, 1, 1, 1));
 
 		Pattern twoFirstNotes = score.getAt(new PatternPosition(simplePositions));
-		assertEquals(2, twoFirstNotes.getContents().size());
+		assertEquals(2, twoFirstNotes.size());
 		assertEquals(1, twoFirstNotes.getVoiceCount());
 
-		assertEquals(Note.of(Pitch.Base.C, 0, 4, Durations.QUARTER), twoFirstNotes.getContents().get(0));
-		assertEquals(Note.of(Pitch.Base.D, 0, 4, Durations.QUARTER), twoFirstNotes.getContents().get(1));
+		final int twoFirstVoiceNumber = twoFirstNotes.getVoiceNumbers().get(0);
+
+		assertEquals(Note.of(Pitch.Base.C, 0, 4, Durations.QUARTER), twoFirstNotes.get(twoFirstVoiceNumber, 0));
+		assertEquals(Note.of(Pitch.Base.D, 0, 4, Durations.QUARTER), twoFirstNotes.get(twoFirstVoiceNumber, 1));
 
 		List<Position> positionsWithGap = new ArrayList<>();
 		positionsWithGap.add(new Position(0, 1, 1, 0));
@@ -184,17 +186,19 @@ public class ScoreTest {
 		positionsWithGap.add(new Position(0, 3, 1, 0));
 
 		Pattern patternWithGaps = score.getAt(new PatternPosition(positionsWithGap));
-		assertEquals(6, patternWithGaps.getContents().size());
+		assertEquals(6, patternWithGaps.size());
 		assertEquals(1, patternWithGaps.getVoiceCount());
 
-		assertEquals(Note.of(Pitch.Base.C, 0, 4, Durations.QUARTER), patternWithGaps.getContents().get(0));
-		assertEquals(Rest.of(Durations.QUARTER), patternWithGaps.getContents().get(1));
-		assertEquals(Rest.of(Durations.QUARTER), patternWithGaps.getContents().get(2));
-		assertEquals(Note.of(Pitch.Base.F, 0, 4, Durations.QUARTER), patternWithGaps.getContents().get(3));
+		final int withGapsVoiceNumber = patternWithGaps.getVoiceNumbers().get(0);
 
-		assertEquals(Rest.of(Durations.WHOLE), patternWithGaps.getContents().get(4));
+		assertEquals(Note.of(Pitch.Base.C, 0, 4, Durations.QUARTER), patternWithGaps.get(withGapsVoiceNumber, 0));
+		assertEquals(Rest.of(Durations.QUARTER), patternWithGaps.get(withGapsVoiceNumber, 1));
+		assertEquals(Rest.of(Durations.QUARTER), patternWithGaps.get(withGapsVoiceNumber, 2));
+		assertEquals(Note.of(Pitch.Base.F, 0, 4, Durations.QUARTER), patternWithGaps.get(withGapsVoiceNumber, 3));
 
-		assertEquals(Note.of(Pitch.Base.C, 0, 4, Durations.WHOLE), patternWithGaps.getContents().get(5));
+		assertEquals(Rest.of(Durations.WHOLE), patternWithGaps.get(withGapsVoiceNumber, 4));
+
+		assertEquals(Note.of(Pitch.Base.C, 0, 4, Durations.WHOLE), patternWithGaps.get(withGapsVoiceNumber, 5));
 	}
 
 	@Test
@@ -206,12 +210,14 @@ public class ScoreTest {
 		positionsWithChord.add(new Position(0, 2, 1, 3));
 
 		Pattern patternWithChord = score.getAt(new PatternPosition(positionsWithChord));
-		assertEquals(2, patternWithChord.getContents().size());
+		assertEquals(2, patternWithChord.size());
 
-		assertEquals(Note.of(Pitch.Base.E, 0, 4, Durations.EIGHTH), patternWithChord.getContents().get(0));
+		final int withChordVoiceNumber = patternWithChord.getVoiceNumbers().get(0);
+
+		assertEquals(Note.of(Pitch.Base.E, 0, 4, Durations.EIGHTH), patternWithChord.get(withChordVoiceNumber, 0));
 		assertEquals(Chord.of(Note.of(Pitch.Base.D, 0, 4, Durations.EIGHTH),
 				Note.of(Pitch.Base.F, 0, 4, Durations.EIGHTH),
-				Note.of(Pitch.Base.A, 0, 4, Durations.EIGHTH)), patternWithChord.getContents().get(1));
+				Note.of(Pitch.Base.A, 0, 4, Durations.EIGHTH)), patternWithChord.get(withChordVoiceNumber, 1));
 
 		List<Position> positionsWithinChord = new ArrayList<>();
 		positionsWithinChord.add(new Position(0, 2, 1, 2));
@@ -219,11 +225,15 @@ public class ScoreTest {
 		positionsWithinChord.add(new Position(0, 1, 2, 1, 3, 1));
 
 		Pattern patternWithinChord = score.getAt(new PatternPosition(positionsWithinChord));
-		assertEquals(2, patternWithinChord.getContents().size());
+		assertEquals(2, patternWithinChord.size());
 
-		assertEquals(Note.of(Pitch.Base.E, 0, 4, Durations.EIGHTH), patternWithinChord.getContents().get(0));
+		final int withinChordVoiceNumber = patternWithinChord.getVoiceNumbers().get(0);
+
+		assertEquals(Note.of(Pitch.Base.E, 0, 4, Durations.EIGHTH),
+				patternWithinChord.get(withinChordVoiceNumber, 0));
 		assertEquals(Chord.of(Note.of(Pitch.Base.D, 0, 4, Durations.EIGHTH),
-				Note.of(Pitch.Base.F, 0, 4, Durations.EIGHTH)), patternWithinChord.getContents().get(1));
+				Note.of(Pitch.Base.F, 0, 4, Durations.EIGHTH)),
+				patternWithinChord.get(withinChordVoiceNumber, 1));
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/notation/ScoreTest.java
+++ b/src/test/java/org/wmn4j/notation/ScoreTest.java
@@ -181,7 +181,7 @@ public class ScoreTest {
 
 		Pattern twoFirstNotes = score.getAt(new PatternPosition(simplePositions));
 		assertEquals(2, twoFirstNotes.getContents().size());
-		assertEquals(1, twoFirstNotes.getNumberOfVoices());
+		assertEquals(1, twoFirstNotes.getVoiceCount());
 
 		assertEquals(Note.of(Pitch.Base.C, 0, 4, Durations.QUARTER), twoFirstNotes.getContents().get(0));
 		assertEquals(Note.of(Pitch.Base.D, 0, 4, Durations.QUARTER), twoFirstNotes.getContents().get(1));
@@ -193,7 +193,7 @@ public class ScoreTest {
 
 		Pattern patternWithGaps = score.getAt(new PatternPosition(positionsWithGap));
 		assertEquals(6, patternWithGaps.getContents().size());
-		assertEquals(1, patternWithGaps.getNumberOfVoices());
+		assertEquals(1, patternWithGaps.getVoiceCount());
 
 		assertEquals(Note.of(Pitch.Base.C, 0, 4, Durations.QUARTER), patternWithGaps.getContents().get(0));
 		assertEquals(Rest.of(Durations.QUARTER), patternWithGaps.getContents().get(1));
@@ -248,7 +248,7 @@ public class ScoreTest {
 		positionsAcrossParts.add(new Position(1, 2, 4, 1, 0));
 
 		final Pattern patternWithNotesAcrossParts = score.getAt(new PatternPosition(positionsAcrossParts));
-		assertEquals(3, patternWithNotesAcrossParts.getNumberOfVoices());
+		assertEquals(3, patternWithNotesAcrossParts.getVoiceCount());
 
 		final List<Durational> voice1 = patternWithNotesAcrossParts.getVoice(1);
 		assertEquals(3, voice1.size());
@@ -289,7 +289,7 @@ public class ScoreTest {
 
 		final Pattern patternFromOverlappingVoices = score.getAt(new PatternPosition(positionsWithOverlappingVoices));
 
-		assertEquals(5, patternFromOverlappingVoices.getNumberOfVoices());
+		assertEquals(5, patternFromOverlappingVoices.getVoiceCount());
 
 		final List<Durational> voice1 = patternFromOverlappingVoices.getVoice(1);
 		assertEquals(1, voice1.size());

--- a/src/test/java/org/wmn4j/notation/ScoreTest.java
+++ b/src/test/java/org/wmn4j/notation/ScoreTest.java
@@ -242,28 +242,25 @@ public class ScoreTest {
 		final Pattern patternWithNotesAcrossParts = score.getAt(new PatternPosition(positionsAcrossParts));
 		assertEquals(3, patternWithNotesAcrossParts.getVoiceCount());
 
-		final List<Durational> voice1 = patternWithNotesAcrossParts.getVoice(1);
-		assertEquals(3, voice1.size());
+		assertEquals(3, patternWithNotesAcrossParts.getVoiceSize(1));
 
-		assertEquals(Note.of(Pitch.Base.C, 0, 4, Durations.QUARTER), voice1.get(0));
-		assertEquals(Rest.of(Durations.QUARTER), voice1.get(1));
-		assertEquals(Note.of(Pitch.Base.E, 0, 5, Durations.HALF), voice1.get(2));
+		assertEquals(Note.of(Pitch.Base.C, 0, 4, Durations.QUARTER), patternWithNotesAcrossParts.get(1, 0));
+		assertEquals(Rest.of(Durations.QUARTER), patternWithNotesAcrossParts.get(1, 1));
+		assertEquals(Note.of(Pitch.Base.E, 0, 5, Durations.HALF), patternWithNotesAcrossParts.get(1, 2));
 
-		final List<Durational> voice2 = patternWithNotesAcrossParts.getVoice(2);
-		assertEquals(4, voice2.size());
+		assertEquals(4, patternWithNotesAcrossParts.getVoiceSize(2));
 
-		assertEquals(Note.of(Pitch.Base.A, 0, 4, Durations.QUARTER), voice2.get(0));
-		assertEquals(Rest.of(Durations.QUARTER), voice2.get(1));
-		assertEquals(Rest.of(Durations.QUARTER.multiplyBy(3)), voice2.get(2));
-		assertEquals(Note.of(Pitch.Base.D, 0, 4, Durations.HALF), voice2.get(3));
+		assertEquals(Note.of(Pitch.Base.A, 0, 4, Durations.QUARTER), patternWithNotesAcrossParts.get(2, 0));
+		assertEquals(Rest.of(Durations.QUARTER), patternWithNotesAcrossParts.get(2, 1));
+		assertEquals(Rest.of(Durations.QUARTER.multiplyBy(3)), patternWithNotesAcrossParts.get(2, 2));
+		assertEquals(Note.of(Pitch.Base.D, 0, 4, Durations.HALF), patternWithNotesAcrossParts.get(2, 3));
 
-		final List<Durational> voice3 = patternWithNotesAcrossParts.getVoice(3);
-		assertEquals(4, voice3.size());
+		assertEquals(4, patternWithNotesAcrossParts.getVoiceSize(3));
 
-		assertEquals(Rest.of(Durations.HALF), voice3.get(0));
-		assertEquals(Rest.of(Durations.HALF.addDot()), voice3.get(1));
-		assertEquals(Rest.of(Durations.HALF.addDot()), voice3.get(2));
-		assertEquals(Note.of(Pitch.Base.D, 0, 3, Durations.HALF), voice3.get(3));
+		assertEquals(Rest.of(Durations.HALF), patternWithNotesAcrossParts.get(3, 0));
+		assertEquals(Rest.of(Durations.HALF.addDot()), patternWithNotesAcrossParts.get(3, 1));
+		assertEquals(Rest.of(Durations.HALF.addDot()), patternWithNotesAcrossParts.get(3, 2));
+		assertEquals(Note.of(Pitch.Base.D, 0, 3, Durations.HALF), patternWithNotesAcrossParts.get(3, 3));
 	}
 
 	@Test
@@ -283,33 +280,28 @@ public class ScoreTest {
 
 		assertEquals(5, patternFromOverlappingVoices.getVoiceCount());
 
-		final List<Durational> voice1 = patternFromOverlappingVoices.getVoice(1);
-		assertEquals(1, voice1.size());
-		assertEquals(Note.of(Pitch.Base.D, 0, 4, Durations.QUARTER), voice1.get(0));
+		assertEquals(1, patternFromOverlappingVoices.getVoiceSize(1));
+		assertEquals(Note.of(Pitch.Base.D, 0, 4, Durations.QUARTER), patternFromOverlappingVoices.get(1, 0));
 
-		final List<Durational> voice2 = patternFromOverlappingVoices.getVoice(2);
-		assertEquals(1, voice2.size());
-		assertEquals(Note.of(Pitch.Base.E, 0, 5, Durations.HALF), voice2.get(0));
+		assertEquals(1, patternFromOverlappingVoices.getVoiceSize(2));
+		assertEquals(Note.of(Pitch.Base.E, 0, 5, Durations.HALF), patternFromOverlappingVoices.get(2, 0));
 
-		final List<Durational> voice3 = patternFromOverlappingVoices.getVoice(3);
-		assertEquals(4, voice3.size());
+		assertEquals(4, patternFromOverlappingVoices.getVoiceSize(3));
 
-		assertEquals(Rest.of(Durations.HALF.addDot()), voice3.get(0));
-		assertEquals(Rest.of(Durations.SIXTEENTH), voice3.get(1));
-		assertEquals(Rest.of(Durations.SIXTEENTH), voice3.get(2));
-		assertEquals(Note.of(Pitch.Base.D, -1, 5, Durations.EIGHTH), voice3.get(3));
+		assertEquals(Rest.of(Durations.HALF.addDot()), patternFromOverlappingVoices.get(3, 0));
+		assertEquals(Rest.of(Durations.SIXTEENTH), patternFromOverlappingVoices.get(3, 1));
+		assertEquals(Rest.of(Durations.SIXTEENTH), patternFromOverlappingVoices.get(3, 2));
+		assertEquals(Note.of(Pitch.Base.D, -1, 5, Durations.EIGHTH), patternFromOverlappingVoices.get(3, 3));
 
-		final List<Durational> voice4 = patternFromOverlappingVoices.getVoice(4);
-		assertEquals(2, voice4.size());
+		assertEquals(2, patternFromOverlappingVoices.getVoiceSize(4));
 
-		assertEquals(Rest.of(Durations.HALF.addDot()), voice4.get(0));
-		assertEquals(Note.of(Pitch.Base.D, 0, 4, Durations.HALF), voice4.get(1));
+		assertEquals(Rest.of(Durations.HALF.addDot()), patternFromOverlappingVoices.get(4, 0));
+		assertEquals(Note.of(Pitch.Base.D, 0, 4, Durations.HALF), patternFromOverlappingVoices.get(4, 1));
 
-		final List<Durational> voice5 = patternFromOverlappingVoices.getVoice(5);
-		assertEquals(2, voice5.size());
+		assertEquals(2, patternFromOverlappingVoices.getVoiceSize(5));
 
-		assertEquals(Rest.of(Durations.HALF.addDot()), voice5.get(0));
-		assertEquals(Note.of(Pitch.Base.D, 0, 3, Durations.QUARTER), voice5.get(1));
+		assertEquals(Rest.of(Durations.HALF.addDot()), patternFromOverlappingVoices.get(5, 0));
+		assertEquals(Note.of(Pitch.Base.D, 0, 3, Durations.QUARTER), patternFromOverlappingVoices.get(5, 1));
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/notation/ScoreTest.java
+++ b/src/test/java/org/wmn4j/notation/ScoreTest.java
@@ -4,9 +4,9 @@
 package org.wmn4j.notation;
 
 import org.junit.jupiter.api.Test;
+import org.wmn4j.TestHelper;
 import org.wmn4j.mir.Pattern;
 import org.wmn4j.mir.PatternPosition;
-import org.wmn4j.TestHelper;
 import org.wmn4j.notation.access.PartWiseScoreIterator;
 import org.wmn4j.notation.access.Position;
 import org.wmn4j.notation.access.ScoreIterator;
@@ -92,14 +92,6 @@ public class ScoreTest {
 		attributes.put(Score.Attribute.TITLE, "ModifiedName");
 		assertEquals(SCORE_NAME, score.getTitle().get(),
 				"Score title was changed by modifying map used for creating score");
-
-		final List<Part> scoreParts = score.getParts();
-		try {
-			scoreParts.add(parts.get(0));
-		} catch (final Exception e) {
-			/* Do nothing */
-		}
-		assertEquals(5, score.getPartCount(), "Number of parts changed in score");
 	}
 
 	@Test

--- a/src/test/java/org/wmn4j/notation/SingleStaffPartTest.java
+++ b/src/test/java/org/wmn4j/notation/SingleStaffPartTest.java
@@ -4,19 +4,6 @@
 package org.wmn4j.notation;
 
 import org.junit.jupiter.api.Test;
-import org.wmn4j.notation.Chord;
-import org.wmn4j.notation.Clefs;
-import org.wmn4j.notation.Durational;
-import org.wmn4j.notation.Durations;
-import org.wmn4j.notation.KeySignature;
-import org.wmn4j.notation.KeySignatures;
-import org.wmn4j.notation.Measure;
-import org.wmn4j.notation.Note;
-import org.wmn4j.notation.Pitch;
-import org.wmn4j.notation.Rest;
-import org.wmn4j.notation.SingleStaffPart;
-import org.wmn4j.notation.Staff;
-import org.wmn4j.notation.TimeSignatures;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,6 +14,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -69,7 +57,7 @@ class SingleStaffPartTest {
 		final List<Measure> measuresCopy = new ArrayList<>(this.measures);
 		final SingleStaffPart part = SingleStaffPart.of("Test part", Staff.of(measuresCopy));
 		measuresCopy.set(0, null);
-		assertTrue(part.getStaff().getMeasures().get(0) != null,
+		assertNotNull(part.getStaff().getMeasure(1),
 				"Modifying list used to create part modified part also.");
 	}
 
@@ -90,7 +78,7 @@ class SingleStaffPartTest {
 	void testGetStaff() {
 		final SingleStaffPart part = SingleStaffPart.of("Test part", Staff.of(this.measures));
 		final Staff staff = part.getStaff();
-		assertEquals(5, staff.getMeasures().size());
+		assertEquals(5, staff.getMeasureCount());
 	}
 
 	@Test
@@ -127,7 +115,7 @@ class SingleStaffPartTest {
 			/* Ignore */
 		}
 
-		assertEquals(this.measureCount, part.getStaff().getMeasures().size());
+		assertEquals(this.measureCount, part.getStaff().getMeasureCount());
 	}
 
 }

--- a/src/test/java/org/wmn4j/notation/StaffTest.java
+++ b/src/test/java/org/wmn4j/notation/StaffTest.java
@@ -4,17 +4,6 @@
 package org.wmn4j.notation;
 
 import org.junit.jupiter.api.Test;
-import org.wmn4j.notation.Clefs;
-import org.wmn4j.notation.Durational;
-import org.wmn4j.notation.Durations;
-import org.wmn4j.notation.KeySignatures;
-import org.wmn4j.notation.Measure;
-import org.wmn4j.notation.Note;
-import org.wmn4j.notation.Pitch;
-import org.wmn4j.notation.Rest;
-import org.wmn4j.notation.Staff;
-import org.wmn4j.notation.TimeSignature;
-import org.wmn4j.notation.TimeSignatures;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -41,31 +30,6 @@ class StaffTest {
 		measures.add(Measure.of(1, notes, timeSig, KeySignatures.CMAJ_AMIN, Clefs.G));
 		measures.add(Measure.of(2, notes, timeSig, KeySignatures.CMAJ_AMIN, Clefs.G));
 		return measures;
-	}
-
-	@Test
-	void testGetMeasures() {
-		final List<Measure> origMeasures = getTestMeasures();
-		final Staff staff = Staff.of(origMeasures);
-
-		final List<Measure> measures = staff.getMeasures();
-
-		assertEquals(origMeasures.size(), measures.size());
-
-		try {
-			measures.add(origMeasures.get(0));
-			fail("Did not throw UnsupportedOperationException");
-		} catch (final Exception e) {
-			assertTrue(e instanceof UnsupportedOperationException, "Exception was of incorrect type: " + e);
-		}
-
-		final int sizeBeforeAddition = origMeasures.size();
-		final List<Durational> voice = new ArrayList<>();
-		voice.add(Rest.of(Durations.WHOLE));
-		final Map<Integer, List<Durational>> notes = new HashMap<>();
-		notes.put(1, voice);
-		origMeasures.add(Measure.of(3, notes, TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN, Clefs.G));
-		assertEquals(sizeBeforeAddition, staff.getMeasures().size());
 	}
 
 	@Test


### PR DESCRIPTION
* Remove methods that reveal too much of the implementations and are not really needed
* Improve documentation of methods
* Unify method naming