### PR TITLE
Change accidental to enum

### DIFF
--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlPatternWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlPatternWriterDom.java
@@ -38,7 +38,7 @@ final class MusicXmlPatternWriterDom extends MusicXmlWriterDom {
 	private static final String DEFAULT_SCORE_TITLE = "Patterns";
 	private static final String VOICE_NAME = "Voice";
 	private static final String ABBREVIATED_VOICE_NAME = "V";
-	private static final int MIDDLE_C_AS_INT = Pitch.of(Pitch.Base.C, 0, 4).toInt();
+	private static final int MIDDLE_C_AS_INT = Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4).toInt();
 
 	private static final TimeSignature DEFAULT_TIME_SIGNATURE = TimeSignature.of(2, 1);
 	private static final Duration MEASURE_CUTOFF_DURATION = DEFAULT_TIME_SIGNATURE.getTotalDuration();

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
@@ -763,7 +763,7 @@ abstract class MusicXmlWriterDom implements MusicXmlWriter {
 		pitchElement.appendChild(step);
 
 		final Element alter = getDocument().createElement(MusicXmlTags.PITCH_ALTER);
-		alter.setTextContent(Integer.toString(pitch.getAlter()));
+		alter.setTextContent(Integer.toString(pitch.getAccidental().getAlterationInt()));
 		pitchElement.appendChild(alter);
 
 		final Element octave = getDocument().createElement(MusicXmlTags.PITCH_OCT);

--- a/src/main/java/org/wmn4j/notation/Note.java
+++ b/src/main/java/org/wmn4j/notation/Note.java
@@ -31,15 +31,14 @@ public final class Note implements Durational, Pitched {
 	/**
 	 * Returns an instance with the given parameters.
 	 *
-	 * @param pitchName the letter part of the pitch name
-	 * @param alter     how many half-steps the pitch is altered up (positive) or
-	 *                  down (negative)
-	 * @param octave    octave number of the pitch
-	 * @param duration  the duration of the note. Must not be null
+	 * @param pitchName  the letter part of the pitch name
+	 * @param accidental the accidental of the pitch
+	 * @param octave     octave number of the pitch
+	 * @param duration   the duration of the note. Must not be null
 	 * @return an instance with the given parameters
 	 */
-	public static Note of(Pitch.Base pitchName, int alter, int octave, Duration duration) {
-		return of(Pitch.of(pitchName, alter, octave), duration, null);
+	public static Note of(Pitch.Base pitchName, Pitch.Accidental accidental, int octave, Duration duration) {
+		return of(Pitch.of(pitchName, accidental, octave), duration, null);
 	}
 
 	/**

--- a/src/main/java/org/wmn4j/notation/Pitch.java
+++ b/src/main/java/org/wmn4j/notation/Pitch.java
@@ -64,9 +64,49 @@ public final class Pitch implements Comparable<Pitch> {
 	}
 
 	/**
-	 * The limit for altering notes in half-steps (=3).
+	 * Represents an accidental mark.
 	 */
-	public static final int ALTER_LIMIT = 3;
+	public enum Accidental {
+		/**
+		 * Represents the natural accidental (i.e., no alteration).
+		 */
+		NATURAL(0),
+
+		/**
+		 * Represents a normal sharp.
+		 */
+		SHARP(1),
+
+		/**
+		 * Represents a double sharp.
+		 */
+		DOUBLE_SHARP(2),
+
+		/**
+		 * Represents a normal flat.
+		 */
+		FLAT(-1),
+
+		/**
+		 * Represents a double flat.
+		 */
+		DOUBLE_FLAT(-2);
+
+		private final int alter;
+
+		Accidental(int alter) {
+			this.alter = alter;
+		}
+
+		/**
+		 * Returns the integer alteration to pitch number caused by this accidental.
+		 *
+		 * @return the integer alteration to pitch number caused by this accidental
+		 */
+		public int getAlterationInt() {
+			return alter;
+		}
+	}
 
 	/**
 	 * Highest allowed octave number (=10).
@@ -74,47 +114,34 @@ public final class Pitch implements Comparable<Pitch> {
 	public static final int MAX_OCTAVE = 10;
 
 	private final Base pitchBase;
-	private final int alter;
+	private final Accidental accidental;
 	private final int octave;
 
 	/**
 	 * Returns an instance.
 	 *
-	 * @param pitchName the letter on which the name of the pitch is based
-	 * @param alter     by how many half-steps the pitch is altered up (positive
-	 *                  values) or down (negative values)
-	 * @param octave    the octave of the pitch
+	 * @param pitchName  the letter on which the name of the pitch is based
+	 * @param accidental the accidental to use or natural if this pitch is not sharp or flat
+	 * @param octave     the octave of the pitch
 	 * @return Pitch object with the specified attributes
-	 * @throws IllegalArgumentException if alter is greater than {@link #ALTER_LIMIT
-	 *                                  ALTER_LIMIT} of smaller than
-	 *                                  {@link #ALTER_LIMIT -1*ALTER_LIMIT}, or if
-	 *                                  octave is negative or larger than
+	 * @throws IllegalArgumentException if octave is negative or larger than
 	 *                                  {@link #MAX_OCTAVE MAX_OCTAVE}.
 	 */
-	public static Pitch of(Base pitchName, int alter, int octave) {
-		if (alter > ALTER_LIMIT || alter < -1 * ALTER_LIMIT) {
-			throw new IllegalArgumentException(
-					"alter was " + alter + ". alter must be between -" + ALTER_LIMIT + " and " + ALTER_LIMIT);
-		}
-
+	public static Pitch of(Base pitchName, Accidental accidental, int octave) {
 		if (octave < 0 || octave > MAX_OCTAVE) {
 			throw new IllegalArgumentException("octave was " + octave + ". octave must be between 0 and " + MAX_OCTAVE);
 		}
 
-		return new Pitch(Objects.requireNonNull(pitchName), alter, octave);
+		return new Pitch(Objects.requireNonNull(pitchName), Objects.requireNonNull(accidental), octave);
 	}
 
 	/**
 	 * Private constructor.
-	 *
-	 * @param pitchName the letter on which the name of the pitch is based.
-	 * @param alter     by how many half-steps the pitch is altered up or down.
-	 * @param octave    the octave of the pitch.
 	 */
-	private Pitch(Base pitchName, int alter, int octave) {
+	private Pitch(Base pitchName, Accidental accidental, int octave) {
 		this.pitchBase = pitchName;
-		this.alter = alter;
 		this.octave = octave;
+		this.accidental = accidental;
 	}
 
 	/**
@@ -127,13 +154,12 @@ public final class Pitch implements Comparable<Pitch> {
 	}
 
 	/**
-	 * Returns by how many half-steps this pitch is altered.
+	 * Returns the accidental (i.e., alteration) of this pitch.
 	 *
-	 * @return by how many half-steps the pitch is altered up (positive value) or
-	 * down (negative value)
+	 * @return the accidental (i.e., alteration) of this pitch.
 	 */
-	public int getAlter() {
-		return this.alter;
+	public Accidental getAccidental() {
+		return accidental;
 	}
 
 	/**
@@ -157,7 +183,7 @@ public final class Pitch implements Comparable<Pitch> {
 	 * @return this Pitch as an integer.
 	 */
 	public int toInt() {
-		return this.pitchBase.pitchAsInt + this.alter + (this.octave + 1) * 12;
+		return this.pitchBase.pitchAsInt + accidental.getAlterationInt() + (this.octave + 1) * 12;
 	}
 
 	/**
@@ -195,6 +221,7 @@ public final class Pitch implements Comparable<Pitch> {
 	public String toString() {
 		String pitchName = this.pitchBase.toString();
 
+		final int alter = accidental.getAlterationInt();
 		if (alter >= 0) {
 			for (int i = 0; i < alter; ++i) {
 				pitchName += "#";
@@ -238,7 +265,7 @@ public final class Pitch implements Comparable<Pitch> {
 			return false;
 		}
 
-		if (other.alter != this.alter) {
+		if (other.accidental != this.accidental) {
 			return false;
 		}
 
@@ -249,7 +276,7 @@ public final class Pitch implements Comparable<Pitch> {
 	public int hashCode() {
 		int hash = 5;
 		hash = 89 * hash + Objects.hashCode(this.pitchBase);
-		hash = 89 * hash + this.alter;
+		hash = 89 * hash + Objects.hashCode(this.accidental);
 		hash = 89 * hash + this.octave;
 		return hash;
 	}

--- a/src/test/java/org/wmn4j/TestHelper.java
+++ b/src/test/java/org/wmn4j/TestHelper.java
@@ -32,10 +32,14 @@ public class TestHelper {
 
 	public static final String TESTFILE_PATH = "src/test/resources/";
 
-	private static final NoteBuilder C4 = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.HALF);
-	private static final NoteBuilder E4 = new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.HALF);
-	private static final NoteBuilder G4 = new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF);
-	private static final NoteBuilder C4Quarter = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+	private static final NoteBuilder C4 = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+			Durations.HALF);
+	private static final NoteBuilder E4 = new NoteBuilder(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4),
+			Durations.HALF);
+	private static final NoteBuilder G4 = new NoteBuilder(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4),
+			Durations.HALF);
+	private static final NoteBuilder C4Quarter = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+			Durations.QUARTER);
 
 	public static MeasureBuilder getTestMeasureBuilder(int number) {
 		final MeasureBuilder builder = new MeasureBuilder(number);

--- a/src/test/java/org/wmn4j/analysis/harmony/ChromagramBuilderTest.java
+++ b/src/test/java/org/wmn4j/analysis/harmony/ChromagramBuilderTest.java
@@ -17,11 +17,13 @@ class ChromagramBuilderTest {
 	// By how much values are allowed fo differ
 	private static final double TOLERANCE = 0.0000000001;
 
-	private static final Note C_EIGHTH = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
-	private static final Note E_EIGHTH = Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH);
-	private static final Note G_EIGHTH = Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH);
-	private static final Note C_SHARP_SIXTEENTH = Note.of(Pitch.of(Pitch.Base.C, 1, 4), Durations.SIXTEENTH);
-	private static final Note A_FLAT_TRIPLET = Note.of(Pitch.of(Pitch.Base.A, -1, 2), Durations.EIGHTH_TRIPLET);
+	private static final Note C_EIGHTH = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
+	private static final Note E_EIGHTH = Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
+	private static final Note G_EIGHTH = Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
+	private static final Note C_SHARP_SIXTEENTH = Note
+			.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.SHARP, 4), Durations.SIXTEENTH);
+	private static final Note A_FLAT_TRIPLET = Note
+			.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.FLAT, 2), Durations.EIGHTH_TRIPLET);
 	private static final Chord C_TRIAD_EIGHTH = Chord.of(C_EIGHTH, E_EIGHTH, G_EIGHTH);
 
 	@Test

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
@@ -63,7 +63,7 @@ class MusicXmlFileChecks {
 		assertEquals(Clefs.G, measure.getClef());
 
 		assertEquals(1, measure.getVoiceSize(1));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.WHOLE), measure.get(1, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.WHOLE), measure.get(1, 0));
 	}
 
 	/*
@@ -90,17 +90,23 @@ class MusicXmlFileChecks {
 
 		// Verify notes of measure one
 		assertEquals(8, measureOne.getVoiceSize(1));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), measureOne.get(1, 0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH), measureOne.get(1, 1));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH), measureOne.get(1, 2));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER),
+				measureOne.get(1, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+				measureOne.get(1, 1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+				measureOne.get(1, 2));
 		assertEquals(Rest.of(Durations.EIGHTH), measureOne.get(1, 3));
-		final Chord cMajor = Chord.of(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH),
-				Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH),
-				Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH));
+		final Chord cMajor = Chord.of(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+				Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+				Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		assertEquals(cMajor, measureOne.get(1, 4));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHTH_TRIPLET), measureOne.get(1, 5));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHTH_TRIPLET), measureOne.get(1, 6));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHTH_TRIPLET), measureOne.get(1, 7));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.EIGHTH_TRIPLET),
+				measureOne.get(1, 5));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.EIGHTH_TRIPLET),
+				measureOne.get(1, 6));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.EIGHTH_TRIPLET),
+				measureOne.get(1, 7));
 
 		// Verify data of measure two
 		final Measure measureTwo = staff.getMeasure(2);
@@ -113,13 +119,18 @@ class MusicXmlFileChecks {
 
 		// Verify notes of measure two
 		assertEquals(2, measureTwo.getVoiceSize(1));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.HALF), measureTwo.get(1, 0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.HALF), measureTwo.get(1, 1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.HALF),
+				measureTwo.get(1, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.HALF),
+				measureTwo.get(1, 1));
 
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), measureTwo.get(2, 0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), measureTwo.get(2, 1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER),
+				measureTwo.get(2, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER),
+				measureTwo.get(2, 1));
 		assertEquals(Rest.of(Durations.QUARTER), measureTwo.get(2, 2));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), measureTwo.get(2, 3));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER),
+				measureTwo.get(2, 3));
 	}
 
 	/*
@@ -146,8 +157,10 @@ class MusicXmlFileChecks {
 
 		// Verify contents of measure one of staff one
 		assertEquals(1, staffOneMeasureOne.getVoiceCount());
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF), staffOneMeasureOne.get(1, 0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER), staffOneMeasureOne.get(1, 1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.HALF),
+				staffOneMeasureOne.get(1, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.QUARTER),
+				staffOneMeasureOne.get(1, 1));
 
 		// Verify data of measure two of staff one
 		final Measure staffOneMeasureTwo = staffOne.getMeasure(2);
@@ -161,7 +174,8 @@ class MusicXmlFileChecks {
 		// Verify contents of measure one of staff one
 		assertEquals(1, staffOneMeasureTwo.getVoiceCount());
 		assertEquals(Rest.of(Durations.QUARTER), staffOneMeasureTwo.get(1, 0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF), staffOneMeasureTwo.get(1, 1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.HALF),
+				staffOneMeasureTwo.get(1, 1));
 
 		final SingleStaffPart partTwo = (SingleStaffPart) score.getPart(1);
 		final Staff staffTwo = partTwo.getStaff();
@@ -179,7 +193,8 @@ class MusicXmlFileChecks {
 
 		// Verify contents of measure one of staff two
 		assertEquals(1, staffTwoMeasureOne.getVoiceCount());
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 3), Durations.HALF.addDot()), staffTwoMeasureOne.get(1, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 3), Durations.HALF.addDot()),
+				staffTwoMeasureOne.get(1, 0));
 
 		// Verify data of measure two of staff two
 		final Measure staffTwoMeasureTwo = staffTwo.getMeasure(2);
@@ -192,7 +207,8 @@ class MusicXmlFileChecks {
 
 		// Verify contents of measure two of staff two
 		assertEquals(1, staffTwoMeasureTwo.getVoiceCount());
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 3), Durations.HALF.addDot()), staffTwoMeasureTwo.get(1, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 3), Durations.HALF.addDot()),
+				staffTwoMeasureTwo.get(1, 0));
 	}
 
 	/*
@@ -326,7 +342,7 @@ class MusicXmlFileChecks {
 		assertEquals(2, multiStaff.getStaffCount());
 
 		int measureCount = 0;
-		final Note expectedNote = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.WHOLE);
+		final Note expectedNote = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.WHOLE);
 
 		for (Measure measure : multiStaff) {
 			assertTrue(measure.isSingleVoice());
@@ -377,7 +393,8 @@ class MusicXmlFileChecks {
 		final Measure firstMeasure = part.getMeasure(1);
 		final Note first = (Note) firstMeasure.get(1, 0);
 		assertTrue(first.isTiedToFollowing());
-		assertEquals(Pitch.of(Pitch.Base.C, 0, 4), first.getFollowingTiedNote().get().getPitch());
+		assertEquals(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+				first.getFollowingTiedNote().get().getPitch());
 
 		final Note second = (Note) firstMeasure.get(1, 1);
 		assertTrue(second.isTiedFromPrevious());
@@ -856,14 +873,20 @@ class MusicXmlFileChecks {
 	 */
 	static void assertClefChangeInCorrectPlaceWhenNoteCarriesOverClefChange(Score score) {
 		final Measure measure = score.getPart(0).getMeasure(1, 1);
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER), measure.get(1, 0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.D, 0, 5), Durations.HALF), measure.get(1, 1));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.F, 0, 5), Durations.QUARTER), measure.get(1, 2));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.QUARTER),
+				measure.get(1, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 5), Durations.HALF), measure.get(1, 1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.F, Pitch.Accidental.NATURAL, 5), Durations.QUARTER),
+				measure.get(1, 2));
 
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER), measure.get(2, 0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER), measure.get(2, 1));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 3), Durations.QUARTER), measure.get(2, 2));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 3), Durations.QUARTER), measure.get(2, 3));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.QUARTER),
+				measure.get(2, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.QUARTER),
+				measure.get(2, 1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 3), Durations.QUARTER),
+				measure.get(2, 2));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 3), Durations.QUARTER),
+				measure.get(2, 3));
 
 		assertEquals(Clefs.G, measure.getClef());
 		final Map<Duration, Clef> clefChanges = measure.getClefChanges();

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlPatternWriterDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlPatternWriterDomTest.java
@@ -63,27 +63,27 @@ class MusicXmlPatternWriterDomTest {
 
 	private final List<Durational> getPatternVoiceOnGClef() {
 		List<Durational> voice = new ArrayList<>();
-		voice.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		voice.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
 		voice.add(Rest.of(Durations.QUARTER));
-		voice.add(Note.of(Pitch.of(Pitch.Base.A, -1, 4), Durations.EIGHTH));
-		voice.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHTH));
-		voice.add(Chord.of(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER),
-				Note.of(Pitch.of(Pitch.Base.F, 1, 4), Durations.QUARTER),
-				Note.of(Pitch.of(Pitch.Base.A, 0, 4), Durations.QUARTER)));
-		voice.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
-		voice.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.HALF));
+		voice.add(Note.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.FLAT, 4), Durations.EIGHTH));
+		voice.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.EIGHTH));
+		voice.add(Chord.of(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.QUARTER),
+				Note.of(Pitch.of(Pitch.Base.F, Pitch.Accidental.SHARP, 4), Durations.QUARTER),
+				Note.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 4), Durations.QUARTER)));
+		voice.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.SIXTEENTH));
+		voice.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.HALF));
 		return voice;
 	}
 
 	private final List<Durational> getPatternVoiceOnFClef() {
 		List<Durational> voice = new ArrayList<>();
-		voice.add(Note.of(Pitch.of(Pitch.Base.C, 0, 2), Durations.QUARTER));
+		voice.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2), Durations.QUARTER));
 		voice.add(Rest.of(Durations.QUARTER));
