### PR TITLE
Use the term library instead of API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/otsob/wmn4j.svg?branch=master)](https://travis-ci.com/otsob/wmn4j)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-wmn4j is a Java API for handling western music notation.
+wmn4j is a Java library for handling western music notation.
 The main purpose of wmn4j is to enable easy and efficient analysis of scores and wmn4j is intended to also provide funtionality for algorithmic composition by generating scores.
 
 ## The structure of wmn4j
@@ -25,7 +25,7 @@ It is recommended to delegate the building of the project to Gradle using the pr
 Contributions to wmn4j are very welcome. If you are interested, feel free to message me (otsob) through Github.
 Contributing to wmn4j happens throught pull requests. For commits we try to follow basic practices (for example, see the ones by [Painsi](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53) or [Beams](https://chris.beams.io/posts/git-commit/)).
 
-As wmn4j is an API, the testing happens through unit tests and it is preferred that changes come accompanied by corresponding unit tests.
+As wmn4j is a library, the testing happens through unit tests and it is preferred that changes come accompanied by corresponding unit tests.
 
 The coding style of wmn4j is not very strict, but there are some [basic guidelines](CODING_CONVENTIONS.md).
 


### PR DESCRIPTION
Wmn4j does expose an API but is supposed to also
contain the implementation, this library is more
descriptive than API.