### PR TITLE
Fix null pointer exception for marking with no beginning

### DIFF
--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
@@ -766,7 +766,10 @@ abstract class MusicXmlWriterDom implements MusicXmlWriter {
 				}
 
 				if (note.getMarkingConnection(marking).get().isEnd()) {
-					notationsElement.appendChild(markingResolver.createStopElement(marking));
+					Element markingStop = markingResolver.createStopElement(marking);
+					if (markingStop != null) {
+						notationsElement.appendChild(markingStop);
+					}
 				}
 			}
 		}
@@ -860,14 +863,18 @@ abstract class MusicXmlWriterDom implements MusicXmlWriter {
 		}
 
 		Element createStopElement(Marking marking) {
-			Element markingElement = document.createElement(MARKING_TYPES.get(marking.getType()));
+			Element markingElement = null;
 
-			markingElement.setAttribute(MusicXmlTags.MARKING_NUMBER, unresolvedMarkings.get(marking).toString());
+			if (unresolvedMarkings.containsKey(marking)) {
+				markingElement = document.createElement(MARKING_TYPES.get(marking.getType()));
 
-			usedMarkingNumbers.remove(unresolvedMarkings.get(marking));
-			unresolvedMarkings.remove(marking);
+				markingElement.setAttribute(MusicXmlTags.MARKING_NUMBER, unresolvedMarkings.get(marking).toString());
 
-			markingElement.setAttribute(MusicXmlTags.MARKING_TYPE, MusicXmlTags.MARKING_TYPE_STOP);
+				usedMarkingNumbers.remove(unresolvedMarkings.get(marking));
+				unresolvedMarkings.remove(marking);
+
+				markingElement.setAttribute(MusicXmlTags.MARKING_TYPE, MusicXmlTags.MARKING_TYPE_STOP);
+			}
 
 			return markingElement;
 		}


### PR DESCRIPTION
When writing patterns, it's possible that a note that ends
a marking is found but the note beginning the marking is not
included. In that case do not add any markings to MusicXML.