-		voice.add(Note.of(Pitch.of(Pitch.Base.A, -1, 2), Durations.EIGHTH));
-		voice.add(Note.of(Pitch.of(Pitch.Base.C, 0, 3), Durations.EIGHTH));
-		voice.add(Chord.of(Note.of(Pitch.of(Pitch.Base.D, 0, 2), Durations.QUARTER),
-				Note.of(Pitch.of(Pitch.Base.F, 1, 2), Durations.QUARTER),
-				Note.of(Pitch.of(Pitch.Base.A, 0, 2), Durations.QUARTER)));
+		voice.add(Note.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.FLAT, 2), Durations.EIGHTH));
+		voice.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 3), Durations.EIGHTH));
+		voice.add(Chord.of(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 2), Durations.QUARTER),
+				Note.of(Pitch.of(Pitch.Base.F, Pitch.Accidental.SHARP, 2), Durations.QUARTER),
+				Note.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 2), Durations.QUARTER)));
 		return voice;
 	}
 
@@ -234,7 +234,7 @@ class MusicXmlPatternWriterDomTest {
 
 	@Test
 	void givenTwoMultivoicePatternsWhenPatternsAreWrittenThenOutputHasCorrectLayout() {
-		List<Durational> singleNoteVoice = Arrays.asList(Note.of(Pitch.Base.C, 0, 4, Durations.QUARTER));
+		List<Durational> singleNoteVoice = Arrays.asList(Note.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4, Durations.QUARTER));
 
 		Map<Integer, List<? extends Durational>> pattern1voices = new HashMap<>();
 		pattern1voices.put(1, singleNoteVoice);
@@ -292,7 +292,7 @@ class MusicXmlPatternWriterDomTest {
 
 	@Test
 	void testGivenPatternsWithNamesAndLabelsWhenWrittenToMusicXmlThenNamesAndLabelsCorrectlyOutputted() {
-		List<Durational> singleNoteVoice = Arrays.asList(Note.of(Pitch.Base.C, 0, 4, Durations.QUARTER));
+		List<Durational> singleNoteVoice = Arrays.asList(Note.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4, Durations.QUARTER));
 
 		Set<String> labels = new HashSet<>();
 		labels.add("LabelA1");

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlScoreWriterDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlScoreWriterDomTest.java
@@ -93,9 +93,12 @@ class MusicXmlScoreWriterDomTest {
 		PartBuilder partBuilder = new PartBuilder("Part1");
 		MeasureBuilder measureBuilder = new MeasureBuilder(1);
 
-		measureBuilder.addToVoice(1, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 0), Durations.QUARTER));
-		measureBuilder.addToVoice(1, new NoteBuilder(Pitch.of(Pitch.Base.D, 1, 1), Durations.HALF));
-		measureBuilder.addToVoice(1, new NoteBuilder(Pitch.of(Pitch.Base.E, -2, 2), Durations.QUARTER_TRIPLET));
+		measureBuilder
+				.addToVoice(1, new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 0), Durations.QUARTER));
+		measureBuilder
+				.addToVoice(1, new NoteBuilder(Pitch.of(Pitch.Base.D, Pitch.Accidental.SHARP, 1), Durations.HALF));
+		measureBuilder.addToVoice(1,
+				new NoteBuilder(Pitch.of(Pitch.Base.E, Pitch.Accidental.DOUBLE_FLAT, 2), Durations.QUARTER_TRIPLET));
 
 		partBuilder.add(measureBuilder);
 		scoreBuilder.addPart(partBuilder);
@@ -107,19 +110,19 @@ class MusicXmlScoreWriterDomTest {
 
 		Note note = (Note) iterator.next();
 		assertEquals(Pitch.Base.C, note.getPitch().getBase());
-		assertEquals(0, note.getPitch().getAlter());
+		assertEquals(Pitch.Accidental.NATURAL, note.getPitch().getAccidental());
 		assertEquals(0, note.getPitch().getOctave());
 		assertEquals(Durations.QUARTER, note.getDuration());
 
 		note = (Note) iterator.next();
 		assertEquals(Pitch.Base.D, note.getPitch().getBase());
-		assertEquals(1, note.getPitch().getAlter());
+		assertEquals(Pitch.Accidental.SHARP, note.getPitch().getAccidental());
 		assertEquals(1, note.getPitch().getOctave());
 		assertEquals(Durations.HALF, note.getDuration());
 
 		note = (Note) iterator.next();
 		assertEquals(Pitch.Base.E, note.getPitch().getBase());
-		assertEquals(-2, note.getPitch().getAlter());
+		assertEquals(Pitch.Accidental.DOUBLE_FLAT, note.getPitch().getAccidental());
 		assertEquals(2, note.getPitch().getOctave());
 		assertEquals(Durations.QUARTER_TRIPLET, note.getDuration());
 

--- a/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/MonophonicPatternTest.java
@@ -29,11 +29,11 @@ class MonophonicPatternTest {
 
 	MonophonicPatternTest() {
 		final List<Durational> notes = new ArrayList<>();
-		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
-		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHTH));
+		notes.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		notes.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.EIGHTH));
 		notes.add(Rest.of(Durations.QUARTER));
-		notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
-		notes.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
+		notes.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		notes.add(Note.of(Pitch.of(Pitch.Base.B, Pitch.Accidental.FLAT, 3), Durations.QUARTER));
 
 		this.referenceNotes = Collections.unmodifiableList(notes);
 	}
@@ -57,8 +57,8 @@ class MonophonicPatternTest {
 		}
 
 		final List<Durational> chordList = new ArrayList<>();
-		chordList.add(Chord.of(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH),
-				Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH)));
+		chordList.add(Chord.of(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+				Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)));
 
 		try {
 			new MonophonicPattern(chordList);
@@ -129,10 +129,10 @@ class MonophonicPatternTest {
 		final Pattern pattern = new MonophonicPattern(this.referenceNotes);
 
 		final List<Durational> notes = new ArrayList<>();
-		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
-		notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
-		notes.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.WHOLE));
+		notes.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		notes.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.SIXTEENTH));
+		notes.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		notes.add(Note.of(Pitch.of(Pitch.Base.B, Pitch.Accidental.FLAT, 3), Durations.WHOLE));
 
 		assertTrue(pattern.equalsInPitch(new MonophonicPattern(notes)));
 
@@ -141,11 +141,11 @@ class MonophonicPatternTest {
 		assertTrue(pattern.equalsInPitch(new MonophonicPattern(notes)),
 				"Adding rest to end of pattern should not make pattern inequal in pitches");
 
-		notes.set(1, Note.of(Pitch.of(Pitch.Base.E, -1, 3), Durations.WHOLE));
+		notes.set(1, Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.FLAT, 3), Durations.WHOLE));
 		assertFalse(pattern.equalsInPitch(new MonophonicPattern(notes)));
 
 		List<Durational> referenceNotesWithAddition = new ArrayList<>(referenceNotes);
-		referenceNotesWithAddition.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
+		referenceNotesWithAddition.add(Note.of(Pitch.of(Pitch.Base.B, Pitch.Accidental.FLAT, 3), Durations.QUARTER));
 		assertFalse(pattern.equalsInPitch(new MonophonicPattern(referenceNotesWithAddition)));
 	}
 
@@ -156,21 +156,29 @@ class MonophonicPatternTest {
 		assertTrue(pattern.equalsEnharmonically(new MonophonicPattern(referenceNotes)));
 
 		final List<Durational> samePitchesWithDifferentDurations = new ArrayList<>();
-		samePitchesWithDifferentDurations.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		samePitchesWithDifferentDurations.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
+		samePitchesWithDifferentDurations
+				.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		samePitchesWithDifferentDurations
+				.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.SIXTEENTH));
 		samePitchesWithDifferentDurations.add(Rest.of(Durations.QUARTER));
-		samePitchesWithDifferentDurations.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
-		samePitchesWithDifferentDurations.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.WHOLE));
+		samePitchesWithDifferentDurations
+				.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		samePitchesWithDifferentDurations
+				.add(Note.of(Pitch.of(Pitch.Base.B, Pitch.Accidental.FLAT, 3), Durations.WHOLE));
 
 		assertTrue(pattern.equalsEnharmonically(new MonophonicPattern(samePitchesWithDifferentDurations)),
 				"Difference in durations affected enharmonic equality when it shouldn't have affected it.");
 
 		final List<Durational> samePitchesWithDifferentSpellings = new ArrayList<>();
-		samePitchesWithDifferentSpellings.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
-		samePitchesWithDifferentSpellings.add(Note.of(Pitch.of(Pitch.Base.D, -2, 5), Durations.EIGHTH));
+		samePitchesWithDifferentSpellings
+				.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		samePitchesWithDifferentSpellings
+				.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.DOUBLE_FLAT, 5), Durations.EIGHTH));
 		samePitchesWithDifferentSpellings.add(Rest.of(Durations.QUARTER));
-		samePitchesWithDifferentSpellings.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
-		samePitchesWithDifferentSpellings.add(Note.of(Pitch.of(Pitch.Base.A, 1, 3), Durations.QUARTER));
+		samePitchesWithDifferentSpellings
+				.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		samePitchesWithDifferentSpellings
+				.add(Note.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.SHARP, 3), Durations.QUARTER));
 
 		assertTrue(pattern.equalsEnharmonically(new MonophonicPattern(samePitchesWithDifferentSpellings)),
 				"Difference in note spellings affected enharmonic equality when it shouldn't have affected it.");
@@ -182,11 +190,14 @@ class MonophonicPatternTest {
 				"Adding rest to end of pattern should not make patterns unequal enharmonically.");
 
 		final List<Durational> enharmonicallyUnequalPitches = new ArrayList<>();
-		enharmonicallyUnequalPitches.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
-		enharmonicallyUnequalPitches.add(Note.of(Pitch.of(Pitch.Base.D, 0, 5), Durations.EIGHTH));
+		enharmonicallyUnequalPitches
+				.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		enharmonicallyUnequalPitches
+				.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 5), Durations.EIGHTH));
 		enharmonicallyUnequalPitches.add(Rest.of(Durations.QUARTER));
-		enharmonicallyUnequalPitches.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
-		enharmonicallyUnequalPitches.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
+		enharmonicallyUnequalPitches
+				.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		enharmonicallyUnequalPitches.add(Note.of(Pitch.of(Pitch.Base.B, Pitch.Accidental.FLAT, 3), Durations.QUARTER));
 
 		assertFalse(pattern.equalsEnharmonically(new MonophonicPattern(enharmonicallyUnequalPitches)));
 	}
@@ -197,45 +208,47 @@ class MonophonicPatternTest {
 		assertTrue(pattern.equalsTranspositionally(new MonophonicPattern(referenceNotes)));
 
 		final List<Durational> transposedUpByMajorSecond = new ArrayList<>();
-		transposedUpByMajorSecond.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
-		transposedUpByMajorSecond.add(Note.of(Pitch.of(Pitch.Base.D, 0, 5), Durations.EIGHTH));
+		transposedUpByMajorSecond.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		transposedUpByMajorSecond.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 5), Durations.EIGHTH));
 		transposedUpByMajorSecond.add(Rest.of(Durations.QUARTER));
-		transposedUpByMajorSecond.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER));
-		transposedUpByMajorSecond.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		transposedUpByMajorSecond.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		transposedUpByMajorSecond.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
 
 		assertTrue(pattern.equalsTranspositionally(new MonophonicPattern(transposedUpByMajorSecond)));
 
 		final List<Durational> transposedDownByOctave = new ArrayList<>();
-		transposedDownByOctave.add(Note.of(Pitch.of(Pitch.Base.C, 0, 3), Durations.EIGHTH));
-		transposedDownByOctave.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
+		transposedDownByOctave.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 3), Durations.EIGHTH));
+		transposedDownByOctave.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		transposedDownByOctave.add(Rest.of(Durations.QUARTER));
-		transposedDownByOctave.add(Note.of(Pitch.of(Pitch.Base.D, 0, 3), Durations.QUARTER));
-		transposedDownByOctave.add(Note.of(Pitch.of(Pitch.Base.B, -1, 2), Durations.QUARTER));
+		transposedDownByOctave.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 3), Durations.QUARTER));
+		transposedDownByOctave.add(Note.of(Pitch.of(Pitch.Base.B, Pitch.Accidental.FLAT, 2), Durations.QUARTER));
 
 		assertTrue(pattern.equalsTranspositionally(new MonophonicPattern(transposedDownByOctave)));
 
 		final List<Durational> withOneNoteInDifferentOctaveThanInReferencePattern = new ArrayList<>();
-		withOneNoteInDifferentOctaveThanInReferencePattern.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
-		withOneNoteInDifferentOctaveThanInReferencePattern.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
+		withOneNoteInDifferentOctaveThanInReferencePattern
+				.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		withOneNoteInDifferentOctaveThanInReferencePattern
+				.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		withOneNoteInDifferentOctaveThanInReferencePattern.add(Rest.of(Durations.QUARTER));
 		withOneNoteInDifferentOctaveThanInReferencePattern
-				.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
+				.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
 		withOneNoteInDifferentOctaveThanInReferencePattern
-				.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
+				.add(Note.of(Pitch.of(Pitch.Base.B, Pitch.Accidental.FLAT, 3), Durations.QUARTER));
 
 		assertFalse(pattern.equalsTranspositionally(
 				new MonophonicPattern(withOneNoteInDifferentOctaveThanInReferencePattern)));
 
 		final List<Durational> transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond = new ArrayList<>();
 		transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond
-				.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+				.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond
-				.add(Note.of(Pitch.of(Pitch.Base.D, 0, 5), Durations.EIGHTH));
+				.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 5), Durations.EIGHTH));
 		transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond.add(Rest.of(Durations.QUARTER));
 		transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond
-				.add(Note.of(Pitch.of(Pitch.Base.D, 1, 4), Durations.QUARTER));
+				.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.SHARP, 4), Durations.QUARTER));
 		transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond
-				.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
+				.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
 
 		assertFalse(pattern.equalsTranspositionally(
 				new MonophonicPattern(transposedUpByMajorSecondWithOneNoteTransposedByMinorSecond)));
