### PR TITLE
Add dot information to duration

### DIFF
--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlReaderDom.java
@@ -924,6 +924,9 @@ final class MusicXmlReaderDom implements MusicXmlReader {
 
 	private Duration getDuration(Node nodeWithDuration, int divisions) {
 		final Optional<Node> durationNode = DocHelper.findChild(nodeWithDuration, MusicXmlTags.NOTE_DURATION);
+
+		final int dotCount = DocHelper.findChildren(nodeWithDuration, MusicXmlTags.DOT).size();
+
 		if (durationNode.isPresent()) {
 			final int nominator = Integer.parseInt(durationNode.get().getTextContent());
 
@@ -931,7 +934,7 @@ final class MusicXmlReaderDom implements MusicXmlReader {
 			if (nominator != 0) {
 				// In MusicXml divisions is the number of parts into which a quarter note
 				// is divided. Therefore divisions needs to be multiplied by 4.
-				return Duration.of(nominator, divisions * 4);
+				return Duration.of(nominator, divisions * 4, dotCount);
 			}
 		}
 

--- a/src/main/java/org/wmn4j/notation/Duration.java
+++ b/src/main/java/org/wmn4j/notation/Duration.java
@@ -15,12 +15,18 @@ import java.util.Iterator;
  * 1/4. The rational number is always reduced to the lowest possible numerator
  * and denominator.
  * <p>
+ * In order to correctly create dotted durations, use the {@link Duration#addDot()} method.
+ * The number of dots a duration has is not used in comparisons, only the actual length of
+ * the duration is considered in comparison. For example 1/4 + 1/8 is considered equal to
+ * a dotted 1/4. Operations such as add and subtract are not guaranteed to retain dot information.
+ * <p>
  * This class is immutable.
  */
 public final class Duration implements Comparable<Duration> {
 
 	private final int numerator;
 	private final int denominator;
+	private final int dotCount;
 
 	/**
 	 * Returns an instance with the given numerator and denominator. The numerator
@@ -32,12 +38,31 @@ public final class Duration implements Comparable<Duration> {
 	 * @throws IllegalArgumentException if numerator or denominator are less than 1
 	 */
 	public static Duration of(int numerator, int denominator) {
+		return of(numerator, denominator, 0);
+	}
+
+	/**
+	 * Returns an instance with the given numerator and denominator and the given number
+	 * of dots. The numerator and denominator must be at least 1. The given dot count must be positive
+	 * and at most 5. The given dot count does not affect the length of the duration, in order to create
+	 * dotted durations by extending the length of the duration use the {@link Duration#addDot()} method.
+	 *
+	 * @param numerator   the numerator part of the duration
+	 * @param denominator the denominator part of the duration
+	 * @param dotCount    the number of dots used to express the duration
+	 * @return an instance with the given numerator and denominator
+	 * @throws IllegalArgumentException if numerator or denominator are less than 1
+	 */
+	public static Duration of(int numerator, int denominator, int dotCount) {
 
 		if (numerator < 1) {
 			throw new IllegalArgumentException("numerator must be at least 1");
 		}
 		if (denominator < 1) {
 			throw new IllegalArgumentException("denominator must be at least 1");
+		}
+		if (dotCount < 0 || dotCount > 5) {
+			throw new IllegalArgumentException("dotCount must be at least zero and at most 5.");
 		}
 
 		int reducedNumerator = numerator;
@@ -50,7 +75,7 @@ public final class Duration implements Comparable<Duration> {
 			reducedDenominator = denominator / gcd;
 		}
 		// TODO: Implement caching instead of creating new.
-		return new Duration(reducedNumerator, reducedDenominator);
+		return new Duration(reducedNumerator, reducedDenominator, dotCount);
 	}
 
 	/**
@@ -60,9 +85,11 @@ public final class Duration implements Comparable<Duration> {
 	 * @param numerator   the numerator part of the duration
 	 * @param denominator the denominator part of the duration
 	 */
-	private Duration(int numerator, int denominator) {
+	private Duration(int numerator, int denominator, int dotCount) {
 		this.numerator = numerator;
 		this.denominator = denominator;
+
+		this.dotCount = dotCount;
 	}
 
 	/**
@@ -115,17 +142,45 @@ public final class Duration implements Comparable<Duration> {
 
 	@Override
 	public String toString() {
-		return "(" + this.numerator + "/" + this.denominator + ")";
+		StringBuilder builder = new StringBuilder();
+		builder.append("(").append(this.numerator).append("/").append(this.denominator).append(")")
+				.append(".".repeat(getDotCount()));
+		return builder.toString();
 	}
 
 	/**
-	 * Returns a duration that is this duration with half of this duration added to
-	 * it.
+	 * Returns a duration that is this duration with a dot added to it.
 	 *
-	 * @return duration that is this incremented by half of this
+	 * @return duration that is this duration with a dot added to it
 	 */
 	public Duration addDot() {
-		return this.add(Duration.of(this.numerator, 2 * this.denominator));
+		final int newDotCount = getDotCount() + 1;
+		final Duration dotDuration;
+
+		if (dotCount == 0) {
+			dotDuration = this.divideBy(2);
+		} else {
+			// The duration of previous dot is current duration / (2^newDotCount) - 1.
+			final int prevDotDurationDivisor = (1 << newDotCount) - 1;
+			final Duration prevDotDuration = this.divideBy(prevDotDurationDivisor);
+			// The new dot adds half of previous dot duration.
+			dotDuration = prevDotDuration.divideBy(2);
+		}
+
+		final Duration dottedDuration = this.add(dotDuration);
+
+		return of(dottedDuration.getNumerator(), dottedDuration.getDenominator(), newDotCount);
+	}
+
+	/**
+	 * Returns the number of dots in this duration.
+	 * The dots do not affect the mathematical duration and do not thus
+	 * affect the equality comparisons of durations.
+	 *
+	 * @return the number of dots in this duration
+	 */
+	public int getDotCount() {
+		return dotCount;
 	}
 
 	/**

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
@@ -814,4 +814,42 @@ class MusicXmlFileChecks {
 		assertTrue(clefChanges.containsKey(Durations.HALF));
 		assertEquals(Clefs.ALTO, clefChanges.get(Durations.HALF));
 	}
+
+	/*
+	 * Expects the content of "dotted_note_test.musicxml".
+	 * Checks only that the durations are correct.
+	 */
+	static void assertDottedNotesReadCorrectly(Score score) {
+		final Measure firstMeasure = score.getPart(0).getMeasure(1, 1);
+
+		final Duration firstNoteDuration = firstMeasure.get(1, 0).getDuration();
+		assertEquals(Durations.QUARTER.addDot(), firstNoteDuration);
+		assertEquals(1, firstNoteDuration.getDotCount());
+
+		final Duration secondNoteDuration = firstMeasure.get(1, 2).getDuration();
+		assertEquals(Durations.EIGHTH, secondNoteDuration);
+		assertEquals(0, secondNoteDuration.getDotCount());
+
+		final Duration secondRestDuration = firstMeasure.get(1, 3).getDuration();
+		assertEquals(Durations.QUARTER.addDot(), secondRestDuration);
+		assertEquals(1, secondRestDuration.getDotCount());
+
+		final Measure secondMeasure = score.getPart(0).getMeasure(1, 2);
+		final Duration thirdNoteDuration = secondMeasure.get(1, 0).getDuration();
+		assertEquals(Durations.HALF.addDot().addDot(), thirdNoteDuration);
+		assertEquals(2, thirdNoteDuration.getDotCount());
+
+		final Measure thirdMeasure = score.getPart(0).getMeasure(1, 3);
+		final Duration fourthNoteDuration = thirdMeasure.get(1, 0).getDuration();
+		assertEquals(Durations.EIGHTH_TRIPLET.addDot(), fourthNoteDuration);
+		assertEquals(1, fourthNoteDuration.getDotCount());
+
+		final Duration fifthNoteDuration = thirdMeasure.get(1, 1).getDuration();
+		assertEquals(Durations.SIXTEENTH_TRIPLET, fifthNoteDuration);
+		assertEquals(0, fifthNoteDuration.getDotCount());
+
+		final Duration sixthNoteDuration = thirdMeasure.get(1, 2).getDuration();
+		assertEquals(Durations.EIGHTH_TRIPLET, sixthNoteDuration);
+		assertEquals(0, sixthNoteDuration.getDotCount());
+	}
 }

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
@@ -245,8 +245,7 @@ class MusicXmlReaderDomTest {
 		final MusicXmlReader reader = getMusicXmlReader(
 				Paths.get(TestHelper.TESTFILE_PATH + MUSICXML_FILE_PATH + "singleCInvalidMusicXml.xml"), true);
 		try {
-			reader.readScoreBuilder(
-			);
+			reader.readScoreBuilder();
 			fail("No exception was thrown when trying to read XML file that does not comply to MusicXml schema");
 		} catch (IOException ioException) {
 			fail("Reading the score failed due to IOException when a parsing failure was expected");
@@ -364,5 +363,11 @@ class MusicXmlReaderDomTest {
 				"clef_change_where_note_in_another_voice_carries_over.xml", false);
 		MusicXmlFileChecks
 				.assertClefChangeInCorrectPlaceWhenNoteCarriesOverClefChange(scoreBuilderWithClefChange.build());
+	}
+
+	@Test
+	void testDottedDurationsAreReadWithCorrectDotCounts() {
+		Score scoreWithDottedDurations = readScore("dotted_note_test.musicxml", true);
+		MusicXmlFileChecks.assertDottedNotesReadCorrectly(scoreWithDottedDurations);
 	}
 }

--- a/src/test/java/org/wmn4j/notation/DurationTest.java
+++ b/src/test/java/org/wmn4j/notation/DurationTest.java
@@ -4,8 +4,6 @@
 package org.wmn4j.notation;
 
 import org.junit.jupiter.api.Test;
-import org.wmn4j.notation.Duration;
-import org.wmn4j.notation.Durations;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,8 +19,9 @@ class DurationTest {
 	void testGetDurationWithValidParameter() {
 		final Duration duration = Duration.of(1, 4);
 		assertTrue(duration != null);
-		assertTrue(duration.getNumerator() == 1);
-		assertTrue(duration.getDenominator() == 4);
+		assertEquals(1, duration.getNumerator());
+		assertEquals(4, duration.getDenominator());
+		assertEquals(0, duration.getDotCount());
 	}
 
 	@Test
@@ -35,6 +34,12 @@ class DurationTest {
 		}
 		try {
 			final Duration duration = Duration.of(1, 0);
+			fail("No exception was thrown. Expected: IllegalArgumentException");
+		} catch (final Exception e) {
+			assertTrue(e instanceof IllegalArgumentException);
+		}
+		try {
+			final Duration duration = Duration.of(1, 2, -1);
 			fail("No exception was thrown. Expected: IllegalArgumentException");
 		} catch (final Exception e) {
 			assertTrue(e instanceof IllegalArgumentException);
@@ -136,8 +141,28 @@ class DurationTest {
 
 	@Test
 	void testAddDot() {
-		assertEquals(Duration.of(3, 8), Durations.QUARTER.addDot());
-		assertEquals(Duration.of(3, 4), Durations.HALF.addDot());
+		final Duration dottedQuarter = Durations.QUARTER.addDot();
+		assertEquals(Duration.of(3, 8), dottedQuarter);
+		assertEquals(1, dottedQuarter.getDotCount());
+
+		final Duration doubleDottedQuarter = dottedQuarter.addDot();
+		assertEquals(Duration.of(7, 16), doubleDottedQuarter);
+		assertEquals(2, doubleDottedQuarter.getDotCount());
+
+		final Duration tripleDottedHalf = Durations.HALF.addDot().addDot().addDot();
+		assertEquals(Duration.of(15, 16), tripleDottedHalf);
+		assertEquals(3, tripleDottedHalf.getDotCount());
+
+		Duration multiDottedTriplet = Durations.EIGHTH_TRIPLET;
+		Duration expected = Durations.EIGHTH_TRIPLET;
+
+		for (int dots = 1; dots < 5; dots++) {
+			multiDottedTriplet = multiDottedTriplet.addDot();
+			expected = expected.add(Durations.EIGHTH_TRIPLET.divideBy((int) Math.pow(2, dots)));
+
+			assertEquals(dots, multiDottedTriplet.getDotCount());
+			assertEquals(expected, multiDottedTriplet);
+		}
 	}
 
 	@Test

--- a/src/test/resources/musicxml/dotted_note_test.musicxml
+++ b/src/test/resources/musicxml/dotted_note_test.musicxml
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Title</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer</creator>
+    <encoding>
+      <software>MuseScore 3.4.2</software>
+      <encoding-date>2020-04-21</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1683.36</page-height>
+      <page-width>1190.88</page-width>
+      <page-margins type="even">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <credit page="1">
+    <credit-words default-x="595.44" default-y="1607.65" justify="center" valign="top" font-size="24">Dotted note test</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="404.13">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>0.00</left-margin>
+            <right-margin>-0.00</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>12</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="79.27" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>18</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <dot/>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        </note>
+      <note default-x="240.90" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>18</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <dot/>
+        </note>
+      </measure>
+    <measure number="2" width="315.72">
+      <note default-x="10.00" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>42</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot/>
+        <dot/>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        </note>
+      </measure>
+    <measure number="3" width="357.65">
+      <note default-x="10.00" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <dot/>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no"/>
+          </notations>
+        </note>
+      <note default-x="74.14" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">forward hook</beam>
+        </note>
+      <note default-x="107.01" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>eighth</normal-type>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop"/>
+          </notations>
+        </note>
+      <note>
+        <rest/>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>24</duration>
+        <voice>1</voice>
+        <type>half</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>


### PR DESCRIPTION
Addresses part of #123

Dot information is useful for note appearance inference. The dots
do not affect the use of Durations in computations.