### PR TITLE
Fix handling of non-numeric measure numbers

### DIFF
--- a/src/main/java/org/wmn4j/io/musicxml/PartContext.java
+++ b/src/main/java/org/wmn4j/io/musicxml/PartContext.java
@@ -354,4 +354,8 @@ final class PartContext {
 		}
 		return offset;
 	}
+
+	public void incrementMeasureNumber() {
+		++measureNumber;
+	}
 }

--- a/src/main/java/org/wmn4j/io/musicxml/StaxReader.java
+++ b/src/main/java/org/wmn4j/io/musicxml/StaxReader.java
@@ -421,9 +421,18 @@ final class StaxReader implements MusicXmlReader {
 		}, element);
 	}
 
+	private void updateMeasureNumber() throws XMLStreamException {
+		try {
+			final String measureNumberStr = reader.getAttributeValue(null, Tags.NUMBER).replaceAll("\\D", "");
+			partContext.setMeasureNumber(Integer.parseInt(measureNumberStr));
+		} catch (NumberFormatException e) {
+			// If measure "number" does not contain a number at all, just increment the number.
+			partContext.incrementMeasureNumber();
+		}
+	}
+
 	private void consumeMeasureElem() throws XMLStreamException {
-		partContext.setMeasureNumber(Integer.parseInt(
-				reader.getAttributeValue(null, Tags.NUMBER)));
+		updateMeasureNumber();
 
 		consumeUntil(tag -> {
 			switch (tag) {

--- a/src/test/java/org/wmn4j/io/musicxml/StaxReaderTest.java
+++ b/src/test/java/org/wmn4j/io/musicxml/StaxReaderTest.java
@@ -61,6 +61,14 @@ class StaxReaderTest {
 	}
 
 	@Test
+	void testReadScoreWithNonNumericMeasureNumber() {
+		// The score is otherwise equal to singleC.musicxml, apart from having measure-
+		// number with a non-numeric character in it.
+		final Score score = readScore("nonnumeric_measure_number.musicxml", true);
+		MusicXmlFileChecks.assertSingleNoteScoreReadCorrectly(score);
+	}
+
+	@Test
 	void testReadScoreBuilderWithSingleNote() {
 		final ScoreBuilder scoreBuilder = readScoreBuilder("singleC.musicxml", false);
 		MusicXmlFileChecks.assertSingleNoteScoreReadCorrectly(scoreBuilder.build());

--- a/src/test/resources/musicxml/nonnumeric_measure_number.musicxml
+++ b/src/test/resources/musicxml/nonnumeric_measure_number.musicxml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+  <movement-title>Single C</movement-title>
+  <identification>
+    <creator type="composer">TestFile Composer</creator>
+    <encoding>
+      <software>Finale 2014.5 for Mac</software>
+      <software>Dolet Light for Finale 2014.5</software>
+      <encoding-date>2016-08-31</encoding-date>
+      <supports attribute="new-system" element="print" type="yes" value="yes"/>
+      <supports attribute="new-page" element="print" type="yes" value="yes"/>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="stem" type="yes"/>
+    </encoding>
+  </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.2319</millimeters>
+      <tenths>40</tenths>
+    </scaling>
+    <page-layout>
+      <page-height>1545</page-height>
+      <page-width>1194</page-width>
+      <page-margins type="both">
+        <left-margin>70</left-margin>
+        <right-margin>70</right-margin>
+        <top-margin>88</top-margin>
+        <bottom-margin>88</bottom-margin>
+      </page-margins>
+    </page-layout>
+    <system-layout>
+      <system-margins>
+        <left-margin>0</left-margin>
+        <right-margin>0</right-margin>
+      </system-margins>
+      <system-distance>121</system-distance>
+      <top-system-distance>70</top-system-distance>
+    </system-layout>
+    <appearance>
+      <line-width type="stem">0.7487</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="staff">0.7487</line-width>
+      <line-width type="light barline">0.7487</line-width>
+      <line-width type="heavy barline">5</line-width>
+      <line-width type="leger">0.7487</line-width>
+      <line-width type="ending">0.7487</line-width>
+      <line-width type="wedge">0.7487</line-width>
+      <line-width type="enclosure">0.7487</line-width>
+      <line-width type="tuplet bracket">0.7487</line-width>
+      <note-size type="grace">60</note-size>
+      <note-size type="cue">60</note-size>
+      <distance type="hyphen">120</distance>
+      <distance type="beam">8</distance>
+    </appearance>
+    <music-font font-family="Maestro,engraved" font-size="20.5"/>
+    <word-font font-family="Times New Roman" font-size="10.25"/>
+  </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="597" default-y="1440" font-size="24" justify="center" valign="top">Single C</credit-words>
+  </credit>
+  <credit page="1">
+    <credit-type>composer</credit-type>
+    <credit-words default-x="1124" default-y="1362" font-size="12" justify="right" valign="top">TestFile Composer</credit-words>
+  </credit>
+  <credit page="1">
+    <credit-words default-x="70" default-y="1453" font-size="12" valign="top">Score</credit-words>
+  </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Part1</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>MusicXML Default 1</instrument-name>
+      </score-instrument>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+      </midi-instrument>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P1">
+    <measure number="X1" width="983">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>70</left-margin>
+            <right-margin>0</right-margin>
+          </system-margins>
+          <top-system-distance>211</top-system-distance>
+        </system-layout>
+        <measure-numbering>system</measure-numbering>
+      </print>
+      <attributes>
+        <divisions>2</divisions>
+        <key>
+          <fifths>0</fifths>
+          <mode>major</mode>
+        </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <sound tempo="120"/>
+      <note default-x="86">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+  <!--=========================================================-->
+</score-partwise>


### PR DESCRIPTION
MusicXML allows measure number attribute to
contain non-numeric characters, or even omit
numbers altogether.