@@ -252,38 +265,47 @@ class MonophonicPatternTest {
 		assertTrue(pattern.equalsInDurations(new MonophonicPattern(referenceNotes)));
 
 		List<Durational> withSameDurationsButDifferentPitches = new ArrayList<>();
-		withSameDurationsButDifferentPitches.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
-		withSameDurationsButDifferentPitches.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHTH));
+		withSameDurationsButDifferentPitches
+				.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		withSameDurationsButDifferentPitches
+				.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.EIGHTH));
 		withSameDurationsButDifferentPitches.add(Rest.of(Durations.QUARTER));
-		withSameDurationsButDifferentPitches.add(Note.of(Pitch.of(Pitch.Base.D, -1, 4), Durations.QUARTER));
-		withSameDurationsButDifferentPitches.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
+		withSameDurationsButDifferentPitches
+				.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.FLAT, 4), Durations.QUARTER));
+		withSameDurationsButDifferentPitches
+				.add(Note.of(Pitch.of(Pitch.Base.B, Pitch.Accidental.FLAT, 3), Durations.QUARTER));
 
 		assertTrue(pattern.equalsInDurations(new MonophonicPattern(withSameDurationsButDifferentPitches)));
 
 		List<Durational> withDifferentNoteDurations = new ArrayList<>();
-		withDifferentNoteDurations.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
-		withDifferentNoteDurations.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.SIXTEENTH));
+		withDifferentNoteDurations.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		withDifferentNoteDurations
+				.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.SIXTEENTH));
 		withDifferentNoteDurations.add(Rest.of(Durations.QUARTER));
-		withDifferentNoteDurations.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
-		withDifferentNoteDurations.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
+		withDifferentNoteDurations.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		withDifferentNoteDurations.add(Note.of(Pitch.of(Pitch.Base.B, Pitch.Accidental.FLAT, 3), Durations.QUARTER));
 
 		assertFalse(pattern.equalsInDurations(new MonophonicPattern(withDifferentNoteDurations)));
 
 		List<Durational> withDifferentRestDurations = new ArrayList<>();
-		withDifferentRestDurations.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
-		withDifferentRestDurations.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHTH));
+		withDifferentRestDurations.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		withDifferentRestDurations.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.EIGHTH));
 		withDifferentRestDurations.add(Rest.of(Durations.EIGHTH));
-		withDifferentRestDurations.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
-		withDifferentRestDurations.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
+		withDifferentRestDurations.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		withDifferentRestDurations.add(Note.of(Pitch.of(Pitch.Base.B, Pitch.Accidental.FLAT, 3), Durations.QUARTER));
 
 		assertFalse(pattern.equalsInDurations(new MonophonicPattern(withDifferentRestDurations)));
 
 		final List<Durational> withRestInAPlaceWhereReferenceHasANote = new ArrayList<>();
-		withRestInAPlaceWhereReferenceHasANote.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
-		withRestInAPlaceWhereReferenceHasANote.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHTH));
-		withRestInAPlaceWhereReferenceHasANote.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
+		withRestInAPlaceWhereReferenceHasANote
+				.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		withRestInAPlaceWhereReferenceHasANote
+				.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.EIGHTH));
+		withRestInAPlaceWhereReferenceHasANote
+				.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
 		withRestInAPlaceWhereReferenceHasANote.add(Rest.of(Durations.QUARTER));
-		withRestInAPlaceWhereReferenceHasANote.add(Note.of(Pitch.of(Pitch.Base.B, -1, 3), Durations.QUARTER));
+		withRestInAPlaceWhereReferenceHasANote
+				.add(Note.of(Pitch.of(Pitch.Base.B, Pitch.Accidental.FLAT, 3), Durations.QUARTER));
 
 		assertFalse(pattern.equalsInDurations(new MonophonicPattern(withRestInAPlaceWhereReferenceHasANote)));
 

--- a/src/test/java/org/wmn4j/mir/PatternBuilderTest.java
+++ b/src/test/java/org/wmn4j/mir/PatternBuilderTest.java
@@ -20,22 +20,22 @@ class PatternBuilderTest {
 	void testGivenMonophonicContentsWhenBuiltMonophonicPatternIsCreated() {
 		final PatternBuilder builder = new PatternBuilder();
 
-		final Note firstElement = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
+		final Note firstElement = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
 		builder.add(new NoteBuilder(firstElement));
 
-		final Note secondElement = Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH);
+		final Note secondElement = Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
 		builder.add(new NoteBuilder(secondElement));
 
 		final Rest thirdElement = Rest.of(Durations.QUARTER);
 		builder.add(new RestBuilder(thirdElement));
 
-		final Note fourthElement = Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.SIXTEENTH);
+		final Note fourthElement = Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.SIXTEENTH);
 		builder.add(new NoteBuilder(fourthElement));
 
 		final Rest fifthElement = Rest.of(Durations.EIGHTH);
 		builder.add(new RestBuilder(fifthElement));
 
-		final Note sixthElement = Note.of(Pitch.of(Pitch.Base.B, -1, 4), Durations.SIXTEENTH);
+		final Note sixthElement = Note.of(Pitch.of(Pitch.Base.B, Pitch.Accidental.FLAT, 4), Durations.SIXTEENTH);
 		builder.add(new NoteBuilder(sixthElement));
 
 		assertTrue(builder.isMonophonic());
@@ -57,23 +57,24 @@ class PatternBuilderTest {
 	void testGivenPolyphonicContentsInSingleVoiceWhenBuiltPolyphonicPatternIsCreated() {
 		final PatternBuilder builder = new PatternBuilder();
 
-		final Note firstElement = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
+		final Note firstElement = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
 		builder.add(new NoteBuilder(firstElement));
 
-		final Note secondElement = Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH);
+		final Note secondElement = Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
 		builder.add(new NoteBuilder(secondElement));
 
 		final Rest thirdElement = Rest.of(Durations.QUARTER);
 		builder.add(new RestBuilder(thirdElement));
 
-		final Note fourthElement = Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.SIXTEENTH);
+		final Note fourthElement = Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.SIXTEENTH);
 		builder.add(new NoteBuilder(fourthElement));
 
 		final Rest fifthElement = Rest.of(Durations.EIGHTH);
 		builder.add(new RestBuilder(fifthElement));
 
-		final Chord sixthElement = Chord.of(Note.of(Pitch.of(Pitch.Base.B, -1, 4), Durations.SIXTEENTH),
-				Note.of(Pitch.of(Pitch.Base.E, -1, 4), Durations.SIXTEENTH));
+		final Chord sixthElement = Chord
+				.of(Note.of(Pitch.of(Pitch.Base.B, Pitch.Accidental.FLAT, 4), Durations.SIXTEENTH),
+						Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.FLAT, 4), Durations.SIXTEENTH));
 		builder.add(new ChordBuilder(sixthElement));
 
 		assertFalse(builder.isMonophonic());
@@ -98,23 +99,23 @@ class PatternBuilderTest {
 		final PatternBuilder builder = new PatternBuilder();
 
 		final int voice1number = 1;
-		final Note firstElement = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
+		final Note firstElement = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
 		builder.addToVoice(voice1number, new NoteBuilder(firstElement));
 
-		final Note secondElement = Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH);
+		final Note secondElement = Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
 		builder.addToVoice(voice1number, new NoteBuilder(secondElement));
 
 		final Rest thirdElement = Rest.of(Durations.QUARTER);
 		builder.addToVoice(voice1number, new RestBuilder(thirdElement));
 
 		final int voice2number = 2;
-		final Note fourthElement = Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.SIXTEENTH);
+		final Note fourthElement = Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.SIXTEENTH);
 		builder.addToVoice(voice2number, new NoteBuilder(fourthElement));
 
 		final Rest fifthElement = Rest.of(Durations.EIGHTH);
 		builder.addToVoice(voice2number, new RestBuilder(fifthElement));
 
-		final Note sixthElement = Note.of(Pitch.of(Pitch.Base.B, -1, 4), Durations.SIXTEENTH);
+		final Note sixthElement = Note.of(Pitch.of(Pitch.Base.B, Pitch.Accidental.FLAT, 4), Durations.SIXTEENTH);
 		builder.addToVoice(voice2number, new NoteBuilder(sixthElement));
 
 		final Pattern patternWithTwoVoices = builder.build();
@@ -137,7 +138,7 @@ class PatternBuilderTest {
 	void testSettingName() {
 		final PatternBuilder builder = new PatternBuilder();
 
-		final Note firstElement = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
+		final Note firstElement = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
 		builder.add(new NoteBuilder(firstElement));
 
 		final String patternName = "Pattern A";
@@ -151,7 +152,7 @@ class PatternBuilderTest {
 	void testAddingLabels() {
 		final PatternBuilder builder = new PatternBuilder();
 
-		final Note firstElement = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
+		final Note firstElement = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
 		builder.add(new NoteBuilder(firstElement));
 
 		String labelA = "LabelA";

--- a/src/test/java/org/wmn4j/mir/PatternTest.java
+++ b/src/test/java/org/wmn4j/mir/PatternTest.java
@@ -21,10 +21,10 @@ public class PatternTest {
 
 	@Test
 	public void testCreatingPatternFromList() {
-		final Note noteC = Note.of(Pitch.Base.C, 0, 4, Durations.HALF);
-		final Note noteD = Note.of(Pitch.Base.D, 0, 4, Durations.HALF);
-		final Note noteE = Note.of(Pitch.Base.E, 0, 4, Durations.QUARTER);
-		final Note noteF = Note.of(Pitch.Base.F, 0, 4, Durations.QUARTER);
+		final Note noteC = Note.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4, Durations.HALF);
+		final Note noteD = Note.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4, Durations.HALF);
+		final Note noteE = Note.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4, Durations.QUARTER);
+		final Note noteF = Note.of(Pitch.Base.F, Pitch.Accidental.NATURAL, 4, Durations.QUARTER);
 
 		List<Note> notes = new ArrayList<>();
 		notes.add(noteC);
@@ -60,15 +60,15 @@ public class PatternTest {
 	public void testCreatingPatternFromMap() {
 		final Map<Integer, List<? extends Durational>> voices = new HashMap<>();
 		List<Durational> voice1 = new ArrayList<>();
-		voice1.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
+		voice1.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		voice1.add(Rest.of(Durations.QUARTER));
-		voice1.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+		voice1.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 
 		List<Durational> voice2 = new ArrayList<>();
 
-		voice2.add(Note.of(Pitch.of(Pitch.Base.E, 0, 3), Durations.QUARTER));
+		voice2.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 3), Durations.QUARTER));
 		voice2.add(Rest.of(Durations.EIGHTH));
-		voice2.add(Note.of(Pitch.of(Pitch.Base.F, 1, 3), Durations.EIGHTH));
+		voice2.add(Note.of(Pitch.of(Pitch.Base.F, Pitch.Accidental.SHARP, 3), Durations.EIGHTH));
 
 		voices.put(1, voice1);
 		voices.put(2, voice2);

--- a/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
@@ -27,15 +27,15 @@ public class PolyphonicPatternTest {
 	private Map<Integer, List<? extends Durational>> createReferencePatternVoices() {
 		final Map<Integer, List<? extends Durational>> voices = new HashMap<>();
 		List<Durational> voice1 = new ArrayList<>();
-		voice1.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
+		voice1.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		voice1.add(Rest.of(Durations.QUARTER));
-		voice1.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+		voice1.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 
 		List<Durational> voice2 = new ArrayList<>();
 
-		voice2.add(Note.of(Pitch.of(Pitch.Base.E, 0, 3), Durations.QUARTER));
+		voice2.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 3), Durations.QUARTER));
 		voice2.add(Rest.of(Durations.EIGHTH));
-		voice2.add(Note.of(Pitch.of(Pitch.Base.F, 1, 3), Durations.EIGHTH));
+		voice2.add(Note.of(Pitch.of(Pitch.Base.F, Pitch.Accidental.SHARP, 3), Durations.EIGHTH));
 
 		voices.put(1, voice1);
 		voices.put(2, voice2);
@@ -58,8 +58,8 @@ public class PolyphonicPatternTest {
 				"Did not throw IllegalArgumentException when trying to create polyphonic pattern with empty voices");
 
 		List<Note> notes = new ArrayList<>();
-		notes.add(Note.of(Pitch.of(Pitch.Base.B, 0, 3), Durations.QUARTER));
-		notes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 3), Durations.QUARTER));
+		notes.add(Note.of(Pitch.of(Pitch.Base.B, Pitch.Accidental.NATURAL, 3), Durations.QUARTER));
+		notes.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 3), Durations.QUARTER));
 
 		Map<Integer, List<? extends Durational>> voices = new HashMap<>();
 		voices.put(1, notes);
@@ -79,12 +79,12 @@ public class PolyphonicPatternTest {
 		final Map<Integer, List<? extends Durational>> voices = new HashMap<>();
 		List<Durational> voice = new ArrayList<>();
 		List<Note> chordContents = new ArrayList<>();
-		chordContents.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
-		chordContents.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH));
-		chordContents.add(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		voice.add(Chord.of(chordContents));
 		voice.add(Rest.of(Durations.QUARTER));
-		voice.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+		voice.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		voices.put(1, voice);
 
 		final Pattern patternWithChord = new PolyphonicPattern(voices);
@@ -143,7 +143,7 @@ public class PolyphonicPatternTest {
 
 		Map<Integer, List<? extends Durational>> modifiedVoices = createReferencePatternVoices();
 		List<Durational> modifiedVoice = new ArrayList<>(modifiedVoices.get(2));
-		Note note = Note.of(Pitch.of(Pitch.Base.C, 1, 5), Durations.EIGHTH);
+		Note note = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.SHARP, 5), Durations.EIGHTH);
 		modifiedVoice.add(note);
 		modifiedVoices.put(2, modifiedVoice);
 
@@ -173,7 +173,7 @@ public class PolyphonicPatternTest {
 
 		Map<Integer, List<? extends Durational>> modifiedVoices = createReferencePatternVoices();
 		List<Durational> modifiedVoice = new ArrayList<>(modifiedVoices.get(1));
-		Note note = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.SIXTEENTH);
+		Note note = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.SIXTEENTH);
 		modifiedVoice.set(0, note);
 		modifiedVoices.put(1, modifiedVoice);
 
@@ -182,16 +182,16 @@ public class PolyphonicPatternTest {
 
 		final Map<Integer, List<? extends Durational>> voicesWithDifferentRests = new HashMap<>();
 		List<Durational> voice1 = new ArrayList<>();
-		voice1.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
+		voice1.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		voice1.add(Rest.of(Durations.EIGHTH));
 		voice1.add(Rest.of(Durations.SIXTEENTH));
-		voice1.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+		voice1.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 
 		List<Durational> voice2 = new ArrayList<>();
 
-		voice2.add(Note.of(Pitch.of(Pitch.Base.E, 0, 3), Durations.QUARTER));
+		voice2.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 3), Durations.QUARTER));
 		voice2.add(Rest.of(Durations.SIXTEENTH));
-		voice2.add(Note.of(Pitch.of(Pitch.Base.F, 1, 3), Durations.EIGHTH));
+		voice2.add(Note.of(Pitch.of(Pitch.Base.F, Pitch.Accidental.SHARP, 3), Durations.EIGHTH));
 
 		voicesWithDifferentRests.put(1, voice1);
 		voicesWithDifferentRests.put(2, voice2);
@@ -205,7 +205,7 @@ public class PolyphonicPatternTest {
 		final Pattern pattern = new PolyphonicPattern(createReferencePatternVoices());
 		Map<Integer, List<? extends Durational>> modifiedVoices = createReferencePatternVoices();
 		List<Durational> modifiedVoice = new ArrayList<>(modifiedVoices.get(2));
-		Note note = Note.of(Pitch.of(Pitch.Base.C, 1, 5), Durations.EIGHTH);
+		Note note = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.SHARP, 5), Durations.EIGHTH);
 		modifiedVoice.set(0, note);
 		modifiedVoices.put(2, modifiedVoice);
 
@@ -224,12 +224,12 @@ public class PolyphonicPatternTest {
 	void testEqualsInPitchWithChords() {
 		List<Durational> contentsA = new ArrayList<>();
 		List<Note> chordContents = new ArrayList<>();
-		chordContents.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
-		chordContents.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH));
-		chordContents.add(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		contentsA.add(Chord.of(chordContents));
 		contentsA.add(Rest.of(Durations.QUARTER));
-		contentsA.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+		contentsA.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 
 		final Pattern patternA = new PolyphonicPattern(contentsA);
 		final Pattern patternACopy = new PolyphonicPattern(contentsA);
@@ -240,9 +240,9 @@ public class PolyphonicPatternTest {
 		List<Durational> contentsB = new ArrayList<>(contentsA);
 
 		List<Note> differentChordContents = new ArrayList<>();
-		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
-		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH));
-		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.G, 1, 4), Durations.EIGHTH));
+		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.SHARP, 4), Durations.EIGHTH));
 		contentsB.set(0, Chord.of(differentChordContents));
 
 		final Pattern patternB = new PolyphonicPattern(contentsB);
