### PR TITLE
Use point-patterns for polyphonic comparisons

### DIFF
--- a/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
+++ b/src/main/java/org/wmn4j/mir/PolyphonicPattern.java
@@ -6,9 +6,9 @@ package org.wmn4j.mir;
 import org.wmn4j.notation.Chord;
 import org.wmn4j.notation.Durational;
 import org.wmn4j.notation.Note;
+import org.wmn4j.representation.geometric.PointPattern;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -21,7 +21,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Class that represents a polyphonic pattern. In a polyphonic pattern there can be
@@ -281,57 +280,38 @@ final class PolyphonicPattern implements Pattern {
 
 	@Override
 	public boolean equalsEnharmonically(Pattern other) {
-		BiFunction<Iterable<Durational>, Iterable<Durational>, Boolean> equalsEnharmonically = (voiceA, voiceB) ->
-				isNoteContentEqualWithTransformation(voiceA, voiceB,
-						note -> note.getPitch().orElseGet(note::getDisplayPitch).toInt());
-		return containsEqualVoices(other, equalsEnharmonically);
+		final var thisPitches = PointPattern.from(this);
+		final var otherPitches = PointPattern.from(other);
+
+		if (thisPitches.size() != otherPitches.size()) {
+			return false;
+		}
+
+		for (int i = 0; i < thisPitches.size(); ++i) {
+			if (thisPitches.get(i).getPitch() != otherPitches.get(i).getPitch()) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	@Override
 	public boolean equalsTranspositionally(Pattern other) {
+		final var thisIntervals = PointPattern.from(this).vectorized();
+		final var otherIntervals = PointPattern.from(other).vectorized();
 
-		// TODO: Reimplement this with PointPatterns
+		if (thisIntervals.size() != otherIntervals.size()) {
+			return false;
+		}
 
-		Function<Durational, Integer> toPitchNumber = durational -> {
-			if (durational.isNote()) {
-				final Note note = durational.toNote();
-				return note.getPitch().orElseGet(note::getDisplayPitch).toInt();
-			}
-
-			return ((Chord) durational).getLowest().getPitch().get().toInt();
-		};
-
-		// Get the first pitches available in this patterns voices. For chords get the lowest.
-		Collection<Integer> firstPitchNumbersInThis = voices.values().stream()
-				.map(voice -> voice.stream().filter(durational -> !durational.isRest()).findFirst())
-				.filter(first -> first.isPresent())
-				.map(Optional::get)
-				.map(toPitchNumber).collect(Collectors.toList());
-
-		// Get the first pitch number of one voice from other.
-
-		Integer pitchNumberInOther = null;
-		for (Durational durational : other.getVoice(other.getVoiceNumbers().get(0))) {
-			if (!durational.isRest()) {
-				pitchNumberInOther = toPitchNumber.apply(durational);
-				break;
+		for (int i = 0; i < thisIntervals.size(); ++i) {
+			if (thisIntervals.get(i).getPitch() != otherIntervals.get(i).getPitch()) {
+				return false;
 			}
 		}
 
-		// Based on the pitch differences, create all tranpositional equivalence comparisons for the
-		// possible transposition candidates.
-		Collection<BiFunction<Iterable<Durational>, Iterable<Durational>, Boolean>> transpositionalEquivalenceCandidates
-				= new ArrayList<>();
-		for (Integer firstPitchNumberInThis : firstPitchNumbersInThis) {
-			final int transposition = pitchNumberInOther - firstPitchNumberInThis;
-			transpositionalEquivalenceCandidates.add((voiceA, voiceB) ->
-					isNoteContentEqualWithTransformations(voiceA, voiceB,
-							note -> note.getPitch().get().toInt() + transposition,
-							note -> note.getPitch().get().toInt()));
-		}
-
-		return transpositionalEquivalenceCandidates.stream()
-				.anyMatch(transpositionallyEquals -> containsEqualVoices(other, transpositionallyEquals));
+		return true;
 	}
 
 	@Override

--- a/src/main/java/org/wmn4j/representation/geometric/Point2D.java
+++ b/src/main/java/org/wmn4j/representation/geometric/Point2D.java
@@ -49,6 +49,24 @@ public final class Point2D implements Point<Point2D> {
 		this.hash = computeHash();
 	}
 
+	/**
+	 * Returns the number representing the pitch dimension.
+	 *
+	 * @return the number representing the pitch dimension
+	 */
+	public double getPitch() {
+		return pitch;
+	}
+
+	/**
+	 * Returns the number representing onset dimension.
+	 *
+	 * @return the number representing onset dimension
+	 */
+	public double getOnset() {
+		return roundedOnset;
+	}
+
 	@Override
 	public int getDimensionality() {
 		return 2;

--- a/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
+++ b/src/test/java/org/wmn4j/mir/PolyphonicPatternTest.java
@@ -268,7 +268,7 @@ public class PolyphonicPatternTest {
 
 		Map<Integer, List<? extends Durational>> modifiedVoices = createReferencePatternVoices();
 		List<Durational> modifiedVoice = new ArrayList<>(modifiedVoices.get(1));
-		Note note = Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.DOUBLE_FLAT, 4), Durations.SIXTEENTH);
+		Note note = Note.of(Pitch.of(Pitch.Base.D, Pitch.Accidental.DOUBLE_FLAT, 4), Durations.EIGHTH);
 		modifiedVoice.set(0, note);
 		modifiedVoices.put(1, modifiedVoice);
 


### PR DESCRIPTION
The translational and enharmonic equivalence comparisons
are easier to implement usint the point-pattern representations.