### PR TITLE
Add support for text playing directions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.3.2-SNAPSHOT
+version=0.4.0-SNAPSHOT
 # These properties are needed for publishing the release builds
 # on Maven central. If needed, fill these values in your personal
 # gradle.properties. NEVER put these in a public repository.

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlTags.java
@@ -154,11 +154,13 @@ final class MusicXmlTags {
 	static final String TRILL_MARK = "trill-mark";
 	static final String TURN = "turn";
 
+	// Direction tags
 	static final String DIRECTION = "direction";
 	static final String DIRECTION_PLACEMENT = "placement";
 	static final String DIRECTION_TYPE = "direction-type";
 	static final String DIRECTION_ABOVE = "above";
 	static final String DIRECTION_WORDS = "words";
+	static final String OFFSET = "offset";
 
 	// Part tags
 	static final String PART = "part";

--- a/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
+++ b/src/main/java/org/wmn4j/io/musicxml/MusicXmlWriterDom.java
@@ -32,6 +32,7 @@ import org.wmn4j.notation.Rest;
 import org.wmn4j.notation.SingleStaffPart;
 import org.wmn4j.notation.Staff;
 import org.wmn4j.notation.TimeSignature;
+import org.wmn4j.notation.access.Offset;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -255,7 +256,7 @@ abstract class MusicXmlWriterDom implements MusicXmlWriter {
 		attributes.ifPresent(attrElement -> measureElement.appendChild(attrElement));
 
 		//Set up handling possible mid-measure clef changes
-		Map<Duration, Clef> undealtClefChanges = new HashMap<>(measure.getClefChanges());
+		Set<Offset<Clef>> undealtClefChanges = new HashSet<>(measure.getClefChanges());
 
 		fillMeasureElement(measureElement, null, measure);
 
@@ -338,7 +339,7 @@ abstract class MusicXmlWriterDom implements MusicXmlWriter {
 	}
 
 	public void fillMeasureElement(Element measureElement, Integer staffNumber, Measure measure) {
-		Map<Duration, Clef> undealtClefChanges = new HashMap<>(measure.getClefChanges());
+		Set<Offset<Clef>> undealtClefChanges = new HashSet<>(measure.getClefChanges());
 
 		//Notes
 		final List<Integer> voiceNumbers = measure.getVoiceNumbers();
@@ -535,7 +536,8 @@ abstract class MusicXmlWriterDom implements MusicXmlWriter {
 			return measure.getClef();
 		}
 
-		return measure.getClefChanges().get(measure.getClefChanges().lastKey());
+		final List<Offset<Clef>> clefChanges = measure.getClefChanges();
+		return clefChanges.get(clefChanges.size() - 1).get();
 	}
 
 	private Element createStavesElement(int staffCount) {
@@ -639,24 +641,31 @@ abstract class MusicXmlWriterDom implements MusicXmlWriter {
 		return clefElement;
 	}
 
-	private void handleMidMeasureClefChanges(Element measureElement, Map<Duration, Clef> undealtClefChanges,
+	private void handleMidMeasureClefChanges(Element measureElement, Set<Offset<Clef>> undealtClefChanges,
 			Duration cumulatedDuration, Integer staffNumber) {
 
-		List<Duration> offsets = new ArrayList<>(undealtClefChanges.keySet());
+		List<Offset<Clef>> offsets = new ArrayList<>(undealtClefChanges);
 		Collections.sort(offsets);
-		for (Duration offset : offsets) {
+		for (Offset<Clef> offset : offsets) {
 
-			if (offset.isShorterThan(cumulatedDuration) || offset.equals(cumulatedDuration)) {
+			// Backward elements are not required for clef changes at beginning of measure.
+			if (offset.getDuration().isEmpty()) {
+				continue;
+			}
+
+			final Duration offsetDuration = offset.getDuration().get();
+
+			if (offsetDuration.isShorterThan(cumulatedDuration) || offsetDuration.equals(cumulatedDuration)) {
 
 				// Backup
-				if (!offset.equals(cumulatedDuration)) {
-					Element backupElement = createBackupElement(cumulatedDuration.subtract(offset));
+				if (!offsetDuration.equals(cumulatedDuration)) {
+					Element backupElement = createBackupElement(cumulatedDuration.subtract(offsetDuration));
 					measureElement.appendChild(backupElement);
 				}
 
 				// Clef
 				Element attributesElement = getDocument().createElement(MusicXmlTags.MEASURE_ATTRIBUTES);
-				Element clefElement = createClefElement(undealtClefChanges.get(offset), staffNumber);
+				Element clefElement = createClefElement(offset.get(), staffNumber);
 
 				attributesElement.appendChild(clefElement);
 				measureElement.appendChild(attributesElement);
@@ -664,8 +673,8 @@ abstract class MusicXmlWriterDom implements MusicXmlWriter {
 				undealtClefChanges.remove(offset);
 
 				// Forward
-				if (!offset.equals(cumulatedDuration)) {
-					Element forwardElement = createForwardElement(cumulatedDuration.subtract(offset));
+				if (!offsetDuration.equals(cumulatedDuration)) {
+					Element forwardElement = createForwardElement(cumulatedDuration.subtract(offsetDuration));
 					measureElement.appendChild(forwardElement);
 				}
 

--- a/src/main/java/org/wmn4j/notation/Measure.java
+++ b/src/main/java/org/wmn4j/notation/Measure.java
@@ -5,6 +5,7 @@ package org.wmn4j.notation;
 
 import org.wmn4j.notation.access.MeasureIterator;
 import org.wmn4j.notation.access.Offset;
+import org.wmn4j.notation.directions.Direction;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -238,6 +239,30 @@ public final class Measure implements Iterable<Durational> {
 	 */
 	public boolean containsClefChanges() {
 		return this.measureAttr.containsClefChanges();
+	}
+
+	/**
+	 * Returns true if this measure contains direction markings.
+	 * <p>
+	 * Directions are defined by the {@link Direction} type.
+	 *
+	 * @return true if this measure contains direction markings
+	 */
+	public boolean containsDirections() {
+		return measureAttr.containsDirections();
+	}
+
+	/**
+	 * Returns the directions in this measure.
+	 * <p>
+	 * The placement of the directions is represented using the {@link Offset} type,
+	 * measure from the beginning of the measure.
+	 * The returned list is sorted in ascending order of offset.
+	 *
+	 * @return the directions in this measure
+	 */
+	public List<Offset<Direction>> getDirections() {
+		return measureAttr.getDirections();
 	}
 
 	/**

--- a/src/main/java/org/wmn4j/notation/Measure.java
+++ b/src/main/java/org/wmn4j/notation/Measure.java
@@ -4,6 +4,7 @@
 package org.wmn4j.notation;
 
 import org.wmn4j.notation.access.MeasureIterator;
+import org.wmn4j.notation.access.Offset;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -218,14 +219,15 @@ public final class Measure implements Iterable<Durational> {
 	}
 
 	/**
-	 * Returns the clef changes in this measure. The keys in the map are
-	 * the offsets of the clef changes from the beginning of the measure.
-	 * The offsets are sorted from smallest to greatest.
+	 * Returns the clef changes in this measure.
+	 * <p>
+	 * The placement of clef changes are represented using {@link Offset} types,
+	 * where the placement of the clef change is measured by an offset from the
+	 * beginning of the measure. The list is sorted in ascending order of offset.
 	 *
-	 * @return a map of clef changes in this measure, where the duration key is the
-	 * offset counted from the beginning of the measure.
+	 * @return the clef changes in this measure.
 	 */
-	public SortedMap<Duration, Clef> getClefChanges() {
+	public List<Offset<Clef>> getClefChanges() {
 		return this.measureAttr.getClefChanges();
 	}
 

--- a/src/main/java/org/wmn4j/notation/MeasureBuilder.java
+++ b/src/main/java/org/wmn4j/notation/MeasureBuilder.java
@@ -4,6 +4,7 @@
 package org.wmn4j.notation;
 
 import org.wmn4j.notation.access.Offset;
+import org.wmn4j.notation.directions.Direction;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -206,6 +207,18 @@ public class MeasureBuilder {
 	 */
 	public MeasureBuilder addClefChange(Duration offset, Clef clef) {
 		attributesBuilder.clefChanges.add(new Offset<>(clef, offset));
+		return this;
+	}
+
+	/**
+	 * Adds a {@link Direction} with the given offset.
+	 *
+	 * @param offset    the duration of the offset, can be null if direction is not offset
+	 * @param direction the direction to add at given offset
+	 * @return reference to this builder
+	 */
+	public MeasureBuilder addDirection(Duration offset, Direction direction) {
+		attributesBuilder.directions.add(new Offset<>(direction, offset));
 		return this;
 	}
 
@@ -449,6 +462,7 @@ public class MeasureBuilder {
 		private Barline leftBarline;
 		private Barline rightBarline;
 		private Set<Offset<Clef>> clefChanges;
+		private Set<Offset<Direction>> directions;
 
 		private MeasureAttributesBuilder() {
 			this.timeSignature = TimeSignatures.FOUR_FOUR;
@@ -457,6 +471,7 @@ public class MeasureBuilder {
 			this.leftBarline = Barline.NONE;
 			this.rightBarline = Barline.SINGLE;
 			this.clefChanges = new HashSet<>();
+			this.directions = new HashSet<>();
 		}
 
 		private MeasureAttributesBuilder(MeasureAttributes measureAttributes) {
@@ -466,10 +481,12 @@ public class MeasureBuilder {
 			this.leftBarline = measureAttributes.getLeftBarline();
 			this.rightBarline = measureAttributes.getRightBarline();
 			this.clefChanges = new HashSet<>(measureAttributes.getClefChanges());
+			this.directions = new HashSet<>(measureAttributes.getDirections());
 		}
 
 		private MeasureAttributes build() {
-			return MeasureAttributes.of(timeSignature, keySignature, rightBarline, leftBarline, clef, clefChanges);
+			return MeasureAttributes
+					.of(timeSignature, keySignature, rightBarline, leftBarline, clef, clefChanges, directions);
 		}
 
 		private boolean equalsInContent(MeasureAttributes measureAttributes) {
@@ -498,6 +515,10 @@ public class MeasureBuilder {
 			}
 
 			if (!clefChanges.equals(measureAttributes.getClefChanges())) {
+				return false;
+			}
+
+			if (!directions.equals(measureAttributes.getDirections())) {
 				return false;
 			}
 

--- a/src/main/java/org/wmn4j/notation/MeasureBuilder.java
+++ b/src/main/java/org/wmn4j/notation/MeasureBuilder.java
@@ -3,10 +3,15 @@
  */
 package org.wmn4j.notation;
 
+import org.wmn4j.notation.access.Offset;
+
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -180,13 +185,15 @@ public class MeasureBuilder {
 	}
 
 	/**
-	 * Returns the clef changes in this builder. The keys in the map are the offset
-	 * values of the clef changes measured from the beginning of the measure.
+	 * Returns the clef changes set in this builder.
+	 * <p>
+	 * The placement of clef changes are represented using {@link Offset} types,
+	 * where the placement of the clef change is measured by an offset from the
+	 * beginning of the measure. The collection is not in any particular order.
 	 *
-	 * @return clef changes currently set for this builder. Durations are offsets
-	 * from the beginning of the measure.
+	 * @return the clef changes specified in the attributes
 	 */
-	public Map<Duration, Clef> getClefChanges() {
+	public Collection<Offset<Clef>> getClefChanges() {
 		return attributesBuilder.clefChanges;
 	}
 
@@ -198,7 +205,7 @@ public class MeasureBuilder {
 	 * @return reference to this builder
 	 */
 	public MeasureBuilder addClefChange(Duration offset, Clef clef) {
-		attributesBuilder.clefChanges.put(offset, clef);
+		attributesBuilder.clefChanges.add(new Offset<>(clef, offset));
 		return this;
 	}
 
@@ -441,7 +448,7 @@ public class MeasureBuilder {
 		private Clef clef;
 		private Barline leftBarline;
 		private Barline rightBarline;
-		private Map<Duration, Clef> clefChanges;
+		private Set<Offset<Clef>> clefChanges;
 
 		private MeasureAttributesBuilder() {
 			this.timeSignature = TimeSignatures.FOUR_FOUR;
@@ -449,7 +456,7 @@ public class MeasureBuilder {
 			this.clef = Clefs.G;
 			this.leftBarline = Barline.NONE;
 			this.rightBarline = Barline.SINGLE;
-			this.clefChanges = new HashMap<>();
+			this.clefChanges = new HashSet<>();
 		}
 
 		private MeasureAttributesBuilder(MeasureAttributes measureAttributes) {
@@ -458,7 +465,7 @@ public class MeasureBuilder {
 			this.clef = measureAttributes.getClef();
 			this.leftBarline = measureAttributes.getLeftBarline();
 			this.rightBarline = measureAttributes.getRightBarline();
-			this.clefChanges = new HashMap<>(measureAttributes.getClefChanges());
+			this.clefChanges = new HashSet<>(measureAttributes.getClefChanges());
 		}
 
 		private MeasureAttributes build() {

--- a/src/main/java/org/wmn4j/notation/Pitch.java
+++ b/src/main/java/org/wmn4j/notation/Pitch.java
@@ -7,9 +7,8 @@ import java.util.Objects;
 
 /**
  * Represents a pitch. Pitches consist of the basic pitch letter
- * {@link Pitch.Base}, alter number which tells by how many half-steps the pitch
- * is altered, and octave number which tells the octave of the note. Octave
- * number is based on
+ * {@link Pitch.Base}, accidentals, and octave number which tells the octave of the note.
+ * Octave number is based on
  * <a href="http://en.wikipedia.org/wiki/Scientific_pitch_notation">scientific
  * pitch notation</a>.
  * <p>

--- a/src/main/java/org/wmn4j/notation/access/Offset.java
+++ b/src/main/java/org/wmn4j/notation/access/Offset.java
@@ -1,0 +1,94 @@
+/*
+ * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
+ */
+package org.wmn4j.notation.access;
+
+import org.wmn4j.notation.Duration;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A wrapper class for associating a notation element with an offset.
+ * The offset is a {@link Duration} or empty if the offset is zero.
+ * <p>
+ * Offsets are compared by their offset durations.
+ *
+ * @param <T> the type of the notation element
+ */
+public final class Offset<T> implements Comparable<Offset<?>> {
+
+	private final T element;
+	private final Duration offsetDuration;
+
+	/**
+	 * Creates a new offset notation element.
+	 *
+	 * @param element        the notation element that is offset, must be non-null
+	 * @param offsetDuration the amount of offset, can be null for zero offset
+	 */
+	public Offset(T element, Duration offsetDuration) {
+		this.element = Objects.requireNonNull(element);
+		this.offsetDuration = offsetDuration;
+	}
+
+	/**
+	 * Returns the duration of the offset if the duration is non-zero, otherwise returns empty.
+	 *
+	 * @return the duration of the offset if the duration is non-zero, otherwise returns empty
+	 */
+	public Optional<Duration> getDuration() {
+		return Optional.ofNullable(offsetDuration);
+	}
+
+	/**
+	 * Returns the notation element that is offset.
+	 *
+	 * @return the notation element that is offset
+	 */
+	public T get() {
+		return element;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Offset<?>)) {
+			return false;
+		}
+
+		Offset<?> offset1 = (Offset<?>) o;
+
+		return Objects.equals(element, offset1.element)
+				&& Objects.equals(offsetDuration, offset1.offsetDuration);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(element, offsetDuration);
+	}
+
+	@Override
+	public int compareTo(Offset<?> o) {
+		if (Objects.equals(offsetDuration, o.offsetDuration)) {
+			return 0;
+		}
+
+		if (offsetDuration == null && o.offsetDuration != null) {
+			return -1;
+		}
+
+		if (offsetDuration != null && o.offsetDuration == null) {
+			return 1;
+		}
+
+		return offsetDuration.compareTo(o.offsetDuration);
+	}
+
+	@Override
+	public String toString() {
+		return element + " at offset " + offsetDuration;
+	}
+}

--- a/src/main/java/org/wmn4j/notation/directions/Direction.java
+++ b/src/main/java/org/wmn4j/notation/directions/Direction.java
@@ -1,0 +1,105 @@
+/*
+ * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
+ */
+
+/*
+ * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
+ */
+package org.wmn4j.notation.directions;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Represents a playing direction.
+ * <p>
+ * Directions include tempo, dynamics, technique, and general textual directions.
+ * <p>
+ * This class is immutable.
+ */
+public final class Direction {
+
+	private final Type type;
+	private final String text;
+
+	/**
+	 * Defines the type of the direction.
+	 */
+	public enum Type {
+		/**
+		 * Text direction. Default type for directions that do not have a clear type such as tempo or dynamics.
+		 */
+		TEXT
+	}
+
+	/**
+	 * Returns a direction of the given type.
+	 *
+	 * @param type the type of the direction
+	 * @param text the text of the direction if this is a textual direction marking, otherwise can be null
+	 * @return a direction of the given type
+	 */
+	public static Direction of(Type type, String text) {
+		return new Direction(type, text);
+	}
+
+	private Direction(Type type, String text) {
+		this.type = Objects.requireNonNull(type);
+		this.text = text;
+	}
+
+	/**
+	 * Returns the type of this direction.
+	 *
+	 * @return the type of this direction
+	 */
+	public Type getType() {
+		return type;
+	}
+
+	/**
+	 * Returns true if this is a textual direction marking.
+	 * <p>
+	 * For example, tempos can be indicated either as texts such as Allegro or as
+	 * a symbol indicating beats per minute.
+	 *
+	 * @return true if this is a textual direction marking
+	 */
+	public boolean isTextual() {
+		return text != null;
+	}
+
+	/**
+	 * Returns the text of this direction if present, otherwise returns empty.
+	 *
+	 * @return the text of this direction if present, otherwise returns empty
+	 */
+	public Optional<String> getText() {
+		return Optional.ofNullable(text);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (!(o instanceof Direction)) {
+			return false;
+		}
+
+		Direction direction = (Direction) o;
+		return Objects.equals(type, direction.type)
+				&& Objects.equals(text, direction.text);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(type, text);
+	}
+
+	@Override
+	public String toString() {
+		return "Direction{ type=" + type + ", text=" + text + "}";
+	}
+}

--- a/src/main/java/org/wmn4j/notation/directions/package-info.java
+++ b/src/main/java/org/wmn4j/notation/directions/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
+ */
+
+/**
+ * Provides definitions and types for musical directions, such as tempo, expression etc.
+ */
+package org.wmn4j.notation.directions;

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
@@ -28,6 +28,7 @@ import org.wmn4j.notation.SingleStaffPart;
 import org.wmn4j.notation.Staff;
 import org.wmn4j.notation.TimeSignature;
 import org.wmn4j.notation.TimeSignatures;
+import org.wmn4j.notation.access.Offset;
 
 import java.util.Arrays;
 import java.util.List;
@@ -271,16 +272,16 @@ class MusicXmlFileChecks {
 
 		assertEquals(Clef.of(Clef.Symbol.C, 4), part.getMeasure(4).getClef());
 		assertTrue(part.getMeasure(4).containsClefChanges());
-		final Map<Duration, Clef> clefChanges = part.getMeasure(4).getClefChanges();
+		final List<Offset<Clef>> clefChanges = part.getMeasure(4).getClefChanges();
 		assertEquals(2, clefChanges.size());
-		assertEquals(Clefs.F, clefChanges.get(Durations.QUARTER));
-		assertEquals(Clefs.PERCUSSION, clefChanges.get(Durations.WHOLE));
+		assertEquals(new Offset<>(Clefs.F, Durations.QUARTER), clefChanges.get(0));
+		assertEquals(new Offset<>(Clefs.PERCUSSION, Durations.WHOLE), clefChanges.get(1));
 
 		assertEquals(Clefs.PERCUSSION, part.getMeasure(5).getClef());
 		assertTrue(part.getMeasure(5).containsClefChanges());
 		assertEquals(2, part.getMeasure(5).getClefChanges().size());
-		assertEquals(Clefs.G, part.getMeasure(5).getClefChanges().get(Durations.QUARTER));
-		assertEquals(Clefs.F, part.getMeasure(5).getClefChanges().get(Durations.HALF.addDot()));
+		assertEquals(new Offset<>(Clefs.G, Durations.QUARTER), part.getMeasure(5).getClefChanges().get(0));
+		assertEquals(new Offset<>(Clefs.F, Durations.HALF.addDot()), part.getMeasure(5).getClefChanges().get(1));
 	}
 
 	/*
@@ -295,8 +296,10 @@ class MusicXmlFileChecks {
 		assertEquals(Clefs.G, upper.getMeasure(1).getClef(), "Incorrect clef measure 1 upper staff beginning");
 		assertTrue(upper.getMeasure(1).containsClefChanges(), "Upper staff measure 1 does not contain a clef change");
 		assertEquals(1, upper.getMeasure(1).getClefChanges().size(), "Incorrect number of clef changes");
-		assertEquals(Clefs.ALTO,
-				upper.getMeasure(1).getClefChanges().get(Durations.HALF.addDot()), "Incorrect clef change");
+
+		assertEquals(new Offset<>(Clefs.ALTO, Durations.HALF.addDot()),
+				upper.getMeasure(1).getClefChanges().get(0), "Incorrect clef change");
+
 
 		assertEquals(Clefs.ALTO, upper.getMeasure(2).getClef(), "Incorrect clef measure 2 upper staff.");
 		assertFalse(upper.getMeasure(2).containsClefChanges(), "Upper staff measure 2 contains a clef change");
@@ -304,10 +307,9 @@ class MusicXmlFileChecks {
 		// Check lower staff
 		assertEquals(Clefs.F, lower.getMeasure(1).getClef(), "Incorrect clef in measure 1 lower staff");
 		assertTrue(lower.getMeasure(1).containsClefChanges(), "Lower staff measure 1 does not contain a clef change");
-		final Map<Duration, Clef> clefChanges = lower.getMeasure(1).getClefChanges();
+		final List<Offset<Clef>> clefChanges = lower.getMeasure(1).getClefChanges();
 		assertEquals(1, clefChanges.size(), "Incorrect number of clef changes");
-		final Duration offset = Durations.HALF.add(Durations.SIXTEENTH.multiply(3));
-		assertEquals(Clefs.G, clefChanges.get(offset), "Incorrect clef change");
+		assertEquals(new Offset<>(Clefs.G, Durations.HALF.add(Durations.SIXTEENTH.multiply(3))), clefChanges.get(0), "Incorrect clef change");
 
 		assertEquals(Clefs.G, lower.getMeasure(2).getClef(), "Incorrect clef measure 2 of lower staff");
 		assertFalse(lower.getMeasure(2).containsClefChanges(), "Lower staff measure 2 contians clef changes");
@@ -905,11 +907,10 @@ class MusicXmlFileChecks {
 				measure.get(2, 3));
 
 		assertEquals(Clefs.G, measure.getClef());
-		final Map<Duration, Clef> clefChanges = measure.getClefChanges();
+		final List<Offset<Clef>> clefChanges = measure.getClefChanges();
 
 		assertEquals(1, clefChanges.size());
-		assertTrue(clefChanges.containsKey(Durations.HALF));
-		assertEquals(Clefs.ALTO, clefChanges.get(Durations.HALF));
+		assertEquals(new Offset<>(Clefs.ALTO, Durations.HALF), clefChanges.get(0));
 	}
 
 	/*

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlFileChecks.java
@@ -8,6 +8,7 @@ import org.wmn4j.notation.Barline;
 import org.wmn4j.notation.Chord;
 import org.wmn4j.notation.Clef;
 import org.wmn4j.notation.Clefs;
+import org.wmn4j.notation.directions.Direction;
 import org.wmn4j.notation.Duration;
 import org.wmn4j.notation.Durational;
 import org.wmn4j.notation.Durations;
@@ -32,7 +33,6 @@ import org.wmn4j.notation.access.Offset;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -1202,4 +1202,32 @@ class MusicXmlFileChecks {
 		}
 	}
 
+	/*
+	 * Expects the contents of "direction_test.musicxml".
+	 */
+	static void assertDirectionsCorrect(Score score) {
+		final Part part = score.getPart(0);
+		assertTrue(part.isMultiStaff());
+		final Measure topStaffFirst = part.getMeasure(1, 1);
+		assertEquals(1, topStaffFirst.getVoiceCount());
+		assertTrue(topStaffFirst.containsDirections());
+
+		List<Offset<Direction>> topStaffFirstDirections = topStaffFirst.getDirections();
+		assertEquals(1, topStaffFirstDirections.size());
+
+		Offset<Direction> secondDirection = topStaffFirstDirections.get(0);
+		assertEquals(Durations.QUARTER.addDot(), secondDirection.getDuration().get());
+		assertEquals(Direction.of(Direction.Type.TEXT, "A text"), secondDirection.get());
+
+		final Measure topStaffSecond = part.getMeasure(1, 2);
+		assertEquals(2, topStaffSecond.getVoiceCount());
+		assertTrue(topStaffSecond.containsDirections());
+
+		List<Offset<Direction>> topStaffSecondDirections = topStaffSecond.getDirections();
+		assertEquals(1, topStaffSecondDirections.size());
+
+		Offset<Direction> thirdDirection = topStaffSecondDirections.get(0);
+		assertEquals(Durations.QUARTER.addDot(), thirdDirection.getDuration().get());
+		assertEquals(Direction.of(Direction.Type.TEXT, "Another text"), thirdDirection.get());
+	}
 }

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlReaderDomTest.java
@@ -394,4 +394,10 @@ class MusicXmlReaderDomTest {
 		Score scoreWithGraceNotes = readScore("grace_note_chord_test.musicxml", true);
 		MusicXmlFileChecks.assertGraceNoteChordsAreCorrect(scoreWithGraceNotes);
 	}
+
+	@Test
+	void testGivenFileWithDirectionsThenDirectionsCorrectlyRead() {
+		Score scoreWithDirections = readScore("directions_test.musicxml", true);
+		MusicXmlFileChecks.assertDirectionsCorrect(scoreWithDirections);
+	}
 }

--- a/src/test/java/org/wmn4j/io/musicxml/MusicXmlScoreWriterDomTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/MusicXmlScoreWriterDomTest.java
@@ -450,4 +450,11 @@ class MusicXmlScoreWriterDomTest {
 		Score writtenScore = writeAndReadScore(score);
 		MusicXmlFileChecks.assertGraceNoteChordsAreCorrect(writtenScore);
 	}
+
+	@Test
+	void testGivenScoreWithDirectionsThenDirectionsAreCorrectlyWritten() {
+		Score score = readMusicXmlTestFile("directions_test.musicxml", true);
+		Score writtenScore = writeAndReadScore(score);
+		MusicXmlFileChecks.assertDirectionsCorrect(writtenScore);
+	}
 }

--- a/src/test/java/org/wmn4j/notation/MeasureAttributesTest.java
+++ b/src/test/java/org/wmn4j/notation/MeasureAttributesTest.java
@@ -4,17 +4,10 @@
 package org.wmn4j.notation;
 
 import org.junit.jupiter.api.Test;
-import org.wmn4j.notation.Barline;
-import org.wmn4j.notation.Clef;
-import org.wmn4j.notation.Clefs;
-import org.wmn4j.notation.Duration;
-import org.wmn4j.notation.Durations;
-import org.wmn4j.notation.KeySignatures;
-import org.wmn4j.notation.MeasureAttributes;
-import org.wmn4j.notation.TimeSignatures;
+import org.wmn4j.notation.access.Offset;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -79,10 +72,10 @@ class MeasureAttributesTest {
 	@Test
 	void testEquals() {
 
-		final Map<Duration, Clef> clefChangesA = new HashMap<>();
-		clefChangesA.put(Durations.HALF, Clefs.F);
-		final Map<Duration, Clef> clefChangesB = new HashMap<>();
-		clefChangesB.put(Durations.HALF.addDot(), Clefs.F);
+		final Set<Offset<Clef>> clefChangesA = new HashSet<>();
+		clefChangesA.add(new Offset<>(Clefs.F, Durations.HALF));
+		final Set<Offset<Clef>> clefChangesB = new HashSet<>();
+		clefChangesB.add(new Offset<>(Clefs.F, Durations.HALF.addDot()));
 
 		final MeasureAttributes attr = MeasureAttributes.of(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
 				Barline.SINGLE, Barline.SINGLE, Clefs.G, clefChangesA);

--- a/src/test/java/org/wmn4j/notation/MeasureAttributesTest.java
+++ b/src/test/java/org/wmn4j/notation/MeasureAttributesTest.java
@@ -5,12 +5,18 @@ package org.wmn4j.notation;
 
 import org.junit.jupiter.api.Test;
 import org.wmn4j.notation.access.Offset;
+import org.wmn4j.notation.directions.Direction;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -71,24 +77,44 @@ class MeasureAttributesTest {
 
 	@Test
 	void testEquals() {
-
 		final Set<Offset<Clef>> clefChangesA = new HashSet<>();
 		clefChangesA.add(new Offset<>(Clefs.F, Durations.HALF));
 		final Set<Offset<Clef>> clefChangesB = new HashSet<>();
 		clefChangesB.add(new Offset<>(Clefs.F, Durations.HALF.addDot()));
+		final List<Offset<Direction>> directions = new ArrayList<>();
+		directions.add(new Offset<>(Direction.of(Direction.Type.TEXT, "A text"), Durations.QUARTER));
 
 		final MeasureAttributes attr = MeasureAttributes.of(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
-				Barline.SINGLE, Barline.SINGLE, Clefs.G, clefChangesA);
+				Barline.SINGLE, Barline.SINGLE, Clefs.G, clefChangesA, directions);
 
 		final MeasureAttributes other = MeasureAttributes.of(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
-				Barline.SINGLE, Barline.SINGLE, Clefs.G, clefChangesA);
+				Barline.SINGLE, Barline.SINGLE, Clefs.G, clefChangesA, directions);
 
 		final MeasureAttributes different = MeasureAttributes.of(TimeSignatures.FOUR_FOUR,
-				KeySignatures.CMAJ_AMIN, Barline.SINGLE, Barline.DOUBLE, Clefs.G, clefChangesB);
+				KeySignatures.CMAJ_AMIN, Barline.SINGLE, Barline.DOUBLE, Clefs.G, clefChangesB,
+				Collections.emptyList());
 
 		assertTrue(attr.equals(attr));
 		assertTrue(attr.equals(other));
 		assertFalse(attr.equals(different));
 		assertFalse(different.equals(attr));
+	}
+
+	@Test
+	void testGivenUnorderedDirectionsThenDirectionsAreReturnedInOrder() {
+		Collection<Offset<Direction>> directions = new ArrayList<>();
+
+		final Direction first = Direction.of(Direction.Type.TEXT, "A text");
+		final Direction second = Direction.of(Direction.Type.TEXT, "Another text");
+		directions.add(new Offset<>(second, Durations.QUARTER));
+		directions.add(new Offset<>(first, null));
+
+		final MeasureAttributes attr = MeasureAttributes.of(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
+				Barline.SINGLE, Barline.SINGLE, Clefs.G, null, directions);
+
+		assertTrue(attr.containsDirections());
+		assertEquals(2, attr.getDirections().size());
+		assertEquals(first, attr.getDirections().get(0).get());
+		assertEquals(second, attr.getDirections().get(1).get());
 	}
 }

--- a/src/test/java/org/wmn4j/notation/MeasureAttributesTest.java
+++ b/src/test/java/org/wmn4j/notation/MeasureAttributesTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class MeasureAttributesTest {
 
 	@Test
-	void testGetMeasureInfo() {
+	void testCreateMeasureAttributes() {
 		final MeasureAttributes attr = MeasureAttributes.of(TimeSignatures.FOUR_FOUR, KeySignatures.CMAJ_AMIN,
 				Barline.SINGLE, Barline.SINGLE, Clefs.G);
 
@@ -30,7 +30,7 @@ class MeasureAttributesTest {
 	}
 
 	@Test
-	void testGetMeasureInfoWithInvalidParameters() {
+	void testCreateMeasureAttributesWithInvalidParameters() {
 
 		try {
 			final MeasureAttributes attr = MeasureAttributes.of(null, KeySignatures.CMAJ_AMIN, Barline.SINGLE,

--- a/src/test/java/org/wmn4j/notation/MeasureBuilderTest.java
+++ b/src/test/java/org/wmn4j/notation/MeasureBuilderTest.java
@@ -4,6 +4,10 @@
 package org.wmn4j.notation;
 
 import org.junit.jupiter.api.Test;
+import org.wmn4j.notation.access.Offset;
+import org.wmn4j.notation.directions.Direction;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -337,5 +341,22 @@ class MeasureBuilderTest {
 		assertEquals(KeySignatures.DFLATMAJ_BFLATMIN, withSameAttributes.getKeySignature());
 		assertEquals(Barline.DOUBLE, withSameAttributes.getRightBarline());
 		assertEquals(Clefs.F, withSameAttributes.getClef());
+	}
+
+	@Test
+	void testBuildingWithDirections() {
+		final MeasureBuilder builder = new MeasureBuilder(1);
+		builder.addDirection(Durations.EIGHTH, Direction.of(Direction.Type.TEXT, "A text"));
+		builder.addDirection(Durations.SIXTEENTH, Direction.of(Direction.Type.TEXT, "Another text"));
+
+		builder.addToVoice(1, new NoteBuilder(Pitch.of(Pitch.Base.C, Pitch.Accidental.NATURAL, 2), Durations.WHOLE));
+
+		final Measure measure = builder.build();
+		assertTrue(measure.containsDirections());
+		final List<Offset<Direction>> directions = measure.getDirections();
+
+		assertEquals(2, directions.size());
+		assertEquals(new Offset<>(Direction.of(Direction.Type.TEXT, "Another text"), Durations.SIXTEENTH), directions.get(0));
+		assertEquals(new Offset<>(Direction.of(Direction.Type.TEXT, "A text"), Durations.EIGHTH), directions.get(1));
 	}
 }

--- a/src/test/java/org/wmn4j/notation/access/OffsetTest.java
+++ b/src/test/java/org/wmn4j/notation/access/OffsetTest.java
@@ -1,0 +1,52 @@
+/*
+ * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
+ */
+package org.wmn4j.notation.access;
+
+import org.junit.jupiter.api.Test;
+import org.wmn4j.notation.Clef;
+import org.wmn4j.notation.Clefs;
+import org.wmn4j.notation.Durations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OffsetTest {
+
+	@Test
+	void testGivenOffsetWithDurationThenCorrectOffsetIsSet() {
+		final Offset<Clef> offsetClef = new Offset<>(Clefs.G, Durations.EIGHTH);
+		assertEquals(Clefs.G, offsetClef.get());
+		assertTrue(offsetClef.getDuration().isPresent());
+		assertEquals(Durations.EIGHTH, offsetClef.getDuration().get());
+	}
+
+	@Test
+	void testGivenOffsetWithoutDurationThenOffsetIsEmpty() {
+		final Offset<Clef> offsetClef = new Offset<>(Clefs.G, null);
+		assertEquals(Clefs.G, offsetClef.get());
+		assertTrue(offsetClef.getDuration().isEmpty());
+	}
+
+	@Test
+	void testComparisonWithPresentOffsetDurations() {
+		final Offset<Clef> offsetClef = new Offset<>(Clefs.G, Durations.EIGHTH);
+		assertEquals(0, offsetClef.compareTo(offsetClef));
+
+		final Offset<Clef> greaterOffset = new Offset<>(Clefs.ALTO, Durations.QUARTER);
+		assertTrue(offsetClef.compareTo(greaterOffset) < 0);
+		assertTrue(greaterOffset.compareTo(offsetClef) > 0);
+	}
+
+	@Test
+	void testComparisonWithAbsentOffsetDurations() {
+		final Offset<Clef> zeroOffset = new Offset<>(Clefs.G, null);
+		assertEquals(0, zeroOffset.compareTo(zeroOffset));
+
+		final Offset<Clef> greaterOffset = new Offset<>(Clefs.ALTO, Durations.QUARTER);
+		assertTrue(zeroOffset.compareTo(greaterOffset) < 0);
+		assertTrue(greaterOffset.compareTo(zeroOffset) > 0);
+	}
+}
+
+

--- a/src/test/java/org/wmn4j/notation/directions/DirectionTest.java
+++ b/src/test/java/org/wmn4j/notation/directions/DirectionTest.java
@@ -1,0 +1,42 @@
+/*
+ * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
+ */
+
+/*
+ * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
+ */
+
+/*
+ * Distributed under the MIT license (see LICENSE.txt or https://opensource.org/licenses/MIT).
+ */
+package org.wmn4j.notation.directions;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DirectionTest {
+
+	@Test
+	void testTempoHasTypeTempo() {
+		Direction direction = Direction.of(Direction.Type.TEXT, null);
+		assertEquals(Direction.Type.TEXT, direction.getType());
+	}
+
+	@Test
+	void testGivenNonTextualDirectionNoTextIsPresent() {
+		Direction direction = Direction.of(Direction.Type.TEXT, null);
+		assertFalse(direction.isTextual());
+		assertTrue(direction.getText().isEmpty());
+	}
+
+	@Test
+	void testTextualDirectionTextIsPresent() {
+		Direction direction = Direction.of(Direction.Type.TEXT, "A text");
+		assertTrue(direction.isTextual());
+		assertTrue(direction.getText().isPresent());
+		assertEquals("A text", direction.getText().get());
+	}
+}

--- a/src/test/resources/musicxml/directions_test.musicxml
+++ b/src/test/resources/musicxml/directions_test.musicxml
@@ -1,0 +1,417 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN"
+        "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+    <work>
+        <work-title>Directions test</work-title>
+    </work>
+    <identification>
+        <encoding>
+            <software>MuseScore 3.6.2</software>
+            <encoding-date>2021-07-08</encoding-date>
+            <supports element="accidental" type="yes"/>
+            <supports element="beam" type="yes"/>
+            <supports element="print" attribute="new-page" type="yes" value="yes"/>
+            <supports element="print" attribute="new-system" type="yes" value="yes"/>
+            <supports element="stem" type="yes"/>
+        </encoding>
+    </identification>
+    <defaults>
+        <scaling>
+            <millimeters>7</millimeters>
+            <tenths>40</tenths>
+        </scaling>
+        <page-layout>
+            <page-height>1697.14</page-height>
+            <page-width>1200</page-width>
+            <page-margins type="even">
+                <left-margin>85.7143</left-margin>
+                <right-margin>85.7143</right-margin>
+                <top-margin>85.7143</top-margin>
+                <bottom-margin>85.7143</bottom-margin>
+            </page-margins>
+            <page-margins type="odd">
+                <left-margin>85.7143</left-margin>
+                <right-margin>85.7143</right-margin>
+                <top-margin>85.7143</top-margin>
+                <bottom-margin>85.7143</bottom-margin>
+            </page-margins>
+        </page-layout>
+        <word-font font-family="Edwin" font-size="10"/>
+        <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+    <credit page="1">
+        <credit-type>title</credit-type>
+        <credit-words default-x="600" default-y="1611.43" justify="center" valign="top" font-size="22">Directions test
+        </credit-words>
+    </credit>
+    <part-list>
+        <score-part id="P1">
+            <part-name>Piano</part-name>
+            <part-abbreviation>Pno.</part-abbreviation>
+            <score-instrument id="P1-I1">
+                <instrument-name>Piano</instrument-name>
+            </score-instrument>
+            <midi-device id="P1-I1" port="1"></midi-device>
+            <midi-instrument id="P1-I1">
+                <midi-channel>1</midi-channel>
+                <midi-program>1</midi-program>
+                <volume>78.7402</volume>
+                <pan>0</pan>
+            </midi-instrument>
+        </score-part>
+    </part-list>
+    <part id="P1">
+        <measure number="1" width="541.30">
+            <print>
+                <system-layout>
+                    <system-margins>
+                        <left-margin>65.90</left-margin>
+                        <right-margin>0.00</right-margin>
+                    </system-margins>
+                    <top-system-distance>170.00</top-system-distance>
+                </system-layout>
+                <staff-layout number="2">
+                    <staff-distance>65.00</staff-distance>
+                </staff-layout>
+            </print>
+            <attributes>
+                <divisions>2</divisions>
+                <key>
+                    <fifths>0</fifths>
+                </key>
+                <time>
+                    <beats>4</beats>
+                    <beat-type>4</beat-type>
+                </time>
+                <staves>2</staves>
+                <clef number="1">
+                    <sign>G</sign>
+                    <line>2</line>
+                </clef>
+                <clef number="2">
+                    <sign>F</sign>
+                    <line>4</line>
+                </clef>
+            </attributes>
+            <direction placement="above">
+                <direction-type>
+                    <metronome parentheses="no" default-x="-37.68" relative-y="20.00">
+                        <beat-unit>quarter</beat-unit>
+                        <per-minute>80</per-minute>
+                    </metronome>
+                </direction-type>
+                <staff>1</staff>
+                <sound tempo="80"/>
+            </direction>
+            <note default-x="83.49" default-y="-35.00">
+                <pitch>
+                    <step>F</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>2</duration>
+                <voice>1</voice>
+                <type>quarter</type>
+                <stem>up</stem>
+                <staff>1</staff>
+            </note>
+            <note default-x="210.16" default-y="-35.00">
+                <pitch>
+                    <step>F</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>1</duration>
+                <voice>1</voice>
+                <type>eighth</type>
+                <stem>up</stem>
+                <staff>1</staff>
+            </note>
+            <direction placement="above">
+                <direction-type>
+                    <words relative-y="20.00" font-weight="bold" font-size="12">A text</words>
+                </direction-type>
+                <staff>1</staff>
+            </direction>
+            <note>
+                <rest/>
+                <duration>1</duration>
+                <voice>1</voice>
+                <type>eighth</type>
+                <staff>1</staff>
+            </note>
+            <note default-x="336.83" default-y="-35.00">
+                <pitch>
+                    <step>F</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>4</duration>
+                <voice>1</voice>
+                <type>half</type>
+                <stem>up</stem>
+                <staff>1</staff>
+            </note>
+            <backup>
+                <duration>8</duration>
+            </backup>
+            <direction placement="below">
+                <direction-type>
+                    <dynamics default-x="6.50" default-y="-61.64" relative-y="-25.00">
+                        <p/>
+                    </dynamics>
+                </direction-type>
+                <staff>2</staff>
+                <sound dynamics="54.44"/>
+            </direction>
+            <note default-x="83.49" default-y="-110.00">
+                <pitch>
+                    <step>G</step>
+                    <octave>3</octave>
+                </pitch>
+                <duration>1</duration>
+                <voice>5</voice>
+                <type>eighth</type>
+                <stem>up</stem>
+                <staff>2</staff>
+            </note>
+            <note default-x="146.82" default-y="-110.00">
+                <pitch>
+                    <step>G</step>
+                    <octave>3</octave>
+                </pitch>
+                <duration>2</duration>
+                <voice>5</voice>
+                <type>quarter</type>
+                <stem>up</stem>
+                <staff>2</staff>
+            </note>
+            <note default-x="273.49" default-y="-110.00">
+                <pitch>
+                    <step>G</step>
+                    <octave>3</octave>
+                </pitch>
+                <duration>1</duration>
+                <voice>5</voice>
+                <type>eighth</type>
+                <stem>up</stem>
+                <staff>2</staff>
+            </note>
+            <note default-x="336.83" default-y="-110.00">
+                <pitch>
+                    <step>G</step>
+                    <octave>3</octave>
+                </pitch>
+                <duration>4</duration>
+                <voice>5</voice>
+                <type>half</type>
+                <stem>up</stem>
+                <staff>2</staff>
+            </note>
+            <backup>
+                <duration>8</duration>
+            </backup>
+            <note default-x="83.49" default-y="-150.00">
+                <pitch>
+                    <step>F</step>
+                    <octave>2</octave>
+                </pitch>
+                <duration>2</duration>
+                <voice>6</voice>
+                <type>quarter</type>
+                <stem>down</stem>
+                <staff>2</staff>
+            </note>
+            <direction placement="below">
+                <direction-type>
+                    <wedge type="crescendo" number="1" default-y="-83.79"/>
+                </direction-type>
+                <staff>2</staff>
+            </direction>
+            <note default-x="210.16" default-y="-150.00">
+                <pitch>
+                    <step>F</step>
+                    <octave>2</octave>
+                </pitch>
+                <duration>2</duration>
+                <voice>6</voice>
+                <type>quarter</type>
+                <stem>down</stem>
+                <staff>2</staff>
+            </note>
+            <note default-x="336.83" default-y="-150.00">
+                <pitch>
+                    <step>F</step>
+                    <octave>2</octave>
+                </pitch>
+                <duration>2</duration>
+                <voice>6</voice>
+                <type>quarter</type>
+                <stem>down</stem>
+                <staff>2</staff>
+            </note>
+            <direction placement="below">
+                <direction-type>
+                    <wedge type="stop" number="1"/>
+                </direction-type>
+                <staff>2</staff>
+            </direction>
+            <direction placement="below">
+                <direction-type>
+                    <dynamics default-x="3.25" default-y="-68.25" relative-y="-25.00">
+                        <f/>
+                    </dynamics>
+                </direction-type>
+                <staff>2</staff>
+                <sound dynamics="106.67"/>
+            </direction>
+            <note default-x="438.16" default-y="-150.00">
+                <pitch>
+                    <step>F</step>
+                    <octave>2</octave>
+                </pitch>
+                <duration>2</duration>
+                <voice>6</voice>
+                <type>quarter</type>
+                <stem>down</stem>
+                <staff>2</staff>
+            </note>
+        </measure>
+        <measure number="2" width="421.37">
+            <note default-x="13.00" default-y="-5.00">
+                <pitch>
+                    <step>E</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>2</duration>
+                <voice>1</voice>
+                <type>quarter</type>
+                <stem>up</stem>
+                <staff>1</staff>
+            </note>
+            <note default-x="106.58" default-y="-5.00">
+                <pitch>
+                    <step>E</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>2</duration>
+                <voice>1</voice>
+                <type>quarter</type>
+                <stem>up</stem>
+                <staff>1</staff>
+            </note>
+            <note default-x="223.56" default-y="-5.00">
+                <pitch>
+                    <step>E</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>2</duration>
+                <voice>1</voice>
+                <type>quarter</type>
+                <stem>up</stem>
+                <staff>1</staff>
+            </note>
+            <note default-x="317.14" default-y="-5.00">
+                <pitch>
+                    <step>E</step>
+                    <octave>5</octave>
+                </pitch>
+                <duration>2</duration>
+                <voice>1</voice>
+                <type>quarter</type>
+                <stem>up</stem>
+                <staff>1</staff>
+            </note>
+            <backup>
+                <duration>8</duration>
+            </backup>
+            <note default-x="13.00" default-y="-45.00">
+                <pitch>
+                    <step>D</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>4</duration>
+                <voice>2</voice>
+                <type>half</type>
+                <stem>down</stem>
+                <staff>1</staff>
+            </note>
+            <note default-x="223.56" default-y="-45.00">
+                <pitch>
+                    <step>D</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>2</duration>
+                <voice>2</voice>
+                <type>quarter</type>
+                <stem>down</stem>
+                <staff>1</staff>
+            </note>
+            <note default-x="317.14" default-y="-45.00">
+                <pitch>
+                    <step>D</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>2</duration>
+                <voice>2</voice>
+                <type>quarter</type>
+                <stem>down</stem>
+                <staff>1</staff>
+            </note>
+            <backup>
+                <duration>8</duration>
+            </backup>
+            <direction placement="below">
+                <direction-type>
+                    <dynamics default-x="3.25" default-y="-40.00" relative-y="-25.00">
+                        <sfp/>
+                    </dynamics>
+                </direction-type>
+                <staff>2</staff>
+                <sound dynamics="124.44"/>
+            </direction>
+            <note default-x="13.00" default-y="-110.00">
+                <pitch>
+                    <step>G</step>
+                    <octave>3</octave>
+                </pitch>
+                <duration>3</duration>
+                <voice>5</voice>
+                <type>quarter</type>
+                <dot/>
+                <stem>down</stem>
+                <staff>2</staff>
+            </note>
+            <note default-x="165.07" default-y="-110.00">
+                <pitch>
+                    <step>G</step>
+                    <octave>3</octave>
+                </pitch>
+                <duration>1</duration>
+                <voice>5</voice>
+                <type>eighth</type>
+                <stem>down</stem>
+                <staff>2</staff>
+            </note>
+            <note default-x="223.56" default-y="-110.00">
+                <pitch>
+                    <step>G</step>
+                    <octave>3</octave>
+                </pitch>
+                <duration>4</duration>
+                <voice>5</voice>
+                <type>half</type>
+                <stem>down</stem>
+                <staff>2</staff>
+            </note>
+            <direction placement="above">
+                <direction-type>
+                    <words default-y="8.41" relative-y="20.00" font-weight="bold" font-size="12">Another text</words>
+                </direction-type>
+                <offset>-5</offset>
+                <staff>1</staff>
+            </direction>
+            <barline location="right">
+                <bar-style>light-heavy</bar-style>
+            </barline>
+        </measure>
+    </part>
+</score-partwise>


### PR DESCRIPTION
* Adds support for directions which are measure level markings (not related to a specific note, e.g. dynamics, tempo)
* Support for text type markings is added (can be extended later for tempo etc.)
* MusicXML IO is added for directions

Partly implements #176 