@@ -265,7 +265,7 @@ public class PolyphonicPatternTest {
 
 		Map<Integer, List<? extends Durational>> modifiedVoices = createReferencePatternVoices();
 		List<Durational> modifiedVoice = new ArrayList<>(modifiedVoices.get(1));
-		Note note = Note.of(Pitch.of(Pitch.Base.D, -2, 4), Durations.SIXTEENTH);
+		Note note = Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.DOUBLE_FLAT, 4), Durations.SIXTEENTH);
 		modifiedVoice.set(0, note);
 		modifiedVoices.put(1, modifiedVoice);
 
@@ -274,16 +274,16 @@ public class PolyphonicPatternTest {
 
 		final Map<Integer, List<? extends Durational>> voicesWithDifferentRests = new HashMap<>();
 		List<Durational> voice1 = new ArrayList<>();
-		voice1.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
+		voice1.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		voice1.add(Rest.of(Durations.EIGHTH));
 		voice1.add(Rest.of(Durations.SIXTEENTH));
-		voice1.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+		voice1.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 
 		List<Durational> voice2 = new ArrayList<>();
 
-		voice2.add(Note.of(Pitch.of(Pitch.Base.E, 0, 3), Durations.QUARTER));
+		voice2.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 3), Durations.QUARTER));
 		voice2.add(Rest.of(Durations.SIXTEENTH));
-		voice2.add(Note.of(Pitch.of(Pitch.Base.G, -1, 3), Durations.EIGHTH));
+		voice2.add(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.FLAT, 3), Durations.EIGHTH));
 
 		voicesWithDifferentRests.put(1, voice1);
 		voicesWithDifferentRests.put(2, voice2);
@@ -296,12 +296,12 @@ public class PolyphonicPatternTest {
 	void testEqualsEnharmonicallyWithChords() {
 		List<Durational> contentsA = new ArrayList<>();
 		List<Note> chordContents = new ArrayList<>();
-		chordContents.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
-		chordContents.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH));
-		chordContents.add(Note.of(Pitch.of(Pitch.Base.F, 2, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.F, Pitch.Accidental.DOUBLE_SHARP, 4), Durations.EIGHTH));
 		contentsA.add(Chord.of(chordContents));
 		contentsA.add(Rest.of(Durations.QUARTER));
-		contentsA.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+		contentsA.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 
 		final Pattern patternA = new PolyphonicPattern(contentsA);
 		final Pattern patternACopy = new PolyphonicPattern(contentsA);
@@ -312,9 +312,9 @@ public class PolyphonicPatternTest {
 		List<Durational> contentsB = new ArrayList<>(contentsA);
 
 		List<Note> differentChordContents = new ArrayList<>();
-		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
-		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH));
-		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.G, 1, 4), Durations.EIGHTH));
+		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.SHARP, 4), Durations.EIGHTH));
 		contentsB.set(0, Chord.of(differentChordContents));
 
 		final Pattern patternB = new PolyphonicPattern(contentsB);
@@ -337,15 +337,15 @@ public class PolyphonicPatternTest {
 
 		final Map<Integer, List<? extends Durational>> transposedVoicesWithDifferentRests = new HashMap<>();
 		List<Durational> voice1 = new ArrayList<>();
-		voice1.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+		voice1.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		voice1.add(Rest.of(Durations.EIGHTH));
 		voice1.add(Rest.of(Durations.SIXTEENTH));
-		voice1.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH));
+		voice1.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 
 		List<Durational> voice2 = new ArrayList<>();
-		voice2.add(Note.of(Pitch.of(Pitch.Base.F, 1, 3), Durations.QUARTER));
+		voice2.add(Note.of(Pitch.of(Pitch.Base.F, Pitch.Accidental.SHARP, 3), Durations.QUARTER));
 		voice2.add(Rest.of(Durations.SIXTEENTH));
-		voice2.add(Note.of(Pitch.of(Pitch.Base.A, -1, 3), Durations.EIGHTH));
+		voice2.add(Note.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.FLAT, 3), Durations.EIGHTH));
 
 		transposedVoicesWithDifferentRests.put(1, voice1);
 		transposedVoicesWithDifferentRests.put(2, voice2);
@@ -359,7 +359,7 @@ public class PolyphonicPatternTest {
 		final Pattern pattern = new PolyphonicPattern(createReferencePatternVoices());
 		Map<Integer, List<? extends Durational>> modifiedVoices = createReferencePatternVoices();
 		List<Durational> modifiedVoice = new ArrayList<>(modifiedVoices.get(2));
-		Note note = Note.of(Pitch.of(Pitch.Base.C, 1, 5), Durations.EIGHTH);
+		Note note = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.SHARP, 5), Durations.EIGHTH);
 		modifiedVoice.set(0, note);
 		modifiedVoices.put(2, modifiedVoice);
 
@@ -378,12 +378,12 @@ public class PolyphonicPatternTest {
 	void testEqualsTranspositionallyWithChords() {
 		List<Durational> contents = new ArrayList<>();
 		List<Note> chordContents = new ArrayList<>();
-		chordContents.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
-		chordContents.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH));
-		chordContents.add(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		chordContents.add(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		contents.add(Chord.of(chordContents));
 		contents.add(Rest.of(Durations.QUARTER));
-		contents.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+		contents.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 
 		final Pattern patternA = new PolyphonicPattern(contents);
 		final Pattern patternACopy = new PolyphonicPattern(contents);
@@ -393,12 +393,12 @@ public class PolyphonicPatternTest {
 
 		List<Durational> transposedContents = new ArrayList<>();
 		List<Note> transposedChordContents = new ArrayList<>();
-		transposedChordContents.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
-		transposedChordContents.add(Note.of(Pitch.of(Pitch.Base.F, 1, 4), Durations.EIGHTH));
-		transposedChordContents.add(Note.of(Pitch.of(Pitch.Base.A, 0, 4), Durations.EIGHTH));
+		transposedChordContents.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		transposedChordContents.add(Note.of(Pitch.of(Pitch.Base.F, Pitch.Accidental.SHARP, 4), Durations.EIGHTH));
+		transposedChordContents.add(Note.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		transposedContents.add(Chord.of(transposedChordContents));
 		transposedContents.add(Rest.of(Durations.QUARTER));
-		transposedContents.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH));
+		transposedContents.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 
 		final Pattern transposedPatternA = new PolyphonicPattern(transposedContents);
 		assertTrue(patternA.equalsTranspositionally(transposedPatternA));
@@ -406,9 +406,9 @@ public class PolyphonicPatternTest {
 		List<Durational> contentsB = new ArrayList<>(contents);
 
 		List<Note> differentChordContents = new ArrayList<>();
-		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
-		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH));
-		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.G, 1, 4), Durations.EIGHTH));
+		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		differentChordContents.add(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.SHARP, 4), Durations.EIGHTH));
 		contentsB.set(0, Chord.of(differentChordContents));
 
 		final Pattern patternB = new PolyphonicPattern(contentsB);
@@ -424,15 +424,15 @@ public class PolyphonicPatternTest {
 
 		final Map<Integer, List<? extends Durational>> voicesThatEqualReferencePatternInDurations = new HashMap<>();
 		List<Durational> equalVoice1 = new ArrayList<>();
-		equalVoice1.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH));
+		equalVoice1.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		equalVoice1.add(Rest.of(Durations.QUARTER));
-		equalVoice1.add(Note.of(Pitch.of(Pitch.Base.G, -1, 3), Durations.EIGHTH));
+		equalVoice1.add(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.FLAT, 3), Durations.EIGHTH));
 
 		List<Durational> equalVoice2 = new ArrayList<>();
 
-		equalVoice2.add(Note.of(Pitch.of(Pitch.Base.E, 0, 3), Durations.QUARTER));
+		equalVoice2.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 3), Durations.QUARTER));
 		equalVoice2.add(Rest.of(Durations.EIGHTH));
-		equalVoice2.add(Note.of(Pitch.of(Pitch.Base.A, 1, 3), Durations.EIGHTH));
+		equalVoice2.add(Note.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.SHARP, 3), Durations.EIGHTH));
 
 		voicesThatEqualReferencePatternInDurations.put(1, equalVoice1);
 		voicesThatEqualReferencePatternInDurations.put(2, equalVoice2);
@@ -444,14 +444,14 @@ public class PolyphonicPatternTest {
 
 		final Map<Integer, List<? extends Durational>> voicesThatDifferFromReferencePatternInDurations = new HashMap<>();
 		List<Durational> differentVoice1 = new ArrayList<>();
-		differentVoice1.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH));
+		differentVoice1.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		differentVoice1.add(Rest.of(Durations.QUARTER));
-		differentVoice1.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.SIXTEENTH));
+		differentVoice1.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.SIXTEENTH));
 
 		List<Durational> differentVoice2 = new ArrayList<>();
-		differentVoice2.add(Note.of(Pitch.of(Pitch.Base.E, 0, 3), Durations.QUARTER));
+		differentVoice2.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 3), Durations.QUARTER));
 		differentVoice2.add(Rest.of(Durations.EIGHTH));
-		differentVoice2.add(Note.of(Pitch.of(Pitch.Base.F, 1, 3), Durations.EIGHTH));
+		differentVoice2.add(Note.of(Pitch.of(Pitch.Base.F, Pitch.Accidental.SHARP, 3), Durations.EIGHTH));
 
 		voicesThatDifferFromReferencePatternInDurations.put(1, differentVoice1);
 		voicesThatDifferFromReferencePatternInDurations.put(2, differentVoice2);

--- a/src/test/java/org/wmn4j/mir/discovery/GeometricPatternDiscoveryTest.java
+++ b/src/test/java/org/wmn4j/mir/discovery/GeometricPatternDiscoveryTest.java
@@ -39,101 +39,101 @@ public class GeometricPatternDiscoveryTest {
 		assertExpectedPatternCollectionFoundInPatterns(
 				Arrays.asList(
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						)),
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						))
 				), patterns);
 
 		assertExpectedPatternCollectionFoundInPatterns(
 				Arrays.asList(
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						)),
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						))
 				), patterns);
 
 		assertExpectedPatternCollectionFoundInPatterns(
 				Arrays.asList(
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						)),
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						)),
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						))
 				), patterns);
 
 		assertExpectedPatternCollectionFoundInPatterns(
 				Arrays.asList(
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						)),
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						)),
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						)),
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						))
 				), patterns);
 
 		assertExpectedPatternCollectionFoundInPatterns(
 				Arrays.asList(
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						)),
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						)),
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						)),
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						)),
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						)),
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						))
 				), patterns);
 	}
@@ -183,39 +183,39 @@ public class GeometricPatternDiscoveryTest {
 		assertExpectedPatternCollectionFoundInPatterns(
 				Arrays.asList(
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						)),
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						))
 				), patterns);
 
 		assertExpectedPatternCollectionFoundInPatterns(
 				Arrays.asList(
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						)),
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						)),
 						Pattern.of(Arrays.asList(
-								Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH),
+								Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
 								Rest.of(Durations.EIGHTH),
-								Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH)
+								Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH)
 						))
 				), patterns);
 	}

--- a/src/test/java/org/wmn4j/mir/discovery/PointSetTest.java
+++ b/src/test/java/org/wmn4j/mir/discovery/PointSetTest.java
@@ -121,26 +121,26 @@ public class PointSetTest {
 		List<NoteEventVector> vectors = new ArrayList<>();
 		double offset = 0.0;
 
-		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.G, 0, 2).toInt(), 3));
-		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.G, 0, 3).toInt(), 3));
-		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.C, 0, 4).toInt(), 1));
-		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.G, 0, 4).toInt(), 2));
-		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.C, 0, 5).toInt(), 0));
+		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 2).toInt(), 3));
+		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 3).toInt(), 3));
+		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4).toInt(), 1));
+		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4).toInt(), 2));
+		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5).toInt(), 0));
 		offset += Durations.HALF.toDouble();
 
-		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.A, 0, 3).toInt(), 3));
-		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.D, 0, 4).toInt(), 1));
-		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.A, 0, 4).toInt(), 2));
-		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.D, 0, 5).toInt(), 0));
+		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 3).toInt(), 3));
+		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4).toInt(), 1));
+		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 4).toInt(), 2));
+		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 5).toInt(), 0));
 		offset += Durations.QUARTER.toDouble();
 
-		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.A, 0, 2).toInt(), 3));
+		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 2).toInt(), 3));
 		offset += Durations.QUARTER.toDouble();
 
-		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.G, 0, 3).toInt(), 3));
-		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.C, 0, 4).toInt(), 1));
-		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.G, 0, 4).toInt(), 2));
-		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.C, 0, 5).toInt(), 0));
+		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 3).toInt(), 3));
+		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4).toInt(), 1));
+		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4).toInt(), 2));
+		vectors.add(new NoteEventVector(offset, Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5).toInt(), 0));
 
 		return vectors;
 	}

--- a/src/test/java/org/wmn4j/notation/ChordBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/ChordBuilderTest.java
@@ -15,9 +15,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ChordBuilderTest {
 
 	private List<NoteBuilder> getCMajorAsNoteBuilders() {
-		final NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		final NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER);
-		final NoteBuilder third = new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER);
+		final NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
+		final NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
+		final NoteBuilder third = new NoteBuilder(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
 
 		final List<NoteBuilder> cMajor = new ArrayList<>();
 		cMajor.add(first);
@@ -29,9 +29,9 @@ class ChordBuilderTest {
 
 	@Test
 	void testWhenChordBuilderCreatedFromChordThenCorrectValuesAreSet() {
-		final Chord cMajor = Chord.of(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER),
-				Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER),
-				Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER));
+		final Chord cMajor = Chord.of(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER),
+				Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.QUARTER),
+				Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
 
 		ChordBuilder cMajorBuilder = new ChordBuilder(cMajor);
 		assertEquals(cMajor, cMajorBuilder.build());
@@ -43,9 +43,9 @@ class ChordBuilderTest {
 
 		final Chord chord = builder.build();
 		assertEquals(3, chord.getNoteCount());
-		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.QUARTER)));
 	}
 
 	@Test
@@ -73,11 +73,11 @@ class ChordBuilderTest {
 	@Test
 	void testRemoveIf() {
 		final ChordBuilder chordBuilder = new ChordBuilder(getCMajorAsNoteBuilders());
-		chordBuilder.removeIf((NoteBuilder nb) -> nb.getPitch().equals(Pitch.of(Pitch.Base.C, 0, 4)));
+		chordBuilder.removeIf((NoteBuilder nb) -> nb.getPitch().equals(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4)));
 
 		final Chord chord = chordBuilder.build();
 		assertEquals(2, chord.getNoteCount());
-		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER)));
-		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.QUARTER)));
+		assertTrue(chord.contains(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.QUARTER)));
 	}
 }

--- a/src/test/java/org/wmn4j/notation/ChordTest.java
+++ b/src/test/java/org/wmn4j/notation/ChordTest.java
@@ -4,12 +4,6 @@
 package org.wmn4j.notation;
 
 import org.junit.jupiter.api.Test;
-import org.wmn4j.notation.Articulation;
-import org.wmn4j.notation.Chord;
-import org.wmn4j.notation.Duration;
-import org.wmn4j.notation.Durations;
-import org.wmn4j.notation.Note;
-import org.wmn4j.notation.Pitch;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,29 +29,29 @@ class ChordTest {
 
 	ChordTest() {
 		this.cMajorNotes = new ArrayList<>();
-		this.cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		this.cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER));
-		this.cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER));
+		this.cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		this.cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		this.cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
 		this.cMajor = Chord.of(this.cMajorNotes);
 
 		final List<Note> dMajorNotes = new ArrayList<>();
-		dMajorNotes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 3), Durations.QUARTER));
-		dMajorNotes.add(Note.of(Pitch.of(Pitch.Base.F, 1, 3), Durations.QUARTER));
-		dMajorNotes.add(Note.of(Pitch.of(Pitch.Base.A, 0, 3), Durations.QUARTER));
+		dMajorNotes.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 3), Durations.QUARTER));
+		dMajorNotes.add(Note.of(Pitch.of(Pitch.Base.F, Pitch.Accidental.SHARP, 3), Durations.QUARTER));
+		dMajorNotes.add(Note.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 3), Durations.QUARTER));
 		this.dMajor = Chord.of(dMajorNotes);
 
 		final List<Note> fMinorNotes = new ArrayList<>();
