### PR TITLE
Use Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk12
+  - openjdk11
 sudo: false
 script: ./gradlew build --stacktrace
 after_success: ./gradlew javadoc

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ There are a few architectural design principles in wmn4j:
 
 ### Building wmn4j
 
+wmn4j is built with OpenJDK 11, and only Java 11 is supported.
 wmn4j uses Gradle and can be built by running Gradle build. With the current configuration the build consists of compilation, unit tests, and static analysis.
 It is recommended to delegate the building of the project to Gradle using the provided Gradle wrapper in the IDE to ensure all dependencies etc. are handled correctly.
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 group = 'org.wmn4j'
 description = 'A simple Java API for handling western music notation.'
-sourceCompatibility = '12'
+sourceCompatibility = '11'
 
 java {
     withJavadocJar()


### PR DESCRIPTION
Stick to LTS versions to enable proper interoperability
with other JVM languages.