-		fMinorNotes.add(Note.of(Pitch.of(Pitch.Base.F, 0, 4), Durations.QUARTER));
-		fMinorNotes.add(Note.of(Pitch.of(Pitch.Base.A, -1, 4), Durations.QUARTER));
-		fMinorNotes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER));
+		fMinorNotes.add(Note.of(Pitch.of(Pitch.Base.F, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		fMinorNotes.add(Note.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.FLAT, 4), Durations.QUARTER));
+		fMinorNotes.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.QUARTER));
 		this.fMinor = Chord.of(fMinorNotes);
 
 		final ArrayList<Note> DminorMaj9Notes = new ArrayList<>();
-		DminorMaj9Notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
-		DminorMaj9Notes.add(Note.of(Pitch.of(Pitch.Base.F, 0, 4), Durations.EIGHTH));
-		DminorMaj9Notes.add(Note.of(Pitch.of(Pitch.Base.A, 0, 4), Durations.EIGHTH));
-		DminorMaj9Notes.add(Note.of(Pitch.of(Pitch.Base.C, 1, 5), Durations.EIGHTH));
-		DminorMaj9Notes.add(Note.of(Pitch.of(Pitch.Base.E, 0, 5), Durations.EIGHTH));
+		DminorMaj9Notes.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		DminorMaj9Notes.add(Note.of(Pitch.of(Pitch.Base.F, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		DminorMaj9Notes.add(Note.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
+		DminorMaj9Notes.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.SHARP, 5), Durations.EIGHTH));
+		DminorMaj9Notes.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 5), Durations.EIGHTH));
 		this.dMinorMaj9 = Chord.of(DminorMaj9Notes);
 	}
 
@@ -70,7 +64,7 @@ class ChordTest {
 
 		// Test that modifying the list of notes used to create the chord does not
 		// modify the chord.
-		notes.add(Note.of(Pitch.of(Pitch.Base.D, 0, 4), Durations.EIGHTH));
+		notes.add(Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 		assertEquals(3, cMaj.getNoteCount());
 		assertEquals(this.cMajor, cMaj);
 	}
@@ -86,8 +80,8 @@ class ChordTest {
 
 	@Test
 	void testVarargsFactory() {
-		final Note C4 = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
-		final Note E4 = Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH);
+		final Note C4 = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
+		final Note E4 = Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
 		final Chord dyad = Chord.of(C4, E4);
 		assertEquals(2, dyad.getNoteCount());
 		assertTrue(dyad.contains(E4));
@@ -102,8 +96,8 @@ class ChordTest {
 		}
 
 		try {
-			final Note a = Note.of(Pitch.of(Pitch.Base.A, 0, 3), Durations.EIGHTH);
-			final Note b = Note.of(Pitch.of(Pitch.Base.A, 0, 3), Durations.QUARTER);
+			final Note a = Note.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 3), Durations.EIGHTH);
+			final Note b = Note.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 3), Durations.QUARTER);
 			final ArrayList<Note> notes = new ArrayList<>();
 			notes.add(a);
 			notes.add(b);
@@ -117,20 +111,20 @@ class ChordTest {
 
 	@Test
 	void testContainsPitch() {
-		assertTrue(this.cMajor.contains(Pitch.of(Pitch.Base.C, 0, 4)));
-		assertFalse(this.cMajor.contains(Pitch.of(Pitch.Base.C, 1, 4)));
+		assertTrue(this.cMajor.contains(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4)));
+		assertFalse(this.cMajor.contains(Pitch.of(Pitch.Base.C, Pitch.Accidental.SHARP, 4)));
 	}
 
 	@Test
 	void testContainstNote() {
-		assertTrue(this.cMajor.contains(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER)));
-		assertFalse(this.cMajor.contains(Note.of(Pitch.of(Pitch.Base.C, -1, 4), Durations.QUARTER)));
+		assertTrue(this.cMajor.contains(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER)));
+		assertFalse(this.cMajor.contains(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.FLAT, 4), Durations.QUARTER)));
 		final HashSet<Articulation> articulations = new HashSet<>();
 		articulations.add(Articulation.STACCATO);
-		final Note staccatoC5 = Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER, articulations);
+		final Note staccatoC5 = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.QUARTER, articulations);
 		final Chord staccatoC = this.cMajor.add(staccatoC5);
 		assertTrue(staccatoC.contains(staccatoC5));
-		assertFalse(staccatoC.contains(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER)));
+		assertFalse(staccatoC.contains(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.QUARTER)));
 		assertFalse(this.cMajor.contains(staccatoC5));
 	}
 
@@ -142,20 +136,20 @@ class ChordTest {
 
 	@Test
 	public void testGetNote() {
-		assertEquals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER), this.cMajor.getNote(1));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.A, 0, 3), Durations.QUARTER), this.dMajor.getNote(2));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.QUARTER), this.cMajor.getNote(1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 3), Durations.QUARTER), this.dMajor.getNote(2));
 	}
 
 	@Test
 	void testGetLowestNote() {
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), this.cMajor.getLowestNote());
-		assertEquals(Note.of(Pitch.of(Pitch.Base.F, 0, 4), Durations.QUARTER), this.fMinor.getLowestNote());
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER), this.cMajor.getLowestNote());
+		assertEquals(Note.of(Pitch.of(Pitch.Base.F, Pitch.Accidental.NATURAL, 4), Durations.QUARTER), this.fMinor.getLowestNote());
 	}
 
 	@Test
 	void testGetHighestNote() {
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER), this.cMajor.getHighestNote());
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER), this.fMinor.getHighestNote());
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.QUARTER), this.cMajor.getHighestNote());
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.QUARTER), this.fMinor.getHighestNote());
 	}
 
 	@Test
@@ -167,9 +161,9 @@ class ChordTest {
 	@Test
 	void testEquals() {
 		final ArrayList<Note> cMajorNotes = new ArrayList<>();
-		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER));
-		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
 		final Chord cMaj = Chord.of(cMajorNotes);
 		assertTrue(this.cMajor.equals(cMaj));
 		assertTrue(cMaj.equals(this.cMajor));
@@ -185,13 +179,13 @@ class ChordTest {
 
 	@Test
 	void testAddNote() {
-		final Chord cMaj = this.cMajor.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER));
+		final Chord cMaj = this.cMajor.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.QUARTER));
 		assertFalse(this.cMajor.equals(cMaj));
 		assertEquals(4, cMaj.getNoteCount());
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER), cMaj.getHighestNote());
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.QUARTER), cMaj.getHighestNote());
 
 		try {
-			final Chord illegalCMaj = this.cMajor.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.EIGHTH));
+			final Chord illegalCMaj = this.cMajor.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.EIGHTH));
 			fail("Failed to throw expected exception");
 		} catch (final IllegalArgumentException e) {
 			// Pass because exception is expected
@@ -202,7 +196,7 @@ class ChordTest {
 	void testHasArticulations() {
 		List<Note> cMajorCopy = new ArrayList<>(this.cMajorNotes);
 		Set<Articulation> articulations = EnumSet.of(Articulation.ACCENT);
-		cMajorCopy.add(Note.of(Pitch.of(Pitch.Base.C, 0, 5), Durations.QUARTER, articulations));
+		cMajorCopy.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5), Durations.QUARTER, articulations));
 		Chord chordWithAccent = Chord.of(cMajorCopy);
 		assertTrue(chordWithAccent.hasArticulations());
 		assertFalse(cMajor.hasArticulations());
@@ -212,10 +206,10 @@ class ChordTest {
 	void testHasArticulation() {
 		List<Note> cMajorNotesWithAccentAndStaccato = new ArrayList<>();
 		cMajorNotesWithAccentAndStaccato
-				.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER, EnumSet.of(Articulation.ACCENT)));
+				.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER, EnumSet.of(Articulation.ACCENT)));
 		cMajorNotesWithAccentAndStaccato
-				.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER, EnumSet.of(Articulation.STACCATO)));
-		cMajorNotesWithAccentAndStaccato.add(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER));
+				.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.QUARTER, EnumSet.of(Articulation.STACCATO)));
+		cMajorNotesWithAccentAndStaccato.add(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
 		Chord cMajorWithArticulations = Chord.of(cMajorNotesWithAccentAndStaccato);
 
 		assertTrue(cMajorWithArticulations.hasArticulation(Articulation.STACCATO));
@@ -230,10 +224,10 @@ class ChordTest {
 	void testGetArticulations() {
 		List<Note> cMajorNotesWithAccentAndStaccato = new ArrayList<>();
 		cMajorNotesWithAccentAndStaccato
-				.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER, EnumSet.of(Articulation.ACCENT)));
+				.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER, EnumSet.of(Articulation.ACCENT)));
 		cMajorNotesWithAccentAndStaccato
-				.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER, EnumSet.of(Articulation.STACCATO)));
-		cMajorNotesWithAccentAndStaccato.add(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER));
+				.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.QUARTER, EnumSet.of(Articulation.STACCATO)));
+		cMajorNotesWithAccentAndStaccato.add(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
 		Chord cMajorWithArticulations = Chord.of(cMajorNotesWithAccentAndStaccato);
 
 		Collection<Articulation> articulations = cMajorWithArticulations.getArticulations();
@@ -247,26 +241,26 @@ class ChordTest {
 
 	@Test
 	void testRemoveNote() {
-		final Chord D_FSharp = this.dMajor.remove(Note.of(Pitch.of(Pitch.Base.A, 0, 3), Durations.QUARTER));
+		final Chord D_FSharp = this.dMajor.remove(Note.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 3), Durations.QUARTER));
 		assertFalse(this.dMajor.equals(D_FSharp));
 		assertEquals(2, D_FSharp.getNoteCount());
-		assertEquals(Note.of(Pitch.of(Pitch.Base.F, 1, 3), Durations.QUARTER), D_FSharp.getHighestNote());
+		assertEquals(Note.of(Pitch.of(Pitch.Base.F, Pitch.Accidental.SHARP, 3), Durations.QUARTER), D_FSharp.getHighestNote());
 	}
 
 	@Test
 	void testRemovePitch() {
-		final Chord D_FSharp = this.dMajor.remove(Pitch.of(Pitch.Base.A, 0, 3));
+		final Chord D_FSharp = this.dMajor.remove(Pitch.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 3));
 		assertFalse(this.dMajor.equals(D_FSharp));
 		assertEquals(2, D_FSharp.getNoteCount());
-		assertEquals(Note.of(Pitch.of(Pitch.Base.F, 1, 3), Durations.QUARTER), D_FSharp.getHighestNote());
+		assertEquals(Note.of(Pitch.of(Pitch.Base.F, Pitch.Accidental.SHARP, 3), Durations.QUARTER), D_FSharp.getHighestNote());
 	}
 
 	@Test
 	void testIteration() {
 		final ArrayList<Note> cMajorNotes = new ArrayList<>();
-		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER));
-		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		cMajorNotes.add(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
 
 		int noteCount = 0;
 		for (Note note : this.cMajor) {

--- a/src/test/java/org/wmn4j/notation/MeasureBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/MeasureBuilderTest.java
@@ -18,9 +18,9 @@ class MeasureBuilderTest {
 		builder.setTimeSignature(TimeSignatures.SIX_EIGHT).setKeySignature(KeySignatures.DFLATMAJ_BFLATMIN);
 		builder.setRightBarline(Barline.DOUBLE).setClef(Clefs.F);
 
-		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH))
-				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH))
-				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH));
+		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH))
+				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH))
+				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 
 		assertEquals(1, builder.getVoiceCount());
 
@@ -33,9 +33,9 @@ class MeasureBuilderTest {
 		assertEquals(1, measure.getNumber());
 
 		assertEquals(1, measure.getVoiceCount());
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH), measure.get(0, 0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH), measure.get(0, 1));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH), measure.get(0, 2));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH), measure.get(0, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH), measure.get(0, 1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH), measure.get(0, 2));
 	}
 
 	@Test
@@ -44,9 +44,9 @@ class MeasureBuilderTest {
 				KeySignatures.DFLATMAJ_BFLATMIN, Barline.DOUBLE, Clefs.F);
 		final MeasureBuilder builder = new MeasureBuilder(1, measureAttr);
 
-		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH))
-				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH))
-				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH));
+		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH))
+				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH))
+				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 
 		assertEquals(1, builder.getVoiceCount());
 
@@ -60,9 +60,9 @@ class MeasureBuilderTest {
 
 		assertEquals(1, measure.getVoiceCount());
 
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH), measure.get(0, 0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH), measure.get(0, 1));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH), measure.get(0, 2));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH), measure.get(0, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH), measure.get(0, 1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH), measure.get(0, 2));
 	}
 
 	@Test
@@ -74,9 +74,9 @@ class MeasureBuilderTest {
 		builder.setTimeSignature(TimeSignatures.SIX_EIGHT).setKeySignature(KeySignatures.DFLATMAJ_BFLATMIN);
 		builder.setRightBarline(Barline.DOUBLE).setClef(Clefs.F);
 
-		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH))
-				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH))
-				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH));
+		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH))
+				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH))
+				.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH));
 
 		assertEquals(1, builder.getVoiceCount());
 
@@ -89,9 +89,9 @@ class MeasureBuilderTest {
 		assertEquals(1, measure.getNumber());
 
 		assertEquals(1, measure.getVoiceCount());
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH), measure.get(0, 0));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.EIGHTH), measure.get(0, 1));
-		assertEquals(Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.EIGHTH), measure.get(0, 2));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH), measure.get(0, 0));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH), measure.get(0, 1));
+		assertEquals(Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH), measure.get(0, 2));
 	}
 
 	@Test
@@ -120,7 +120,7 @@ class MeasureBuilderTest {
 		MeasureBuilder builder = new MeasureBuilder(1);
 		builder.addToVoice(0, new RestBuilder(Durations.QUARTER));
 		assertFalse(builder.isFull(0), "Voice 0 is full for 4/4 measure after adding one quarter rest");
-		final NoteBuilder c = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.QUARTER);
+		final NoteBuilder c = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2), Durations.QUARTER);
 		builder.addToVoice(0, c);
 		assertFalse(builder.isFull(0), "Voice 0 is full for 4/4 measure after adding two quarters");
 		builder.addToVoice(0, c);
@@ -146,7 +146,7 @@ class MeasureBuilderTest {
 		MeasureBuilder builder = new MeasureBuilder(1);
 		builder.addToVoice(0, new RestBuilder(Durations.QUARTER));
 		assertFalse(builder.isFull(), "builder for 4/4 is full after adding one quarter rest");
-		final NoteBuilder c = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.QUARTER);
+		final NoteBuilder c = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2), Durations.QUARTER);
 		builder.addToVoice(0, c);
 		assertFalse(builder.isFull(), "builder for 4/4 is full only after adding two quarters");
 		builder.addToVoice(0, c);
@@ -169,8 +169,8 @@ class MeasureBuilderTest {
 	@Test
 	void testBuildingMeasureWithTiedNotes() {
 		final MeasureBuilder builder = new MeasureBuilder(1);
-		final NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.HALF);
-		final NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.HALF);
+		final NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2), Durations.HALF);
+		final NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2), Durations.HALF);
 
 		first.addTieToFollowing(second);
 		builder.addToVoice(1, first).addToVoice(1, second);
@@ -187,8 +187,10 @@ class MeasureBuilderTest {
 	void testAllVoicesArePaddedWithRestsWhenBuilding() {
 		final MeasureBuilder builder = new MeasureBuilder(1);
 		builder.setTimeSignature(TimeSignatures.THREE_FOUR);
-		NoteBuilder withHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.HALF);
-		NoteBuilder withEightDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.EIGHTH);
+		NoteBuilder withHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2),
+				Durations.HALF);
+		NoteBuilder withEightDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2),
+				Durations.EIGHTH);
 		builder.addToVoice(0, withHalfDuration);
 		builder.addToVoice(1, withHalfDuration);
 		builder.addToVoice(1, withEightDuration);
@@ -209,8 +211,10 @@ class MeasureBuilderTest {
 	void testIsVoiceOverflowing() {
 		final MeasureBuilder builder = new MeasureBuilder(1);
 		builder.setTimeSignature(TimeSignatures.TWO_FOUR);
-		NoteBuilder withHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.HALF);
-		NoteBuilder withDottedHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.HALF.addDot());
+		NoteBuilder withHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2),
+				Durations.HALF);
+		NoteBuilder withDottedHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2),
+				Durations.HALF.addDot());
 		builder.addToVoice(0, withHalfDuration);
 		builder.addToVoice(1, withDottedHalfDuration);
 
@@ -222,8 +226,10 @@ class MeasureBuilderTest {
 	void testIsOverflowing() {
 		final MeasureBuilder builder = new MeasureBuilder(1);
 		builder.setTimeSignature(TimeSignatures.TWO_FOUR);
-		NoteBuilder withHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.HALF);
-		NoteBuilder withDottedHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.HALF.addDot());
+		NoteBuilder withHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2),
+				Durations.HALF);
+		NoteBuilder withDottedHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2),
+				Durations.HALF.addDot());
 		builder.addToVoice(0, withHalfDuration);
 
 		assertFalse(builder.isOverflowing());
@@ -237,9 +243,12 @@ class MeasureBuilderTest {
 	void testTrimWithSingleElementPerVoice() {
 		final MeasureBuilder builder = new MeasureBuilder(1);
 		builder.setTimeSignature(TimeSignatures.TWO_FOUR);
-		NoteBuilder withHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.HALF);
-		NoteBuilder withDottedHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.HALF.addDot());
-		NoteBuilder withEightDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.EIGHTH);
+		NoteBuilder withHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2),
+				Durations.HALF);
+		NoteBuilder withDottedHalfDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2),
+				Durations.HALF.addDot());
+		NoteBuilder withEightDuration = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2),
+				Durations.EIGHTH);
 
 		builder.addToVoice(0, withHalfDuration);
 		builder.addToVoice(1, withDottedHalfDuration);
@@ -260,10 +269,10 @@ class MeasureBuilderTest {
 		final MeasureBuilder builder = new MeasureBuilder(1);
 		builder.setTimeSignature(TimeSignatures.TWO_FOUR);
 
-		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.QUARTER));
-		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.EIGHTH));
-		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.QUARTER));
-		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.QUARTER));
+		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2), Durations.QUARTER));
+		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2), Durations.EIGHTH));
+		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2), Durations.QUARTER));
+		builder.addToVoice(0, new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2), Durations.QUARTER));
 
 		builder.trim();
 
@@ -283,8 +292,10 @@ class MeasureBuilderTest {
 		final MeasureBuilder builder = new MeasureBuilder(1);
 		builder.setTimeSignature(TimeSignatures.TWO_FOUR);
 
-		NoteBuilder tooLongBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.WHOLE);
-		NoteBuilder tooShortBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 2), Durations.QUARTER);
+		NoteBuilder tooLongBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2),
+				Durations.WHOLE);
+		NoteBuilder tooShortBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2),
+				Durations.QUARTER);
 
 		builder.addToVoice(0, tooLongBuilder);
 		builder.addToVoice(1, tooShortBuilder);

--- a/src/test/java/org/wmn4j/notation/MeasureTest.java
+++ b/src/test/java/org/wmn4j/notation/MeasureTest.java
@@ -24,10 +24,10 @@ class MeasureTest {
 
 	private KeySignature keySig = KeySignatures.CMAJ_AMIN;
 
-	private Note C4 = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.HALF);
-	private Note E4 = Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.HALF);
-	private Note G4 = Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF);
-	private Note C4Quarter = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+	private Note C4 = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.HALF);
+	private Note E4 = Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.HALF);
+	private Note G4 = Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.HALF);
+	private Note C4Quarter = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
 
 	MeasureTest() {
 		final List<Durational> voiceContents = new ArrayList<>();

--- a/src/test/java/org/wmn4j/notation/NotationTest.java
+++ b/src/test/java/org/wmn4j/notation/NotationTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NotationTest {
 
-	private final Note testNote = Note.of(Pitch.of(Pitch.Base.C, 1, 4), Durations.EIGHTH);
+	private final Note testNote = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.SHARP, 4), Durations.EIGHTH);
 
 	@Test
 	void testBeginningOf() {
@@ -64,14 +64,14 @@ class NotationTest {
 		final Notation slur = Notation.of(Notation.Type.SLUR);
 		final Notation firstTie = Notation.of(Notation.Type.TIE);
 		final Notation secondTie = Notation.of(Notation.Type.TIE);
-		final Note third = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH,
+		final Note third = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH,
 				Collections.emptySet(), List.of(Notation.Connection.endOf(slur), Notation.Connection.endOf(secondTie)));
-		final Note second = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH,
+		final Note second = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH,
 				Collections.emptySet(),
 				List.of(Notation.Connection.of(slur, third),
 						Notation.Connection.beginningOf(secondTie, third),
 						Notation.Connection.endOf(firstTie)));
-		final Note first = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH,
+		final Note first = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH,
 				Collections.emptySet(), List.of(Notation.Connection.beginningOf(slur, second),
 						Notation.Connection.beginningOf(secondTie, third),
 						Notation.Connection.beginningOf(firstTie, second)));
@@ -94,11 +94,11 @@ class NotationTest {
 	@Test
 	void testGetAffectedStartingFrom() {
 		final Notation slur = Notation.of(Notation.Type.SLUR);
-		final Note third = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH,
+		final Note third = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH,
 				Collections.emptySet(), List.of(Notation.Connection.endOf(slur)));
-		final Note second = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH,
+		final Note second = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH,
 				Collections.emptySet(), List.of(Notation.Connection.of(slur, third)));
-		final Note first = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH,
+		final Note first = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH,
 				Collections.emptySet(), List.of(Notation.Connection.beginningOf(slur, second)));
 
 		assertTrue(

--- a/src/test/java/org/wmn4j/notation/NoteBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/NoteBuilderTest.java
@@ -17,7 +17,7 @@ class NoteBuilderTest {
 
 	@Test
 	void testWhenCreatingFromNoteThenCorrectValuesAreSet() {
-		final Note noteWithoutArticulations = Note.of(Pitch.Base.A, -1, 2, Duration.of(1, 12));
+		final Note noteWithoutArticulations = Note.of(Pitch.Base.A, Pitch.Accidental.FLAT, 2, Duration.of(1, 12));
 		NoteBuilder builderWithoutArticulations = new NoteBuilder(noteWithoutArticulations);
 
 		assertEquals(noteWithoutArticulations.getPitch(), builderWithoutArticulations.getPitch());
@@ -25,8 +25,9 @@ class NoteBuilderTest {
 		assertEquals(noteWithoutArticulations.getArticulations(), builderWithoutArticulations.getArticulations());
 		assertEquals(noteWithoutArticulations, builderWithoutArticulations.build());
 
-		final Note noteWithArticulations = Note.of(Pitch.of(Pitch.Base.A, 1, 3), Duration.of(1, 16),
-				EnumSet.of(Articulation.ACCENT, Articulation.STACCATO));
+		final Note noteWithArticulations = Note
+				.of(Pitch.of(Pitch.Base.A, Pitch.Accidental.SHARP, 3), Duration.of(1, 16),
+						EnumSet.of(Articulation.ACCENT, Articulation.STACCATO));
 		NoteBuilder builderWithArticulations = new NoteBuilder(noteWithArticulations);
 
 		assertEquals(noteWithArticulations.getPitch(), builderWithArticulations.getPitch());
@@ -37,28 +38,31 @@ class NoteBuilderTest {
 
 	@Test
 	void testBuildingBasicNote() {
-		final NoteBuilder builder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final NoteBuilder builder = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+				Durations.QUARTER);
 		final Note note = builder.build();
 		assertFalse(note.hasArticulations());
 		assertFalse(note.hasNotations());
 		assertFalse(note.isTied());
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER), note);
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER), note);
 	}
 
 	@Test
 	void testBuildingNoteWithAllAttributes() {
-		final NoteBuilder builder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final NoteBuilder builder = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+				Durations.QUARTER);
 		builder.addArticulation(Articulation.STACCATO);
 
 		builder.connectWith(Notation.of(Notation.Type.SLUR),
-				new NoteBuilder(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER));
+				new NoteBuilder(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
 
-		final Note tiedNote = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final Note tiedNote = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
 
 		builder.addTieToFollowing(new NoteBuilder(tiedNote));
 
 		final Note expected = Note
-				.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER, EnumSet.of(Articulation.STACCATO));
+				.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER,
+						EnumSet.of(Articulation.STACCATO));
 
 		final Note note = builder.build();
 		assertTrue(expected.equalsInPitchAndDuration(note));
@@ -71,9 +75,12 @@ class NoteBuilderTest {
 
 	@Test
 	void testBuildingTiedNotes() {
-		final NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		final NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER);
-		final NoteBuilder third = new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER);
+		final NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+				Durations.QUARTER);
+		final NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4),
+				Durations.QUARTER);
+		final NoteBuilder third = new NoteBuilder(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4),
+				Durations.QUARTER);
 
 		first.addTieToFollowing(second);
 		second.addTieToFollowing(third);
@@ -82,40 +89,44 @@ class NoteBuilderTest {
 		final Note secondNote = second.build();
 		final Note thirdNote = third.build();
 
-		assertEquals(Pitch.of(Pitch.Base.C, 0, 4), firstNote.getPitch());
+		assertEquals(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), firstNote.getPitch());
 		assertTrue(firstNote.isTiedToFollowing());
 		assertFalse(firstNote.isTiedFromPrevious());
-		assertEquals(Pitch.of(Pitch.Base.D, 0, 4), firstNote.getFollowingTiedNote().get().getPitch());
+		assertEquals(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4),
+				firstNote.getFollowingTiedNote().get().getPitch());
 
-		assertEquals(Pitch.of(Pitch.Base.D, 0, 4), secondNote.getPitch());
+		assertEquals(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), secondNote.getPitch());
 		assertTrue(secondNote.isTiedToFollowing());
 		assertTrue(secondNote.isTiedFromPrevious());
-		assertEquals(Pitch.of(Pitch.Base.E, 0, 4), secondNote.getFollowingTiedNote().get().getPitch());
+		assertEquals(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4),
+				secondNote.getFollowingTiedNote().get().getPitch());
 
-		assertEquals(Pitch.of(Pitch.Base.E, 0, 4), thirdNote.getPitch());
+		assertEquals(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), thirdNote.getPitch());
 		assertFalse(thirdNote.isTiedToFollowing());
 		assertTrue(thirdNote.isTiedFromPrevious());
 	}
 
 	@Test
 	void testCopyConstructor() {
-		final NoteBuilder builder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final NoteBuilder builder = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+				Durations.QUARTER);
 		final NoteBuilder copy = new NoteBuilder(builder);
 		assertNotSame(builder, copy);
 
 		assertEquals(Durations.QUARTER, copy.getDuration());
-		assertEquals(Pitch.of(Pitch.Base.C, 0, 4), copy.getPitch());
+		assertEquals(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), copy.getPitch());
 
 		builder.setDuration(Durations.HALF);
 		assertEquals(Durations.QUARTER, copy.getDuration());
 
-		builder.setPitch(Pitch.of(Pitch.Base.D, 0, 4));
-		assertEquals(Pitch.of(Pitch.Base.C, 0, 4), copy.getPitch());
+		builder.setPitch(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4));
+		assertEquals(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), copy.getPitch());
 	}
 
 	@Test
 	void testCopyConstructorArticulations() {
-		final NoteBuilder builder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final NoteBuilder builder = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+				Durations.QUARTER);
 		builder.addArticulation(Articulation.STACCATO);
 
 		final NoteBuilder copy = new NoteBuilder(builder);
@@ -127,9 +138,9 @@ class NoteBuilderTest {
 
 	@Test
 	void testBuildingWitMultipleNotesInSlur() {
-		NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.D, 0, 4), Durations.QUARTER);
-		NoteBuilder third = new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER);
+		NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
+		NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
+		NoteBuilder third = new NoteBuilder(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
 
 		final Notation slur = Notation.of(Notation.Type.SLUR);
 		first.connectWith(slur, second);
@@ -154,9 +165,9 @@ class NoteBuilderTest {
 
 	@Test
 	void testBuildingWithMultipleNotesWithTiesInSlur() {
-		NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		NoteBuilder third = new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER);
+		NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
+		NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
+		NoteBuilder third = new NoteBuilder(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
 
 		final Notation slur = Notation.of(Notation.Type.SLUR);
 		first.connectWith(slur, second);
@@ -190,9 +201,9 @@ class NoteBuilderTest {
 
 	@Test
 	void testBuildingWithSlurAndGlissandoAndTie() {
-		NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		NoteBuilder third = new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER);
+		NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
+		NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
+		NoteBuilder third = new NoteBuilder(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
 
 		final Notation slur = Notation.of(Notation.Type.SLUR);
 		final Notation glissando = Notation.of(Notation.Type.GLISSANDO);
@@ -244,9 +255,9 @@ class NoteBuilderTest {
 
 	@Test
 	void testBuildingWithLoopedSlur() {
-		NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		NoteBuilder third = new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER);
+		NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
+		NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
+		NoteBuilder third = new NoteBuilder(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
 
 		final Notation slur = Notation.of(Notation.Type.SLUR);
 		first.connectWith(slur, second);
@@ -265,9 +276,9 @@ class NoteBuilderTest {
 
 	@Test
 	void testBuildingWithLoopedTie() {
-		NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		NoteBuilder third = new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.QUARTER);
+		NoteBuilder first = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
+		NoteBuilder second = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
+		NoteBuilder third = new NoteBuilder(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
 
 		first.addTieToFollowing(second);
 		second.addTieToFollowing(third);

--- a/src/test/java/org/wmn4j/notation/NoteTest.java
+++ b/src/test/java/org/wmn4j/notation/NoteTest.java
@@ -22,12 +22,12 @@ class NoteTest {
 
 	@Test
 	void testEquals() {
-		final Note A1 = Note.of(Pitch.Base.A, 0, 1, Durations.QUARTER);
-		final Note A1differentDur = Note.of(Pitch.Base.A, 0, 1, Durations.EIGHTH);
-		final Note A1Copy = Note.of(Pitch.Base.A, 0, 1, Durations.QUARTER);
-		final Note B1 = Note.of(Pitch.Base.B, 0, 1, Durations.QUARTER);
-		final Note Asharp1 = Note.of(Pitch.Base.A, 1, 1, Durations.QUARTER);
-		final Note C4 = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final Note A1 = Note.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 1, Durations.QUARTER);
+		final Note A1differentDur = Note.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 1, Durations.EIGHTH);
+		final Note A1Copy = Note.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 1, Durations.QUARTER);
+		final Note B1 = Note.of(Pitch.Base.B, Pitch.Accidental.NATURAL, 1, Durations.QUARTER);
+		final Note Asharp1 = Note.of(Pitch.Base.A, Pitch.Accidental.SHARP, 1, Durations.QUARTER);
+		final Note C4 = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
 
 		assertTrue(A1.equals(A1));
 		assertTrue(A1.equals(A1Copy));
@@ -35,9 +35,9 @@ class NoteTest {
 		assertFalse(A1.equals(A1differentDur));
 		assertFalse(A1.equals(B1));
 		assertFalse(A1.equals(Asharp1));
-		assertTrue(C4.equals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER)));
+		assertTrue(C4.equals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER)));
 
-		final Pitch pitch = Pitch.of(Pitch.Base.C, 0, 1);
+		final Pitch pitch = Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 1);
 		final HashSet<Articulation> articulations = new HashSet<>();
 		articulations.add(Articulation.STACCATO);
 		final Note note1 = Note.of(pitch, Durations.EIGHTH, articulations);
@@ -55,21 +55,14 @@ class NoteTest {
 	void testCreatingInvalidNote() {
 
 		try {
-			Note.of(Pitch.Base.C, 5, 1, Durations.QUARTER);
+			Note.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 11, Durations.QUARTER);
 			fail("No exception was thrown. Expected: IllegalArgumentException");
 		} catch (final Exception e) {
 			assertTrue(e instanceof IllegalArgumentException);
 		}
 
 		try {
-			Note.of(Pitch.Base.C, 0, 11, Durations.QUARTER);
-			fail("No exception was thrown. Expected: IllegalArgumentException");
-		} catch (final Exception e) {
-			assertTrue(e instanceof IllegalArgumentException);
-		}
-
-		try {
-			Note.of(Pitch.Base.C, 0, 1, null);
+			Note.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 1, null);
 			fail("No exception was thrown. Expected: IllegalArgumentException");
 		} catch (final Exception e) {
 			assertTrue(e instanceof NullPointerException);
@@ -78,7 +71,7 @@ class NoteTest {
 
 	@Test
 	void testHasArticulation() {
-		final Pitch pitch = Pitch.of(Pitch.Base.C, 0, 1);
+		final Pitch pitch = Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 1);
 		final Set<Articulation> articulations = new HashSet<>();
 		articulations.add(Articulation.STACCATO);
 		assertTrue(Note.of(pitch, Durations.EIGHTH, articulations).hasArticulation(Articulation.STACCATO));
@@ -87,7 +80,7 @@ class NoteTest {
 
 	@Test
 	void testHasArticulations() {
-		final Pitch pitch = Pitch.of(Pitch.Base.C, 0, 1);
+		final Pitch pitch = Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 1);
 		final HashSet<Articulation> articulations = new HashSet<>();
 		articulations.add(Articulation.STACCATO);
 		assertTrue(Note.of(pitch, Durations.EIGHTH, articulations).hasArticulations());
@@ -96,7 +89,7 @@ class NoteTest {
 
 	@Test
 	void testGetArticulations() {
-		final Pitch pitch = Pitch.of(Pitch.Base.C, 0, 1);
+		final Pitch pitch = Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 1);
 		assertTrue(Note.of(pitch, Durations.EIGHTH).getArticulations().isEmpty());
 
 		final Set<Articulation> articulations = new HashSet<>();
@@ -120,8 +113,10 @@ class NoteTest {
 
 	@Test
 	void testTies() {
-		final NoteBuilder firstBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		final NoteBuilder secondBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
+		final NoteBuilder firstBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+				Durations.QUARTER);
+		final NoteBuilder secondBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+				Durations.EIGHTH);
 		firstBuilder.addTieToFollowing(secondBuilder);
 
 		final Note secondNote = secondBuilder.build();
@@ -138,11 +133,13 @@ class NoteTest {
 
 	@Test
 	void testTiedDuration() {
-		final Note untied = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		final Note untied = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
 		assertEquals(Durations.QUARTER, untied.getTiedDuration());
 
-		final NoteBuilder firstBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
-		final NoteBuilder secondBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
+		final NoteBuilder firstBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+				Durations.QUARTER);
+		final NoteBuilder secondBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+				Durations.EIGHTH);
 		firstBuilder.addTieToFollowing(secondBuilder);
 
 		Note firstNote = firstBuilder.build();
@@ -154,7 +151,8 @@ class NoteTest {
 		firstBuilder.clearCache();
 		secondBuilder.clearCache();
 
-		final NoteBuilder thirdBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
+		final NoteBuilder thirdBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+				Durations.EIGHTH);
 		secondBuilder.addTieToFollowing(thirdBuilder);
 
 		firstNote = firstBuilder.build();
@@ -168,7 +166,7 @@ class NoteTest {
 
 	@Test
 	void testBeginsAndEndsNotation() {
-		final Note followingNote = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
+		final Note followingNote = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
 
 		Notation.Connection slurBeginning = Notation.Connection
 				.beginningOf(Notation.of(Notation.Type.SLUR), followingNote);
@@ -177,8 +175,9 @@ class NoteTest {
 		notationConnections.add(slurBeginning);
 		notationConnections.add(glissandoEnd);
 
-		final Note noteWithNotationConnections = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH,
-				Collections.emptySet(), notationConnections);
+		final Note noteWithNotationConnections = Note
+				.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH,
+						Collections.emptySet(), notationConnections);
 
 		assertTrue(noteWithNotationConnections.beginsNotation(Notation.Type.SLUR));
 		assertTrue(noteWithNotationConnections.endsNotation(Notation.Type.GLISSANDO));
@@ -189,13 +188,13 @@ class NoteTest {
 
 	@Test
 	void testHasNotationConnection() {
-		final Note followingNote = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
+		final Note followingNote = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
 		Notation.Connection slurBeginning = Notation.Connection
 				.beginningOf(Notation.of(Notation.Type.SLUR), followingNote);
 		List<Notation.Connection> notationConnections = new ArrayList<>();
 		notationConnections.add(slurBeginning);
 
-		final Note noteThatBeginsSlur = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH,
+		final Note noteThatBeginsSlur = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH,
 				Collections.emptySet(), notationConnections);
 
 		assertTrue(noteThatBeginsSlur.hasNotations());
@@ -206,7 +205,7 @@ class NoteTest {
 
 	@Test
 	void testEqualsAndHashCodeWithNotations() {
-		final Note followingNote = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
+		final Note followingNote = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
 
 		Notation.Connection slurBeginning = Notation.Connection
 				.beginningOf(Notation.of(Notation.Type.SLUR), followingNote);
@@ -214,18 +213,19 @@ class NoteTest {
 		List<Notation.Connection> notationConnections = new ArrayList<>();
 
 		notationConnections.add(slurBeginning);
-		final Note noteThatBeginsSlur = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH,
+		final Note noteThatBeginsSlur = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH,
 				Collections.emptySet(), notationConnections);
 
 		Notation.Connection slurEnd = Notation.Connection.endOf(Notation.of(Notation.Type.SLUR));
 		List<Notation.Connection> slurEndList = new ArrayList<>();
 		slurEndList.add(slurEnd);
-		final Note noteThatEndsSlur = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH,
+		final Note noteThatEndsSlur = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH,
 				Collections.emptySet(), slurEndList);
 
 		notationConnections.add(glissandoEnd);
-		final Note noteWithNotationConnections = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH,
-				Collections.emptySet(), notationConnections);
+		final Note noteWithNotationConnections = Note
+				.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH,
+						Collections.emptySet(), notationConnections);
 
 		assertEquals(noteThatBeginsSlur, noteThatEndsSlur);
 		assertEquals(noteThatBeginsSlur.hashCode(), noteThatEndsSlur.hashCode());
@@ -237,7 +237,7 @@ class NoteTest {
 
 	@Test
 	void testGetNotationConnections() {
-		final Note followingNote = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
+		final Note followingNote = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
 
 		Notation.Connection slurBeginning = Notation.Connection
 				.beginningOf(Notation.of(Notation.Type.SLUR), followingNote);
@@ -246,8 +246,9 @@ class NoteTest {
 		notationConnections.add(slurBeginning);
 		notationConnections.add(glissandoEnd);
 
-		final Note noteWithNotationConnections = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH,
-				Collections.emptySet(), notationConnections);
+		final Note noteWithNotationConnections = Note
+				.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH,
+						Collections.emptySet(), notationConnections);
 
 		final Collection<Notation> notationsInNote = noteWithNotationConnections.getNotations();
 		assertEquals(2, notationsInNote.size());
@@ -266,13 +267,13 @@ class NoteTest {
 
 	@Test
 	void testGetNotationConnection() {
-		final Note followingNote = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH);
+		final Note followingNote = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH);
 		Notation.Connection slurBeginning = Notation.Connection
 				.beginningOf(Notation.of(Notation.Type.SLUR), followingNote);
 		List<Notation.Connection> notationConnections = new ArrayList<>();
 		notationConnections.add(slurBeginning);
 
-		final Note noteThatBeginsSlur = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.EIGHTH,
+		final Note noteThatBeginsSlur = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.EIGHTH,
 				Collections.emptySet(), notationConnections);
 
 		Optional<Notation.Connection> slurBeginningOptional = noteThatBeginsSlur

--- a/src/test/java/org/wmn4j/notation/PartBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/PartBuilderTest.java
@@ -23,10 +23,10 @@ class PartBuilderTest {
 	private final MeasureAttributes measureAttr;
 
 	PartBuilderTest() {
-		NoteBuilder C4 = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.HALF);
-		NoteBuilder E4 = new NoteBuilder(Pitch.of(Pitch.Base.E, 0, 4), Durations.HALF);
-		NoteBuilder G4 = new NoteBuilder(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF);
-		NoteBuilder C4Quarter = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+		NoteBuilder C4 = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.HALF);
+		NoteBuilder E4 = new NoteBuilder(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.HALF);
+		NoteBuilder G4 = new NoteBuilder(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.HALF);
+		NoteBuilder C4Quarter = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
 
 		final Map<Integer, List<DurationalBuilder>> noteVoice = new HashMap<>();
 		noteVoice.put(0, new ArrayList<>());
@@ -175,11 +175,13 @@ class PartBuilderTest {
 	void testBuildPartWithTieBetweenMeasures() {
 
 		final MeasureBuilder firstMeasureBuilder = new MeasureBuilder(1);
-		final NoteBuilder firstNoteBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.WHOLE);
+		final NoteBuilder firstNoteBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+				Durations.WHOLE);
 		firstMeasureBuilder.addToVoice(1, firstNoteBuilder);
 
 		final MeasureBuilder secondMeasureBuilder = new MeasureBuilder(2);
-		final NoteBuilder secondNoteBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.WHOLE);
+		final NoteBuilder secondNoteBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+				Durations.WHOLE);
 		firstNoteBuilder.addTieToFollowing(secondNoteBuilder);
 		secondMeasureBuilder.addToVoice(1, secondNoteBuilder);
 
@@ -198,11 +200,13 @@ class PartBuilderTest {
 	@Test
 	void testGivenBuilderWithMultipleStavesWhenBuiltPartsHavePadding() {
 		final MeasureBuilder firstMeasureBuilder = new MeasureBuilder(1);
-		final NoteBuilder firstNoteBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.WHOLE);
+		final NoteBuilder firstNoteBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+				Durations.WHOLE);
 		firstMeasureBuilder.addToVoice(1, firstNoteBuilder);
 
 		final MeasureBuilder secondMeasureBuilder = new MeasureBuilder(2);
-		final NoteBuilder secondNoteBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, 0, 4), Durations.WHOLE);
+		final NoteBuilder secondNoteBuilder = new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4),
+				Durations.WHOLE);
 		secondMeasureBuilder.addToVoice(1, secondNoteBuilder);
 
 		final PartBuilder partBuilder = new PartBuilder("Part");

--- a/src/test/java/org/wmn4j/notation/PitchTest.java
+++ b/src/test/java/org/wmn4j/notation/PitchTest.java
@@ -4,8 +4,6 @@
 package org.wmn4j.notation;
 
 import org.junit.jupiter.api.Test;
-import org.wmn4j.notation.Pitch;
-import org.wmn4j.notation.PitchClass;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -15,71 +13,89 @@ class PitchTest {
 
 	@Test
 	void testToInt() {
-		assertEquals(12, Pitch.of(Pitch.Base.C, 0, 0).toInt());
-		assertEquals(60, Pitch.of(Pitch.Base.C, 0, 4).toInt());
-		assertEquals(66, Pitch.of(Pitch.Base.F, 1, 4).toInt());
-		assertEquals(51, Pitch.of(Pitch.Base.E, -1, 3).toInt());
+		assertEquals(12, Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 0).toInt());
+		assertEquals(60, Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4).toInt());
+		assertEquals(66, Pitch.of(Pitch.Base.F, Pitch.Accidental.SHARP, 4).toInt());
+		assertEquals(51, Pitch.of(Pitch.Base.E, Pitch.Accidental.FLAT, 3).toInt());
 	}
 
 	@Test
 	void testGetPitchClass() {
-		assertEquals(PitchClass.C, Pitch.of(Pitch.Base.C, 0, 5).getPitchClass());
-		assertEquals(PitchClass.GSHARP_AFLAT, Pitch.of(Pitch.Base.A, -1, 3).getPitchClass());
-		assertEquals(PitchClass.B, Pitch.of(Pitch.Base.B, 0, 2).getPitchClass());
+		assertEquals(PitchClass.C, Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5).getPitchClass());
+		assertEquals(PitchClass.GSHARP_AFLAT, Pitch.of(Pitch.Base.A, Pitch.Accidental.FLAT, 3).getPitchClass());
+		assertEquals(PitchClass.B, Pitch.of(Pitch.Base.B, Pitch.Accidental.NATURAL, 2).getPitchClass());
 	}
 
 	@Test
 	void testGetPCNumber() {
-		assertEquals(0, Pitch.of(Pitch.Base.C, 0, 5).getPitchClassNumber());
-		assertEquals(8, Pitch.of(Pitch.Base.A, -1, 3).getPitchClassNumber());
-		assertEquals(11, Pitch.of(Pitch.Base.B, 0, 2).getPitchClassNumber());
+		assertEquals(0, Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 5).getPitchClassNumber());
+		assertEquals(8, Pitch.of(Pitch.Base.A, Pitch.Accidental.FLAT, 3).getPitchClassNumber());
+		assertEquals(11, Pitch.of(Pitch.Base.B, Pitch.Accidental.NATURAL, 2).getPitchClassNumber());
 	}
 
 	@Test
 	void testToString() {
-		assertEquals("F0", Pitch.of(Pitch.Base.F, 0, 0).toString());
-		assertEquals("Eb2", Pitch.of(Pitch.Base.E, -1, 2).toString());
-		assertEquals("G#3", Pitch.of(Pitch.Base.G, 1, 3).toString());
-		assertEquals("Abb2", Pitch.of(Pitch.Base.A, -2, 2).toString());
-		assertEquals("D##6", Pitch.of(Pitch.Base.D, 2, 6).toString());
+		assertEquals("F0", Pitch.of(Pitch.Base.F, Pitch.Accidental.NATURAL, 0).toString());
+		assertEquals("Eb2", Pitch.of(Pitch.Base.E, Pitch.Accidental.FLAT, 2).toString());
+		assertEquals("G#3", Pitch.of(Pitch.Base.G, Pitch.Accidental.SHARP, 3).toString());
+		assertEquals("Abb2", Pitch.of(Pitch.Base.A, Pitch.Accidental.DOUBLE_FLAT, 2).toString());
+		assertEquals("D##6", Pitch.of(Pitch.Base.D, Pitch.Accidental.DOUBLE_SHARP, 6).toString());
 	}
 
 	@Test
 	void testEquals() {
-		assertTrue(Pitch.of(Pitch.Base.C, 0, 2).equals(Pitch.of(Pitch.Base.C, 0, 2)));
-		assertTrue(Pitch.of(Pitch.Base.C, 1, 3).equals(Pitch.of(Pitch.Base.C, 1, 3)));
-		assertTrue(Pitch.of(Pitch.Base.C, -1, 2).equals(Pitch.of(Pitch.Base.C, -1, 2)));
+		assertTrue(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2)
+				.equals(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2)));
+		assertTrue(Pitch.of(Pitch.Base.C, Pitch.Accidental.SHARP, 3)
+				.equals(Pitch.of(Pitch.Base.C, Pitch.Accidental.SHARP, 3)));
+		assertTrue(Pitch.of(Pitch.Base.C, Pitch.Accidental.FLAT, 2)
+				.equals(Pitch.of(Pitch.Base.C, Pitch.Accidental.FLAT, 2)));
 
-		assertFalse(Pitch.of(Pitch.Base.C, 0, 2).equals(Pitch.of(Pitch.Base.D, 0, 2)));
-		assertFalse(Pitch.of(Pitch.Base.C, 0, 2).equals(Pitch.of(Pitch.Base.C, 1, 2)));
-		assertFalse(Pitch.of(Pitch.Base.C, -1, 3).equals(Pitch.of(Pitch.Base.D, -1, 2)));
+		assertFalse(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2)
+				.equals(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 2)));
+		assertFalse(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2)
+				.equals(Pitch.of(Pitch.Base.C, Pitch.Accidental.SHARP, 2)));
+		assertFalse(Pitch.of(Pitch.Base.C, Pitch.Accidental.FLAT, 3)
+				.equals(Pitch.of(Pitch.Base.D, Pitch.Accidental.FLAT, 2)));
 	}
 
 	@Test
 	void testEqualsEnharmonically() {
-		assertTrue(Pitch.of(Pitch.Base.C, 1, 2).equalsEnharmonically(Pitch.of(Pitch.Base.C, 1, 2)));
-		assertTrue(Pitch.of(Pitch.Base.C, 1, 2).equalsEnharmonically(Pitch.of(Pitch.Base.D, -1, 2)));
-		assertFalse(Pitch.of(Pitch.Base.C, 1, 2).equalsEnharmonically(Pitch.of(Pitch.Base.D, -1, 3)));
+		assertTrue(Pitch.of(Pitch.Base.C, Pitch.Accidental.SHARP, 2)
+				.equalsEnharmonically(Pitch.of(Pitch.Base.C, Pitch.Accidental.SHARP, 2)));
+		assertTrue(Pitch.of(Pitch.Base.C, Pitch.Accidental.SHARP, 2)
+				.equalsEnharmonically(Pitch.of(Pitch.Base.D, Pitch.Accidental.FLAT, 2)));
+		assertFalse(Pitch.of(Pitch.Base.C, Pitch.Accidental.SHARP, 2)
+				.equalsEnharmonically(Pitch.of(Pitch.Base.D, Pitch.Accidental.FLAT, 3)));
 	}
 
 	@Test
 	void testHigherThan() {
-		assertTrue(Pitch.of(Pitch.Base.C, 0, 3).isHigherThan(Pitch.of(Pitch.Base.C, 0, 2)));
-		assertFalse(Pitch.of(Pitch.Base.C, 0, 1).isHigherThan(Pitch.of(Pitch.Base.C, 0, 1)));
-		assertFalse(Pitch.of(Pitch.Base.C, 0, 2).isHigherThan(Pitch.of(Pitch.Base.C, 0, 3)));
+		assertTrue(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 3)
+				.isHigherThan(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2)));
+		assertFalse(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 1)
+				.isHigherThan(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 1)));
+		assertFalse(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2)
+				.isHigherThan(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 3)));
 	}
 
 	@Test
 	void testLowerThan() {
-		assertTrue(Pitch.of(Pitch.Base.C, 0, 2).isLowerThan(Pitch.of(Pitch.Base.C, 1, 2)));
-		assertFalse(Pitch.of(Pitch.Base.E, 1, 4).isLowerThan(Pitch.of(Pitch.Base.D, 0, 4)));
-		assertFalse(Pitch.of(Pitch.Base.C, 0, 4).isLowerThan(Pitch.of(Pitch.Base.C, 0, 3)));
+		assertTrue(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2)
+				.isLowerThan(Pitch.of(Pitch.Base.C, Pitch.Accidental.SHARP, 2)));
+		assertFalse(Pitch.of(Pitch.Base.E, Pitch.Accidental.SHARP
+				, 4).isLowerThan(Pitch.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4)));
+		assertFalse(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4)
+				.isLowerThan(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 3)));
 	}
 
 	@Test
 	void testCompareTo() {
-		assertTrue(0 == Pitch.of(Pitch.Base.C, 0, 2).compareTo(Pitch.of(Pitch.Base.C, 0, 2)));
-		assertTrue(0 > Pitch.of(Pitch.Base.C, -1, 2).compareTo(Pitch.of(Pitch.Base.C, 0, 2)));
-		assertTrue(0 < Pitch.of(Pitch.Base.E, 0, 3).compareTo(Pitch.of(Pitch.Base.D, 1, 3)));
+		assertTrue(0 == Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2)
+				.compareTo(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2)));
+		assertTrue(0 > Pitch.of(Pitch.Base.C, Pitch.Accidental.FLAT, 2)
+				.compareTo(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2)));
+		assertTrue(0 < Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 3)
+				.compareTo(Pitch.of(Pitch.Base.D, Pitch.Accidental.SHARP, 3)));
 	}
 }

--- a/src/test/java/org/wmn4j/notation/ScoreTest.java
+++ b/src/test/java/org/wmn4j/notation/ScoreTest.java
@@ -131,11 +131,11 @@ public class ScoreTest {
 		}
 
 		// Test first note.
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER),
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER),
 				score.getAt(new Position(0, 1, 1, 1, 0)));
 
 		// Test last note.
-		assertEquals(Note.of(Pitch.of(Pitch.Base.C, 0, 3), Durations.WHOLE),
+		assertEquals(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 3), Durations.WHOLE),
 				score.getAt(new Position(1, 2, 3, 2, 0)));
 	}
 
@@ -160,7 +160,7 @@ public class ScoreTest {
 		// Get the middle note (E) from the chord in the score.
 		final Position position = new Position(0, 1, 1, 1, 1, 1);
 		final Note noteInChord = (Note) score.getAt(position);
-		assertEquals(Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.HALF), noteInChord);
+		assertEquals(Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.HALF), noteInChord);
 	}
 
 	@Test
@@ -177,8 +177,10 @@ public class ScoreTest {
 
 		final int twoFirstVoiceNumber = twoFirstNotes.getVoiceNumbers().get(0);
 
-		assertEquals(Note.of(Pitch.Base.C, 0, 4, Durations.QUARTER), twoFirstNotes.get(twoFirstVoiceNumber, 0));
-		assertEquals(Note.of(Pitch.Base.D, 0, 4, Durations.QUARTER), twoFirstNotes.get(twoFirstVoiceNumber, 1));
+		assertEquals(Note.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4, Durations.QUARTER),
+				twoFirstNotes.get(twoFirstVoiceNumber, 0));
+		assertEquals(Note.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4, Durations.QUARTER),
+				twoFirstNotes.get(twoFirstVoiceNumber, 1));
 
 		List<Position> positionsWithGap = new ArrayList<>();
 		positionsWithGap.add(new Position(0, 1, 1, 0));
@@ -191,14 +193,17 @@ public class ScoreTest {
 
 		final int withGapsVoiceNumber = patternWithGaps.getVoiceNumbers().get(0);
 
-		assertEquals(Note.of(Pitch.Base.C, 0, 4, Durations.QUARTER), patternWithGaps.get(withGapsVoiceNumber, 0));
+		assertEquals(Note.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4, Durations.QUARTER),
+				patternWithGaps.get(withGapsVoiceNumber, 0));
 		assertEquals(Rest.of(Durations.QUARTER), patternWithGaps.get(withGapsVoiceNumber, 1));
 		assertEquals(Rest.of(Durations.QUARTER), patternWithGaps.get(withGapsVoiceNumber, 2));
-		assertEquals(Note.of(Pitch.Base.F, 0, 4, Durations.QUARTER), patternWithGaps.get(withGapsVoiceNumber, 3));
+		assertEquals(Note.of(Pitch.Base.F, Pitch.Accidental.NATURAL, 4, Durations.QUARTER),
+				patternWithGaps.get(withGapsVoiceNumber, 3));
 
 		assertEquals(Rest.of(Durations.WHOLE), patternWithGaps.get(withGapsVoiceNumber, 4));
 
-		assertEquals(Note.of(Pitch.Base.C, 0, 4, Durations.WHOLE), patternWithGaps.get(withGapsVoiceNumber, 5));
+		assertEquals(Note.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4, Durations.WHOLE),
+				patternWithGaps.get(withGapsVoiceNumber, 5));
 	}
 
 	@Test
@@ -214,10 +219,12 @@ public class ScoreTest {
 
 		final int withChordVoiceNumber = patternWithChord.getVoiceNumbers().get(0);
 
-		assertEquals(Note.of(Pitch.Base.E, 0, 4, Durations.EIGHTH), patternWithChord.get(withChordVoiceNumber, 0));
-		assertEquals(Chord.of(Note.of(Pitch.Base.D, 0, 4, Durations.EIGHTH),
-				Note.of(Pitch.Base.F, 0, 4, Durations.EIGHTH),
-				Note.of(Pitch.Base.A, 0, 4, Durations.EIGHTH)), patternWithChord.get(withChordVoiceNumber, 1));
+		assertEquals(Note.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4, Durations.EIGHTH),
+				patternWithChord.get(withChordVoiceNumber, 0));
+		assertEquals(Chord.of(Note.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4, Durations.EIGHTH),
+				Note.of(Pitch.Base.F, Pitch.Accidental.NATURAL, 4, Durations.EIGHTH),
+				Note.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 4, Durations.EIGHTH)),
+				patternWithChord.get(withChordVoiceNumber, 1));
 
 		List<Position> positionsWithinChord = new ArrayList<>();
 		positionsWithinChord.add(new Position(0, 2, 1, 2));
@@ -229,10 +236,10 @@ public class ScoreTest {
 
 		final int withinChordVoiceNumber = patternWithinChord.getVoiceNumbers().get(0);
 
-		assertEquals(Note.of(Pitch.Base.E, 0, 4, Durations.EIGHTH),
+		assertEquals(Note.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4, Durations.EIGHTH),
 				patternWithinChord.get(withinChordVoiceNumber, 0));
-		assertEquals(Chord.of(Note.of(Pitch.Base.D, 0, 4, Durations.EIGHTH),
-				Note.of(Pitch.Base.F, 0, 4, Durations.EIGHTH)),
+		assertEquals(Chord.of(Note.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4, Durations.EIGHTH),
+				Note.of(Pitch.Base.F, Pitch.Accidental.NATURAL, 4, Durations.EIGHTH)),
 				patternWithinChord.get(withinChordVoiceNumber, 1));
 	}
 
@@ -254,23 +261,28 @@ public class ScoreTest {
 
 		assertEquals(3, patternWithNotesAcrossParts.getVoiceSize(1));
 
-		assertEquals(Note.of(Pitch.Base.C, 0, 4, Durations.QUARTER), patternWithNotesAcrossParts.get(1, 0));
+		assertEquals(Note.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4, Durations.QUARTER),
+				patternWithNotesAcrossParts.get(1, 0));
 		assertEquals(Rest.of(Durations.QUARTER), patternWithNotesAcrossParts.get(1, 1));
-		assertEquals(Note.of(Pitch.Base.E, 0, 5, Durations.HALF), patternWithNotesAcrossParts.get(1, 2));
+		assertEquals(Note.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 5, Durations.HALF),
+				patternWithNotesAcrossParts.get(1, 2));
 
 		assertEquals(4, patternWithNotesAcrossParts.getVoiceSize(2));
 
-		assertEquals(Note.of(Pitch.Base.A, 0, 4, Durations.QUARTER), patternWithNotesAcrossParts.get(2, 0));
+		assertEquals(Note.of(Pitch.Base.A, Pitch.Accidental.NATURAL, 4, Durations.QUARTER),
+				patternWithNotesAcrossParts.get(2, 0));
 		assertEquals(Rest.of(Durations.QUARTER), patternWithNotesAcrossParts.get(2, 1));
 		assertEquals(Rest.of(Durations.QUARTER.multiply(3)), patternWithNotesAcrossParts.get(2, 2));
-		assertEquals(Note.of(Pitch.Base.D, 0, 4, Durations.HALF), patternWithNotesAcrossParts.get(2, 3));
+		assertEquals(Note.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4, Durations.HALF),
+				patternWithNotesAcrossParts.get(2, 3));
 
 		assertEquals(4, patternWithNotesAcrossParts.getVoiceSize(3));
 
 		assertEquals(Rest.of(Durations.HALF), patternWithNotesAcrossParts.get(3, 0));
 		assertEquals(Rest.of(Durations.HALF.addDot()), patternWithNotesAcrossParts.get(3, 1));
 		assertEquals(Rest.of(Durations.HALF.addDot()), patternWithNotesAcrossParts.get(3, 2));
-		assertEquals(Note.of(Pitch.Base.D, 0, 3, Durations.HALF), patternWithNotesAcrossParts.get(3, 3));
+		assertEquals(Note.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 3, Durations.HALF),
+				patternWithNotesAcrossParts.get(3, 3));
 	}
 
 	@Test
@@ -291,28 +303,28 @@ public class ScoreTest {
 		assertEquals(5, patternFromOverlappingVoices.getVoiceCount());
 
 		assertEquals(1, patternFromOverlappingVoices.getVoiceSize(1));
-		assertEquals(Note.of(Pitch.Base.D, 0, 4, Durations.QUARTER), patternFromOverlappingVoices.get(1, 0));
+		assertEquals(Note.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4, Durations.QUARTER), patternFromOverlappingVoices.get(1, 0));
 
 		assertEquals(1, patternFromOverlappingVoices.getVoiceSize(2));
-		assertEquals(Note.of(Pitch.Base.E, 0, 5, Durations.HALF), patternFromOverlappingVoices.get(2, 0));
+		assertEquals(Note.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 5, Durations.HALF), patternFromOverlappingVoices.get(2, 0));
 
 		assertEquals(4, patternFromOverlappingVoices.getVoiceSize(3));
 
 		assertEquals(Rest.of(Durations.HALF.addDot()), patternFromOverlappingVoices.get(3, 0));
 		assertEquals(Rest.of(Durations.SIXTEENTH), patternFromOverlappingVoices.get(3, 1));
 		assertEquals(Rest.of(Durations.SIXTEENTH), patternFromOverlappingVoices.get(3, 2));
-		assertTrue(Note.of(Pitch.Base.D, -1, 5, Durations.EIGHTH)
+		assertTrue(Note.of(Pitch.Base.D, Pitch.Accidental.FLAT, 5, Durations.EIGHTH)
 				.equalsInPitchAndDuration((Note) patternFromOverlappingVoices.get(3, 3)));
 
 		assertEquals(2, patternFromOverlappingVoices.getVoiceSize(4));
 
 		assertEquals(Rest.of(Durations.HALF.addDot()), patternFromOverlappingVoices.get(4, 0));
-		assertEquals(Note.of(Pitch.Base.D, 0, 4, Durations.HALF), patternFromOverlappingVoices.get(4, 1));
+		assertEquals(Note.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 4, Durations.HALF), patternFromOverlappingVoices.get(4, 1));
 
 		assertEquals(2, patternFromOverlappingVoices.getVoiceSize(5));
 
 		assertEquals(Rest.of(Durations.HALF.addDot()), patternFromOverlappingVoices.get(5, 0));
-		assertTrue(Note.of(Pitch.Base.D, 0, 3, Durations.QUARTER)
+		assertTrue(Note.of(Pitch.Base.D, Pitch.Accidental.NATURAL, 3, Durations.QUARTER)
 				.equalsInPitchAndDuration((Note) patternFromOverlappingVoices.get(5, 1)));
 	}
 

--- a/src/test/java/org/wmn4j/notation/SingleStaffPartTest.java
+++ b/src/test/java/org/wmn4j/notation/SingleStaffPartTest.java
@@ -25,10 +25,10 @@ class SingleStaffPartTest {
 
 	private KeySignature keySig = KeySignatures.CMAJ_AMIN;
 
-	private Note C4 = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.HALF);
-	private Note E4 = Note.of(Pitch.of(Pitch.Base.E, 0, 4), Durations.HALF);
-	private Note G4 = Note.of(Pitch.of(Pitch.Base.G, 0, 4), Durations.HALF);
-	private Note C4Quarter = Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER);
+	private Note C4 = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.HALF);
+	private Note E4 = Note.of(Pitch.of(Pitch.Base.E, Pitch.Accidental.NATURAL, 4), Durations.HALF);
+	private Note G4 = Note.of(Pitch.of(Pitch.Base.G, Pitch.Accidental.NATURAL, 4), Durations.HALF);
+	private Note C4Quarter = Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER);
 
 	SingleStaffPartTest() {
 		final Map<Integer, List<Durational>> noteVoice = new HashMap<>();

--- a/src/test/java/org/wmn4j/notation/StaffTest.java
+++ b/src/test/java/org/wmn4j/notation/StaffTest.java
@@ -23,10 +23,10 @@ class StaffTest {
 		final TimeSignature timeSig = TimeSignature.of(4, 4);
 		final Map<Integer, List<Durational>> notes = new HashMap<>();
 		notes.put(0, new ArrayList<>());
-		notes.get(0).add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		notes.get(0).add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		notes.get(0).add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
-		notes.get(0).add(Note.of(Pitch.of(Pitch.Base.C, 0, 4), Durations.QUARTER));
+		notes.get(0).add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		notes.get(0).add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		notes.get(0).add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
+		notes.get(0).add(Note.of(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), Durations.QUARTER));
 		measures.add(Measure.of(1, notes, timeSig, KeySignatures.CMAJ_AMIN, Clefs.G));
 		measures.add(Measure.of(2, notes, timeSig, KeySignatures.CMAJ_AMIN, Clefs.G));
 		return measures;

--- a/src/test/java/org/wmn4j/notation/access/PartWiseScoreIteratorTest.java
+++ b/src/test/java/org/wmn4j/notation/access/PartWiseScoreIteratorTest.java
@@ -57,7 +57,7 @@ class PartWiseScoreIteratorTest {
 		Durational next = moveIterSteps(1);
 		assertTrue(next instanceof Note);
 		Note n = (Note) next;
-		assertEquals(Pitch.of(Pitch.Base.C, 0, 4), n.getPitch());
+		assertEquals(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), n.getPitch());
 		assertEquals(Durations.QUARTER, n.getDuration());
 
 		// Move to the rest in the first measure of top part.
@@ -74,7 +74,7 @@ class PartWiseScoreIteratorTest {
 		next = moveIterSteps(5);
 		assertTrue(next instanceof Note);
 		n = (Note) next;
-		assertEquals(Pitch.of(Pitch.Base.C, 0, 4), n.getPitch());
+		assertEquals(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 4), n.getPitch());
 		assertEquals(Durations.QUARTER, n.getDuration());
 	}
 


### PR DESCRIPTION
Addresses issue #171 

Using enum enables extending accidental types to
half sharps etc. in the future.